### PR TITLE
add osm address type

### DIFF
--- a/schema.js
+++ b/schema.js
@@ -3,14 +3,15 @@ var schema = {
   'settings':           require('./settings')(),
   'mappings': {
 
-    // osm
+    // openstreetmap points-of-interest
     'osmnode':          require('./mappings/poi'),
     'osmway':           require('./mappings/poi'),
 
-    // geoname
+    // geonames
     'geoname':          require('./mappings/poi'),
 
     // addresses
+    'osmaddress':       require('./mappings/poi'),
     'openaddresses':    require('./mappings/poi'),
 
     // admin boundaries

--- a/test/compile.js
+++ b/test/compile.js
@@ -11,7 +11,7 @@ module.exports.tests.compile = function(test, common) {
   });
 };
 
-var mandatory_indeces = ['osmnode','osmway','geoname','openaddresses','admin0','admin1','admin2','local_admin','locality','neighborhood'];
+var mandatory_indeces = ['osmnode','osmway','geoname','osmaddress','openaddresses','admin0','admin1','admin2','local_admin','locality','neighborhood'];
 module.exports.tests.indeces = function(test, common) {
   test('contains mandatory indeces', function(t) {
     t.plan( mandatory_indeces.length +1 );


### PR DESCRIPTION
add `osmaddress` type to schema.

the idea here is that we start partitioning the address records from OSM in to their own elasticsearch `"type"`

related: https://github.com/pelias/openstreetmap/issues/29

cc/ @hkrishna @sevko @heffergm 