### PR TITLE
remove tags from schema

### DIFF
--- a/mappings/poi.js
+++ b/mappings/poi.js
@@ -15,8 +15,7 @@ var schema = {
     'locality':         require('./partial/admin'),
     'neighborhood':     require('./partial/admin'),
     'center_point':     require('./partial/centroid'),
-    'suggest':          require('./partial/suggest'),
-    'tags':             merge( {}, require('./partial/hash'), { 'index': 'no' } )
+    'suggest':          require('./partial/suggest')
   },
   '_all': {
     'enabled':          false

--- a/test/poi.js
+++ b/test/poi.js
@@ -21,7 +21,7 @@ module.exports.tests.properties = function(test, common) {
 
 // should contain the correct field definitions
 module.exports.tests.fields = function(test, common) {
-  var fields = ['name','address','type','alpha3','admin0','admin1','admin1_abbr','admin2','local_admin','locality','neighborhood','center_point','suggest','tags'];
+  var fields = ['name','address','type','alpha3','admin0','admin1','admin1_abbr','admin2','local_admin','locality','neighborhood','center_point','suggest'];
   test('fields specified', function(t) {
     fields.forEach( function( field ){
       t.equal(schema.properties.hasOwnProperty(field), true, field + ' field specified');


### PR DESCRIPTION
remove tags from schema

we haven't been storing tags in the db for a very long time (because they are very numerous/large), so we should remove it from the schema
