### PR TITLE
Pelias ngram [DO NOT MERGE] [EXPERIMENT]

### DIFF
--- a/mappings/partial/suggest.json
+++ b/mappings/partial/suggest.json
@@ -2,8 +2,8 @@
   "type": "completion",
   "preserve_position_increments": false,
   "preserve_separators": false,
-  "index_analyzer": "plugin",
-  "search_analyzer": "plugin",
+  "index_analyzer": "suggestions_ngram",
+  "search_analyzer": "suggestions_ngram",
   "payloads": false,
   "context": {
     "dataset": {

--- a/mappings/partial/suggest.json
+++ b/mappings/partial/suggest.json
@@ -6,12 +6,6 @@
   "search_analyzer": "plugin",
   "payloads": false,
   "context": {
-    "location": {
-      "type": "geo",
-      "precision": [1,2,3,4,5],
-      "neighbors": true,
-      "path": "center_point"
-    },
     "dataset": {
       "type": "category",
       "path": "_type"

--- a/scripts/create_index.js
+++ b/scripts/create_index.js
@@ -2,7 +2,7 @@
 var client = require('pelias-esclient')(),
     schema = require('../schema');
 
-client.indices.create( { index: 'pelias', body: schema }, function( err, res ){
+client.indices.create( { index: 'pelias_ngram', body: schema }, function( err, res ){
   console.log( '[put mapping]', '\t', 'pelias', err || '\t', res );
   process.exit( !!err );
 });

--- a/scripts/drop_index.js
+++ b/scripts/drop_index.js
@@ -9,7 +9,7 @@ if( isForced() ) drop();
 else prompt( drop, fail );
 
 function drop(){
-  client.indices.delete( { index: 'pelias' }, function( err, res ){
+  client.indices.delete( { index: 'pelias_ngram' }, function( err, res ){
     console.log( '\n[delete mapping]', '\t', 'pelias', err || '\t', res );
     process.exit( !!err );
   });

--- a/settings.js
+++ b/settings.js
@@ -16,6 +16,11 @@ function generate(){
           "tokenizer": "whitespace",
           "filter": ["lowercase", "asciifolding"]
         },
+        "suggestions_ngram": {
+          "type":"custom",
+          "tokenizer":"standard",
+          "filter":[ "standard", "lowercase", "nGram" ] 
+        },
         "pelias": {
           "type": "custom",
           "tokenizer": "whitespace",

--- a/settings.js
+++ b/settings.js
@@ -18,8 +18,8 @@ function generate(){
         },
         "suggestions_ngram": {
           "type":"custom",
-          "tokenizer":"standard",
-          "filter":[ "standard", "lowercase", "nGram" ] 
+          "tokenizer":"ngram",
+          "filter":[ "lowercase", "asciifolding", "ampersand", "word_delimiter" ] 
         },
         "pelias": {
           "type": "custom",

--- a/settings.js
+++ b/settings.js
@@ -19,7 +19,7 @@ function generate(){
         "suggestions_ngram": {
           "type":"custom",
           "tokenizer":"ngram",
-          "filter":[ "lowercase", "asciifolding", "ampersand", "word_delimiter" ] 
+          "filter":[ "lowercase", "asciifolding", "ampersand", "word_delimiter", "ngram_filter" ] 
         },
         "pelias": {
           "type": "custom",
@@ -30,11 +30,23 @@ function generate(){
           "type": "pelias-analysis"
         }
       },
+      // "tokenizer": {
+      //   "ngram_tokenizer": {
+      //     "type": "nGram",
+      //     "min_gram": 2,
+      //     "max_gram": 10
+      //   }
+      // },
       "filter" : {
         "ampersand" :{
           "type" : "pattern_replace",
           "pattern" : "[&]",
           "replacement" : " and "
+        },
+        "ngram_filter": { 
+            "type":     "ngram",
+            "min_gram": 2,
+            "max_gram": 10
         }
       }
     },


### PR DESCRIPTION
This is purely experimental. I changed the schema to play with ngram tokenizer/token filters. Using ngram token filters posed a few problems including

```
[500] IllegalArgumentException[TokenStream expanded to 3114 finite strings. Only <= 256 finite strings are supported]
```
This happens because the ngram token filter expands a given token ```station``` to ```[s] [t] [a] [t] [i] [o] [n] [st] [ta] [at] [ti] [io] [on]``` which is okay but if you have a bigger token then it quickly gets out of hand.

So, I went back to using ngram tokenizer instead of token filters. 

@missinglink lets discuss ngrams here. I got it started for now. because I was hacking with it over the weekend - decided to push some of it here so, we can play with it - Made a new index called pelias_ngram and updated geonames (https://github.com/pelias/geonames/tree/using-pelias-ngram) and API (https://github.com/pelias/api/tree/using-pelias-ngram) 
