### PR TITLE
add categories to schema

### DIFF
--- a/mappings/boundary.js
+++ b/mappings/boundary.js
@@ -11,6 +11,7 @@ var schema = {
     'woe_id':           require('./partial/foreignkey'),
     'boundaries':       require('./partial/shape'),
     'center_point':     require('./partial/centroid'),
+    'category':         require('./partial/category'),
     'suggest':          require('./partial/suggest')
   },
   '_source' : {

--- a/mappings/partial/category.json
+++ b/mappings/partial/category.json
@@ -1,0 +1,6 @@
+{
+  "type": "string",
+  "index_analyzer": "keyword",
+  "search_analyzer": "keyword",
+  "store": "yes"
+}

--- a/mappings/poi.js
+++ b/mappings/poi.js
@@ -15,6 +15,7 @@ var schema = {
     'locality':         require('./partial/admin'),
     'neighborhood':     require('./partial/admin'),
     'center_point':     require('./partial/centroid'),
+    'category':         require('./partial/category'),
     'population':       require('./partial/multiplier'),
     'popularity':       require('./partial/multiplier'),
     'suggest':          require('./partial/suggest')

--- a/test/boundary.js
+++ b/test/boundary.js
@@ -21,7 +21,7 @@ module.exports.tests.properties = function(test, common) {
 
 // should contain the correct field definitions
 module.exports.tests.fields = function(test, common) {
-  var fields = ['name','alpha3','admin0','admin1','admin1_abbr','admin2','gn_id','woe_id','boundaries','center_point','suggest'];
+  var fields = ['name','alpha3','admin0','admin1','admin1_abbr','admin2','gn_id','woe_id','boundaries','center_point','category','suggest'];
   test('fields specified', function(t) {
     fields.forEach( function( field ){
       t.equal(schema.properties.hasOwnProperty(field), true, field + ' field specified');

--- a/test/partial-category.js
+++ b/test/partial-category.js
@@ -1,0 +1,47 @@
+
+var schema = require('../mappings/partial/category');
+
+module.exports.tests = {};
+
+module.exports.tests.compile = function(test, common) {
+  test('valid schema file', function(t) {
+    t.equal(typeof schema, 'object', 'schema generated');
+    t.equal(Object.keys(schema).length>0, true, 'schema has body');
+    t.end();
+  });
+};
+
+// this should never need to change
+module.exports.tests.type = function(test, common) {
+  test('correct type', function(t) {
+    t.equal(schema.type, 'string', 'correct value');
+    t.end();
+  });
+};
+
+module.exports.tests.store = function(test, common) {
+  test('store enabled', function(t) {
+    t.equal(schema.store, 'yes', 'correct value');
+    t.end();
+  });
+};
+
+// do not perform analysis on categories
+module.exports.tests.analysis = function(test, common) {
+  test('index analysis', function(t) {
+    t.equal(schema.index_analyzer, 'keyword', 'should be keyword');
+    t.equal(schema.search_analyzer, 'keyword', 'should be keyword');
+    t.end();
+  });
+};
+
+module.exports.all = function (tape, common) {
+
+  function test(name, testFunction) {
+    return tape('category: ' + name, testFunction);
+  }
+
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/poi.js
+++ b/test/poi.js
@@ -21,7 +21,7 @@ module.exports.tests.properties = function(test, common) {
 
 // should contain the correct field definitions
 module.exports.tests.fields = function(test, common) {
-  var fields = ['name','address','type','alpha3','admin0','admin1','admin1_abbr','admin2','local_admin','locality','neighborhood','center_point','population','popularity','suggest'];
+  var fields = ['name','address','type','alpha3','admin0','admin1','admin1_abbr','admin2','local_admin','locality','neighborhood','center_point','category','population','popularity','suggest'];
   test('fields specified', function(t) {
     fields.forEach( function( field ){
       t.equal(schema.properties.hasOwnProperty(field), true, field + ' field specified');

--- a/test/run.js
+++ b/test/run.js
@@ -9,6 +9,7 @@ var tests = [
   require('./partial-suggest.js'),
   require('./partial-centroid.js'),
   require('./partial-admin.js'),
+  require('./partial-category.js'),
   require('./partial-hash.js'),
   require('./settings.js')
 ];


### PR DESCRIPTION
Relates pelias/openstreetmap#33

add a new `'category'` field to mapping to `poi` and `boundary` layer schemas.

this PR will facilitate adopting a taxonomy as outlined in https://github.com/pelias/pelias/wiki/Taxonomy-v1 and allow queries such as https://gist.github.com/missinglink/dd1dcdb377a0ff271890