### PR TITLE
change the way we analyze admin fields so we can search on them

### DIFF
--- a/mappings/partial/admin.json
+++ b/mappings/partial/admin.json
@@ -1,6 +1,6 @@
 {
   "type": "string",
-  "index_analyzer": "keyword",
-  "search_analyzer": "keyword",
+  "index_analyzer": "pelias",
+  "search_analyzer": "pelias",
   "store": "yes"
 }

--- a/test/partial-admin.js
+++ b/test/partial-admin.js
@@ -34,11 +34,12 @@ module.exports.tests.index = function(test, common) {
   });
 };
 
-// keyword analysis ensures that we get ['Great Britain'] instead of ['Great','Britain']
+// pelias analysis does not ensure that we get ['Great Britain'] instead of ['Great','Britain']
+// TODO this needs to be addressed 
 module.exports.tests.analysis = function(test, common) {
   test('index analysis', function(t) {
-    t.equal(schema.index_analyzer, 'keyword', 'should be keyword');
-    t.equal(schema.search_analyzer, 'keyword', 'should be keyword');
+    t.equal(schema.index_analyzer, 'pelias', 'should be pelias');
+    t.equal(schema.search_analyzer, 'pelias', 'should be pelias');
     t.end();
   });
 };


### PR DESCRIPTION
```keyword``` analyzer is useful for pin codes but for admin0 and admin1, we'd like to search for ```new york``` or  ```New York``` and always be able to match to ```New York``` using ```match``` query/filter. 

[this is a work in progress] - Problem with this PR is that ```'Great Britain'``` might get broken into ```['great', 'britain']``` 

Maybe all we need is a lowercase filter?? [Lets Discuss]

As per https://github.com/pelias/api/pull/68

Fixes pelias/pelias#43