### PR TITLE
search ngrams

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 language: node_js
 
 node_js:
+ - "0.12"
  - "0.10"
 
-install:
- - npm install
-
-before_script:
- - npm install npm
-
 script:
- - npm test
+  - npm test
+
+services:
+ - elasticsearch

--- a/integration/analyzer_peliasOneEdgeGram.js
+++ b/integration/analyzer_peliasOneEdgeGram.js
@@ -1,0 +1,97 @@
+
+// validate analyzer is behaving as expected
+
+var tape = require('tape'),
+    elastictest = require('elastictest'),
+    schema = require('../schema'),
+    punctuation = require('../punctuation');
+
+module.exports.tests = {};
+
+module.exports.tests.analyze = function(test, common){
+  test( 'analyze', function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+    var assertAnalysis = analyze.bind( null, suite, t, 'peliasOneEdgeGram' );
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
+
+    assertAnalysis( 'lowercase', 'F', ['f']);
+    assertAnalysis( 'asciifolding', 'é', ['e']);
+    assertAnalysis( 'asciifolding', 'ß', ['s','ss']);
+    assertAnalysis( 'asciifolding', 'æ', ['a','ae']);
+    assertAnalysis( 'asciifolding', 'ł', ['l']);
+    assertAnalysis( 'asciifolding', 'ɰ', ['m']);
+    assertAnalysis( 'trim', ' f ', ['f'] );
+    assertAnalysis( 'stop_words', 'a street b avenue c', ['a','b','c'] );
+    assertAnalysis( 'ampersand', 'a and b', ['a','&','b'] );
+    assertAnalysis( 'ampersand', 'a & b', ['a','&','b'] );
+    assertAnalysis( 'ampersand', 'a and & and b', ['a','&','b'] );
+    assertAnalysis( 'peliasOneEdgeGramFilter', '1 a ab abc abcdefghijk', ['1','a','ab','abc','abcd','abcde','abcdef','abcdefg','abcdefgh','abcdefghi','abcdefghij'] );
+    assertAnalysis( 'removeAllZeroNumericPrefix', '00001', ['1'] );
+    assertAnalysis( 'unique', '1 1 1', ['1'] );
+    assertAnalysis( 'notnull', 'avenue street', [] );
+
+    assertAnalysis( 'kstem', 'mcdonalds', ['m', 'mc', 'mcd', 'mcdo', 'mcdon', 'mcdona', 'mcdonal', 'mcdonald'] );
+    assertAnalysis( 'kstem', 'McDonald\'s', ['m', 'mc', 'mcd', 'mcdo', 'mcdon', 'mcdona', 'mcdonal', 'mcdonald'] );
+    assertAnalysis( 'kstem', 'peoples', ['p', 'pe', 'peo', 'peop', 'peopl', 'people'] );
+
+    // remove punctuation (handled by the char_filter)
+    assertAnalysis( 'punctuation', punctuation.all.join(''), ['-','-&'] );
+
+    suite.run( t.end );
+  });
+};
+
+module.exports.tests.functional = function(test, common){
+  test( 'functional', function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+    var assertAnalysis = analyze.bind( null, suite, t, 'peliasOneEdgeGram' );
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
+
+    assertAnalysis( 'country', 'Trinidad and Tobago', [
+      't', 'tr', 'tri', 'trin', 'trini', 'trinid', 'trinida', 'trinidad', '&', 'to', 'tob', 'toba', 'tobag', 'tobago'
+    ]);
+
+    assertAnalysis( 'place', 'Toys "R" Us!', [
+      't', 'to', 'toy', 'r', 'u', 'us'
+    ]);
+
+    assertAnalysis( 'address', '101 mapzen place', [
+      '1', '10', '101', 'm', 'ma', 'map', 'mapz', 'mapze', 'mapzen'
+    ]);
+
+    suite.run( t.end );
+  });
+};
+
+module.exports.all = function (tape, common) {
+
+  function test(name, testFunction) {
+    return tape('peliasOneEdgeGram: ' + name, testFunction);
+  }
+
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};
+
+function analyze( suite, t, analyzer, comment, text, expected ){
+  suite.assert( function( done ){
+    suite.client.indices.analyze({
+      index: suite.props.index,
+      analyzer: analyzer,
+      text: text
+    }, function( err, res ){
+      if( err ) console.error( err );
+      t.deepEqual( simpleTokens( res.tokens ), expected, comment );
+      done();
+    });
+  });
+}
+
+function simpleTokens( tokens ){
+  return tokens.map( function( t ){
+    return t.token;
+  });
+}

--- a/integration/analyzer_peliasPhrase.js
+++ b/integration/analyzer_peliasPhrase.js
@@ -40,6 +40,9 @@ module.exports.tests.analyze = function(test, common){
     assertAnalysis( 'stem street suffixes', 'streets avenue', ['st ave'] );
     assertAnalysis( 'stem street suffixes', 'boulevard roads', ['blvd rd'] );
 
+    assertAnalysis( 'stem direction synonyms', 'south by southwest', ['s by', 'by sw'] );
+    assertAnalysis( 'stem direction synonyms', '20 bear road northeast', ['20 bear', 'bear rd', 'rd ne'] );
+
     // remove punctuation (handled by the char_filter)
     assertAnalysis( 'punctuation', punctuation.all.join(''), [] );
 
@@ -80,6 +83,11 @@ module.exports.tests.functional = function(test, common){
     var expected3 = [ '100 s', 's lake', 'lake dr' ];
     assertAnalysis( 'address', '100 S Lake Dr', expected3 );
     assertAnalysis( 'address', '100 South Lake Drive', expected3 );
+
+    // both terms should map to same tokens
+    var expected4 = [ '100 nw', 'nw hwy' ];
+    assertAnalysis( 'address', '100 northwest highway', expected4 );
+    assertAnalysis( 'address', '100 nw hwy', expected4 );
 
     suite.run( t.end );
   });

--- a/integration/analyzer_peliasPhrase.js
+++ b/integration/analyzer_peliasPhrase.js
@@ -33,7 +33,7 @@ module.exports.tests.analyze = function(test, common){
     assertAnalysis( 'kstem', 'McDonald\'s Restaurant', ['mcdonald restaurant'] );
     assertAnalysis( 'kstem', 'walking peoples', ['walking people'] );
     
-    assertAnalysis( 'peliasShingleFilter', '1 a ab abc abcdefghijk', ['1 a', 'a ab', 'ab abc', 'abc abcdefghijk'] );
+    assertAnalysis( 'peliasShinglesFilter', '1 a ab abc abcdefghijk', ['1 a', 'a ab', 'ab abc', 'abc abcdefghijk'] );
     assertAnalysis( 'unique', '1 1 1', ['1 1'] );
     assertAnalysis( 'notnull', ' a ', [] );
 

--- a/integration/analyzer_peliasPhrase.js
+++ b/integration/analyzer_peliasPhrase.js
@@ -12,7 +12,7 @@ module.exports.tests.analyze = function(test, common){
   test( 'analyze', function(t){
 
     var suite = new elastictest.Suite( null, { schema: schema } );
-    var assertAnalysis = analyze.bind( null, suite, t, 'peliasShingles' );
+    var assertAnalysis = analyze.bind( null, suite, t, 'peliasPhrase' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     assertAnalysis( 'lowercase', 'F f', ['f f']);
@@ -33,7 +33,7 @@ module.exports.tests.analyze = function(test, common){
     assertAnalysis( 'kstem', 'McDonald\'s Restaurant', ['mcdonald restaurant'] );
     assertAnalysis( 'kstem', 'walking peoples', ['walking people'] );
     
-    assertAnalysis( 'peliasShinglesFilter', '1 a ab abc abcdefghijk', ['1 a', 'a ab', 'ab abc', 'abc abcdefghijk'] );
+    assertAnalysis( 'peliasShingleFilter', '1 a ab abc abcdefghijk', ['1 a', 'a ab', 'ab abc', 'abc abcdefghijk'] );
     assertAnalysis( 'unique', '1 1 1', ['1 1'] );
     assertAnalysis( 'notnull', ' a ', [] );
 
@@ -51,7 +51,7 @@ module.exports.tests.functional = function(test, common){
   test( 'functional', function(t){
 
     var suite = new elastictest.Suite( null, { schema: schema } );
-    var assertAnalysis = analyze.bind( null, suite, t, 'peliasShingles' );
+    var assertAnalysis = analyze.bind( null, suite, t, 'peliasPhrase' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     assertAnalysis( 'country', 'Trinidad and Tobago', [
@@ -88,7 +88,7 @@ module.exports.tests.functional = function(test, common){
 module.exports.all = function (tape, common) {
 
   function test(name, testFunction) {
-    return tape('peliasShingles: ' + name, testFunction);
+    return tape('peliasPhrase: ' + name, testFunction);
   }
 
   for( var testCase in module.exports.tests ){

--- a/integration/analyzer_peliasShingles.js
+++ b/integration/analyzer_peliasShingles.js
@@ -1,0 +1,117 @@
+
+// validate analyzer is behaving as expected
+
+var tape = require('tape'),
+    elastictest = require('elastictest'),
+    schema = require('../schema'),
+    punctuation = require('../punctuation');
+
+module.exports.tests = {};
+
+module.exports.tests.analyze = function(test, common){
+  test( 'analyze', function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+    var assertAnalysis = analyze.bind( null, suite, t, 'peliasShingles' );
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
+
+    assertAnalysis( 'lowercase', 'F f', ['f f']);
+    assertAnalysis( 'asciifolding', 'é é', ['e e']);
+    assertAnalysis( 'asciifolding', 'ß ß', ['ss ss']);
+    assertAnalysis( 'asciifolding', 'æ æ', ['ae ae']);
+    assertAnalysis( 'asciifolding', 'ł ł', ['l l']);
+    assertAnalysis( 'asciifolding', 'ɰ ɰ', ['m m']);
+    assertAnalysis( 'trim', ' f f ', ['f f'] );
+    assertAnalysis( 'stop_words (disabled)', 'a st b ave c', ['a st', 'st b', 'b ave', 'ave c'] );
+    assertAnalysis( 'ampersand', 'a and b', ['a &','& b'] );
+    assertAnalysis( 'ampersand', 'a & b', ['a &','& b'] );
+
+    // @todo: handle multiple consecutive 'and'
+    // assertAnalysis( 'ampersand', 'a and & and b', ['a &','& b'] );
+
+    assertAnalysis( 'kstem', 'mcdonalds restaurant', ['mcdonald restaurant'] );
+    assertAnalysis( 'kstem', 'McDonald\'s Restaurant', ['mcdonald restaurant'] );
+    assertAnalysis( 'kstem', 'walking peoples', ['walking people'] );
+    
+    assertAnalysis( 'peliasShinglesFilter', '1 a ab abc abcdefghijk', ['1 a', 'a ab', 'ab abc', 'abc abcdefghijk'] );
+    assertAnalysis( 'unique', '1 1 1', ['1 1'] );
+    assertAnalysis( 'notnull', ' a ', [] );
+
+    assertAnalysis( 'stem street suffixes', 'streets avenue', ['st ave'] );
+    assertAnalysis( 'stem street suffixes', 'boulevard roads', ['blvd rd'] );
+
+    // remove punctuation (handled by the char_filter)
+    assertAnalysis( 'punctuation', punctuation.all.join(''), [] );
+
+    suite.run( t.end );
+  });
+};
+
+module.exports.tests.functional = function(test, common){
+  test( 'functional', function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+    var assertAnalysis = analyze.bind( null, suite, t, 'peliasShingles' );
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
+
+    assertAnalysis( 'country', 'Trinidad and Tobago', [
+      'trinidad &', '& tobago'
+    ]);
+
+    assertAnalysis( 'place', 'Toys "R" Us!', [
+      'toy r', 'r us'
+    ]);
+
+    assertAnalysis( 'address', '101 mapzen pl', [
+      '101 mapzen', 'mapzen pl'
+    ]);
+
+    // both terms should map to same tokens
+    var expected1 = [ '325 n', 'n 12th', '12th st' ];
+    assertAnalysis( 'address', '325 N 12th St', expected1 );
+    assertAnalysis( 'address', '325 North 12th Street', expected1 );
+
+    // both terms should map to same tokens
+    var expected2 = [ '13509 colfax', 'colfax ave', 'ave s' ];
+    assertAnalysis( 'address', '13509 Colfax Ave S', expected2 );
+    assertAnalysis( 'address', '13509 Colfax Avenue South', expected2 );
+
+    // both terms should map to same tokens
+    var expected3 = [ '100 s', 's lake', 'lake dr' ];
+    assertAnalysis( 'address', '100 S Lake Dr', expected3 );
+    assertAnalysis( 'address', '100 South Lake Drive', expected3 );
+
+    suite.run( t.end );
+  });
+};
+
+module.exports.all = function (tape, common) {
+
+  function test(name, testFunction) {
+    return tape('peliasShingles: ' + name, testFunction);
+  }
+
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};
+
+function analyze( suite, t, analyzer, comment, text, expected ){
+  suite.assert( function( done ){
+    suite.client.indices.analyze({
+      index: suite.props.index,
+      analyzer: analyzer,
+      text: text
+    }, function( err, res ){
+      if( err ) console.error( err );
+      t.deepEqual( simpleTokens( res.tokens ), expected, comment );
+      done();
+    });
+  });
+}
+
+function simpleTokens( tokens ){
+  return tokens.map( function( t ){
+    return t.token;
+  });
+}

--- a/integration/analyzer_peliasTwoEdgeGram.js
+++ b/integration/analyzer_peliasTwoEdgeGram.js
@@ -1,0 +1,105 @@
+
+// validate analyzer is behaving as expected
+
+var tape = require('tape'),
+    elastictest = require('elastictest'),
+    schema = require('../schema'),
+    punctuation = require('../punctuation');
+
+module.exports.tests = {};
+
+module.exports.tests.analyze = function(test, common){
+  test( 'analyze', function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+    var assertAnalysis = analyze.bind( null, suite, t, 'peliasTwoEdgeGram' );
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
+
+    assertAnalysis( 'lowercase', 'FA', ['fa']);
+    assertAnalysis( 'asciifolding', 'éA', ['ea']);
+    assertAnalysis( 'asciifolding', 'ß', ['ss']);
+    assertAnalysis( 'asciifolding', 'æ', ['ae']);
+    assertAnalysis( 'asciifolding', 'łA', ['la']);
+    assertAnalysis( 'asciifolding', 'ɰA', ['ma']);
+    assertAnalysis( 'trim', ' fA ', ['fa'] );
+    assertAnalysis( 'stop_words', 'aa street bb avenue cc', ['aa','bb','cc'] );
+    assertAnalysis( 'ampersand', 'aa and bb', ['aa','bb'] );
+
+    // note, this functionality could be changed in the future in
+    // order to allow the following cases to pass:
+    // assertAnalysis( 'ampersand', 'aa and bb', ['aa','&','bb'] );
+    // assertAnalysis( 'ampersand', 'aa & bb', ['aa','&','bb'] );
+    // assertAnalysis( 'ampersand', 'aa and & and bb', ['aa','&','bb'] );
+
+    assertAnalysis( 'peliasTwoEdgeGramFilter', '1 a ab abc abcdefghijk', ['ab','abc','abcd','abcde','abcdef','abcdefg','abcdefgh','abcdefghi','abcdefghij'] );
+    assertAnalysis( 'removeAllZeroNumericPrefix', '0002 00011', ['11'] );
+    assertAnalysis( 'unique', '11 11 11', ['11'] );
+    assertAnalysis( 'notnull', 'avenue street', [] );
+
+    assertAnalysis( 'kstem', 'mcdonalds', ['mc', 'mcd', 'mcdo', 'mcdon', 'mcdona', 'mcdonal', 'mcdonald'] );
+    assertAnalysis( 'kstem', 'McDonald\'s', ['mc', 'mcd', 'mcdo', 'mcdon', 'mcdona', 'mcdonal', 'mcdonald'] );
+    assertAnalysis( 'kstem', 'peoples', ['pe', 'peo', 'peop', 'peopl', 'people'] );
+
+    // remove punctuation (handled by the char_filter)
+    assertAnalysis( 'punctuation', punctuation.all.join(''), ['-&'] );
+
+    // ensure that single grams are not created
+    assertAnalysis( '1grams', 'a aa b bb 1 11', ['aa','bb','11'] );
+
+    suite.run( t.end );
+  });
+};
+
+module.exports.tests.functional = function(test, common){
+  test( 'functional', function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+    var assertAnalysis = analyze.bind( null, suite, t, 'peliasTwoEdgeGram' );
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
+
+    assertAnalysis( 'country', 'Trinidad and Tobago', [
+      'tr', 'tri', 'trin', 'trini', 'trinid', 'trinida', 'trinidad', 'to', 'tob', 'toba', 'tobag', 'tobago'
+    ]);
+
+    assertAnalysis( 'place', 'Toys "R" Us!', [
+      'to', 'toy', 'us'
+    ]);
+
+    assertAnalysis( 'address', '101 mapzen place', [
+      '10', '101', 'ma', 'map', 'mapz', 'mapze', 'mapzen'
+    ]);
+
+    suite.run( t.end );
+  });
+};
+
+module.exports.all = function (tape, common) {
+
+  function test(name, testFunction) {
+    return tape('peliasTwoEdgeGram: ' + name, testFunction);
+  }
+
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};
+
+function analyze( suite, t, analyzer, comment, text, expected ){
+  suite.assert( function( done ){
+    suite.client.indices.analyze({
+      index: suite.props.index,
+      analyzer: analyzer,
+      text: text
+    }, function( err, res ){
+      if( err ) console.error( err );
+      t.deepEqual( simpleTokens( res.tokens ), expected, comment );
+      done();
+    });
+  });
+}
+
+function simpleTokens( tokens ){
+  return tokens.map( function( t ){
+    return t.token;
+  });
+}

--- a/integration/dynamic_templates.js
+++ b/integration/dynamic_templates.js
@@ -1,0 +1,99 @@
+
+// http://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-root-object-type.html#_dynamic_templates
+
+var tape = require('tape'),
+    elastictest = require('elastictest'),
+    schema = require('../schema');
+
+module.exports.tests = {};
+
+// 'admin' mappings have a different 'name' dynamic_template to the other types
+module.exports.tests.dynamic_templates_name = function(test, common){
+  test( 'admin->name', nameAssertion( 'admin0', 'peliasOneEdgeGram' ) );
+  test( 'document->name', nameAssertion( 'myType', 'peliasTwoEdgeGram' ) );
+};
+
+// all types share the same shingle mapping
+module.exports.tests.dynamic_templates_shingle = function(test, common){
+  test( 'admin->shingle', shingleAssertion( 'admin0', 'peliasShingles' ) );
+  test( 'document->shingle', shingleAssertion( 'myType', 'peliasShingles' ) );
+};
+
+module.exports.all = function (tape, common) {
+
+  function test(name, testFunction) {
+    return tape('dynamic_templates: ' + name, testFunction);
+  }
+
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};
+
+function nameAssertion( type, analyzer ){
+  return function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+
+    // index a document from a normal document layer
+    suite.action( function( done ){
+      suite.client.index({
+        index: suite.props.index,
+        type: type,
+        id: '1',
+        body: { name: { default: 'foo', alt: 'bar' } }
+      }, done );
+    });
+
+    // check dynamically created mapping has
+    // inherited from the dynamic_template
+    suite.assert( function( done ){
+      suite.client.indices.getMapping({ index: suite.props.index, type: type }, function( err, res ){
+
+        var properties = res[suite.props.index].mappings[type].properties;
+        t.equal( properties.name.dynamic, 'true' );
+
+        var nameProperties = properties.name.properties;
+        t.equal( nameProperties.default.analyzer, analyzer );
+        t.equal( nameProperties.alt.analyzer, analyzer );
+        done();
+      });
+    });
+
+    suite.run( t.end );
+  };
+}
+
+function shingleAssertion( type, analyzer ){
+  return function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+
+    // index a document from a normal document layer
+    suite.action( function( done ){
+      suite.client.index({
+        index: suite.props.index,
+        type: type,
+        id: '1',
+        body: { shingle: { default: 'foo', alt: 'bar' } }
+      }, done );
+    });
+
+    // check dynamically created mapping has
+    // inherited from the dynamic_template
+    suite.assert( function( done ){
+      suite.client.indices.getMapping({ index: suite.props.index, type: type }, function( err, res ){
+
+        var properties = res[suite.props.index].mappings[type].properties;
+        t.equal( properties.shingle.dynamic, 'true' );
+
+        var shingleProperties = properties.shingle.properties;
+        t.equal( shingleProperties.default.analyzer, analyzer );
+        t.equal( shingleProperties.alt.analyzer, analyzer );
+        done();
+      });
+    });
+
+    suite.run( t.end );
+  };
+}

--- a/integration/dynamic_templates.js
+++ b/integration/dynamic_templates.js
@@ -13,10 +13,10 @@ module.exports.tests.dynamic_templates_name = function(test, common){
   test( 'document->name', nameAssertion( 'myType', 'peliasTwoEdgeGram' ) );
 };
 
-// all types share the same shingle mapping
-module.exports.tests.dynamic_templates_shingle = function(test, common){
-  test( 'admin->shingle', shingleAssertion( 'admin0', 'peliasShingles' ) );
-  test( 'document->shingle', shingleAssertion( 'myType', 'peliasShingles' ) );
+// all types share the same phrase mapping
+module.exports.tests.dynamic_templates_phrase = function(test, common){
+  test( 'admin->phrase', phraseAssertion( 'admin0', 'peliasPhrase' ) );
+  test( 'document->phrase', phraseAssertion( 'myType', 'peliasPhrase' ) );
 };
 
 module.exports.all = function (tape, common) {
@@ -64,7 +64,7 @@ function nameAssertion( type, analyzer ){
   };
 }
 
-function shingleAssertion( type, analyzer ){
+function phraseAssertion( type, analyzer ){
   return function(t){
 
     var suite = new elastictest.Suite( null, { schema: schema } );
@@ -75,7 +75,7 @@ function shingleAssertion( type, analyzer ){
         index: suite.props.index,
         type: type,
         id: '1',
-        body: { shingle: { default: 'foo', alt: 'bar' } }
+        body: { phrase: { default: 'foo', alt: 'bar' } }
       }, done );
     });
 
@@ -85,11 +85,11 @@ function shingleAssertion( type, analyzer ){
       suite.client.indices.getMapping({ index: suite.props.index, type: type }, function( err, res ){
 
         var properties = res[suite.props.index].mappings[type].properties;
-        t.equal( properties.shingle.dynamic, 'true' );
+        t.equal( properties.phrase.dynamic, 'true' );
 
-        var shingleProperties = properties.shingle.properties;
-        t.equal( shingleProperties.default.analyzer, analyzer );
-        t.equal( shingleProperties.alt.analyzer, analyzer );
+        var phraseProperties = properties.phrase.properties;
+        t.equal( phraseProperties.default.analyzer, analyzer );
+        t.equal( phraseProperties.alt.analyzer, analyzer );
         done();
       });
     });

--- a/integration/run.js
+++ b/integration/run.js
@@ -7,7 +7,7 @@ var tests = [
   require('./dynamic_templates.js'),
   require('./analyzer_peliasOneEdgeGram.js'),
   require('./analyzer_peliasTwoEdgeGram.js'),
-  require('./analyzer_peliasShingles.js')
+  require('./analyzer_peliasPhrase.js')
 ];
 
 tests.map(function(t) {

--- a/integration/run.js
+++ b/integration/run.js
@@ -1,0 +1,15 @@
+
+var tape = require('tape');
+var common = {};
+
+var tests = [
+  require('./validate.js'),
+  require('./dynamic_templates.js'),
+  require('./analyzer_peliasOneEdgeGram.js'),
+  require('./analyzer_peliasTwoEdgeGram.js'),
+  require('./analyzer_peliasShingles.js')
+];
+
+tests.map(function(t) {
+  t.all(tape, common);
+});

--- a/integration/validate.js
+++ b/integration/validate.js
@@ -1,0 +1,36 @@
+
+// simply validate that the schema doesn't error when inserted in to
+// your local elasticsearch server, useful to sanity check version upgrades.
+
+var tape = require('tape'),
+    elastictest = require('elastictest'),
+    schema = require('../schema');
+
+module.exports.tests = {};
+
+module.exports.tests.validate = function(test, common){
+  test( 'schema', function(t){
+    
+    var suite = new elastictest.Suite( null, { schema: schema } );
+
+    suite.assert( function( done ){
+      suite.client.info({}, function( err, res ){
+        t.equal( res.status, 200 );
+        done();
+      });
+    });
+
+    suite.run( t.end );
+  });
+};
+
+module.exports.all = function (tape, common) {
+
+  function test(name, testFunction) {
+    return tape('validate: ' + name, testFunction);
+  }
+
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/mappings/document.js
+++ b/mappings/document.js
@@ -6,6 +6,7 @@ var multiplier = require('./partial/multiplier');
 var schema = {
   properties: {
     name: hash,
+    shingle: hash,
     address: merge( {}, hash, { 'index': 'no' } ),
     alpha3: admin,
     admin0: admin,
@@ -22,13 +23,39 @@ var schema = {
     popularity: multiplier,
     suggest: require('./partial/suggest')
   },
-  _source : {
-    excludes : ['shape']
+  dynamic_templates: [{
+    nameGram: {
+      path_match: 'name.*',
+      match_mapping_type: 'string',
+      mapping: {
+        type: 'string',
+        analyzer: 'peliasTwoEdgeGram',
+        fielddata : {
+          format : 'fst',
+          loading: 'eager_global_ordinals'
+        }
+      }
+    },
+  },{
+    shingle: {
+      path_match: 'shingle.*',
+      match_mapping_type: 'string',
+      mapping: {
+        type: 'string',
+        analyzer: 'peliasShingles',
+        fielddata : {
+          loading: 'eager_global_ordinals'
+        }
+      }
+    }
+  }],
+  _source: {
+    excludes : ['shape','shingle']
   },
   _all: {
     enabled: false
   },
-  dynamic: 'strict'
+  dynamic: 'true'
 };
 
 module.exports = schema;

--- a/mappings/document.js
+++ b/mappings/document.js
@@ -6,7 +6,7 @@ var multiplier = require('./partial/multiplier');
 var schema = {
   properties: {
     name: hash,
-    shingle: hash,
+    phrase: hash,
     address: merge( {}, hash, { 'index': 'no' } ),
     alpha3: admin,
     admin0: admin,
@@ -37,12 +37,12 @@ var schema = {
       }
     },
   },{
-    shingle: {
-      path_match: 'shingle.*',
+    phrase: {
+      path_match: 'phrase.*',
       match_mapping_type: 'string',
       mapping: {
         type: 'string',
-        analyzer: 'peliasShingles',
+        analyzer: 'peliasPhrase',
         fielddata : {
           loading: 'eager_global_ordinals'
         }
@@ -50,7 +50,7 @@ var schema = {
     }
   }],
   _source: {
-    excludes : ['shape','shingle']
+    excludes : ['shape','phrase']
   },
   _all: {
     enabled: false

--- a/mappings/partial/centroid.js
+++ b/mappings/partial/centroid.js
@@ -6,15 +6,15 @@ var schema = {
   /* `lat_lon` enabled since both the geo distance and bounding box filters can either be executed using in memory checks, or using the indexed lat lon values */
   'lat_lon': true,
 
-  // 'geohash': true,
-  // 'geohash_prefix': true,
-  // 'geohash_precision': 20,
+  /* store geohashes (with prefixes) in order to facilitate the geohash_cell filter */
+  'geohash': true,
+  'geohash_prefix': true,
+  'geohash_precision': 18,
 
-  /* `precision: 3m` option allows us to trade precision for memory. */
+  /* eager loading should be enabled to prevent cold starts */
   'fielddata' : {
-    'format' : 'compressed',
-    'precision' : '3m'
+    'loading': 'eager_global_ordinals'
   }
-}
+};
 
 module.exports = schema;

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "main": "schema.js",
   "scripts": {
     "test": "node test/run.js | tap-spec",
+    "integration": "node integration/run.js | tap-spec",
     "create_index": "node scripts/create_index",
     "drop_index": "node scripts/drop_index",
     "reset_type": "node scripts/reset_type",
@@ -35,8 +36,9 @@
     "pelias-config": "latest"
   },
   "devDependencies": {
-    "tape": "^2.13.4",
+    "elastictest": "^0.1.0",
+    "pelias-esclient": "latest",
     "tap-spec": "^0.2.0",
-    "pelias-esclient": "latest"
+    "tape": "^2.13.4"
   }
 }

--- a/punctuation.js
+++ b/punctuation.js
@@ -1,0 +1,24 @@
+
+// These characters will be removed from ngrams/shingles
+// @see: org/apache/lucene/analysis/cn/smart/stopwords.txt
+
+module.exports.all = [
+  ",",".","`","-","_","=","?","'","|","\"","(",")","{","}","[","]","<",">","*",
+  "#","&","^","$","@","!","~",":",";","+","/","\\\\","《","》","—","－","，","。",
+  "、", "：","；","！","·","？","“","”","）","（","【","】","［","］","●"
+];
+
+module.exports.allowed = [
+  "-", // allow hypens
+  "&"  // allow ampersands
+];
+
+module.exports.blacklist = module.exports.all.slice();
+
+// remove alowed chars from blacklist
+module.exports.allowed.forEach(function(item){
+  var index = module.exports.blacklist.indexOf(item);
+  if( index > -1 ){
+    module.exports.blacklist.splice(index, 1);
+  }
+});

--- a/schema.js
+++ b/schema.js
@@ -1,9 +1,30 @@
 var doc = require('./mappings/document');
 
+var oneGramMapping = {
+  dynamic_templates: [{
+    nameGram: {
+      path_match: 'name.*',
+      match_mapping_type: 'string',
+      mapping: {
+        type: 'string',
+        analyzer: 'peliasOneEdgeGram',
+        fielddata : {
+          format : 'fst',
+          loading: 'eager_global_ordinals'
+        }
+      }
+    }
+  }]
+};
+
 var schema = {
   settings: require('./settings')(),
   mappings: {
-    _default_: doc
+    _default_: doc,
+
+    admin0: oneGramMapping,
+    admin1: oneGramMapping,
+    admin2: oneGramMapping
   }
 };
 

--- a/settings.js
+++ b/settings.js
@@ -55,7 +55,7 @@ function generate(){
             "notnull"
           ]
         },
-        "peliasShingles": {
+        "peliasPhrase": {
           "type": "custom",
           "tokenizer":"whitespace",
           "char_filter" : ["punctuation"],

--- a/settings.js
+++ b/settings.js
@@ -1,6 +1,8 @@
 
 var Mergeable = require('mergeable');
 var peliasConfig = require('pelias-config');
+var punctuation = require('./punctuation');
+var street_suffix = require('./street_suffix');
 
 var moduleDir = require('path').dirname("../");
 
@@ -11,25 +13,126 @@ function generate(){
   var settings = {
     "analysis": {
       "analyzer": {
-        "suggestions": {
-          "type": "custom",
-          "tokenizer": "whitespace",
-          "filter": ["lowercase", "asciifolding"]
+        "plugin": {
+          "type": "pelias-analysis"
         },
         "pelias": {
           "type": "custom",
           "tokenizer": "whitespace",
           "filter": ["lowercase", "asciifolding","ampersand","word_delimiter"]
         },
-        "plugin": {
-          "type": "pelias-analysis"
+        "peliasOneEdgeGram" : {
+          "type": "custom",
+          "tokenizer" : "whitespace",
+          "char_filter" : ["punctuation"],
+          "filter": [
+            "lowercase",
+            "asciifolding",
+            "trim",
+            "address_stop",
+            "ampersand",
+            "removeAllZeroNumericPrefix",
+            "kstem",
+            "peliasOneEdgeGramFilter",
+            "unique",
+            "notnull"
+          ]
+        },
+        "peliasTwoEdgeGram" : {
+          "type": "custom",
+          "tokenizer" : "whitespace",
+          "char_filter" : ["punctuation"],
+          "filter": [
+            "lowercase",
+            "asciifolding",
+            "trim",
+            "address_stop",
+            "ampersand",
+            "removeAllZeroNumericPrefix",
+            "kstem",
+            "peliasTwoEdgeGramFilter",
+            "unique",
+            "notnull"
+          ]
+        },
+        "peliasShingles": {
+          "type": "custom",
+          "tokenizer":"whitespace",
+          "char_filter" : ["punctuation"],
+          "filter": [
+            "lowercase",
+            "asciifolding",
+            "trim",
+            "ampersand",
+            "kstem",
+            "street_synonym",
+            "direction_synonym",
+            "peliasShinglesFilter",
+            "unique",
+            "notnull"
+          ]
         }
       },
       "filter" : {
         "ampersand" :{
           "type" : "pattern_replace",
-          "pattern" : "[&]",
-          "replacement" : " and "
+          "pattern" : "and",
+          "replacement" : "&"
+        },
+        "notnull" :{
+          "type" : "length",
+          "min" : 1
+        },
+        "peliasOneEdgeGramFilter": {
+          "type" : "edgeNGram",
+          "min_gram" : 1,
+          "max_gram" : 10
+        },
+        "peliasTwoEdgeGramFilter": {
+          "type" : "edgeNGram",
+          "min_gram" : 2,
+          "max_gram" : 10
+        },
+        // "prefixOneDigitNumbers" :{
+        //   "type" : "pattern_replace",
+        //   "pattern" : "^([1-9]{1})(.*)$",
+        //   "replacement" : "00$1$2"
+        // },
+        // "prefixTwoDigitNumbers" :{
+        //   "type" : "pattern_replace",
+        //   "pattern" : "^([1-9]{2})(.*)$",
+        //   "replacement" : "0$1$2"
+        // },
+        "removeAllZeroNumericPrefix" :{
+          "type" : "pattern_replace",
+          "pattern" : "^(0*)",
+          "replacement" : ""
+        },
+        "peliasShinglesFilter": {
+          "type": "shingle",
+          "min_shingle_size": 2,
+          "max_shingle_size": 2,
+          "output_unigrams": false
+        },
+        "address_stop": {
+          "type": "stop",
+          "stopwords": street_suffix.terms
+        },
+        "street_synonym": {
+          "type": "synonym",
+          "synonyms": street_suffix.synonyms
+        },
+        "direction_synonym": {
+          "type": "synonym",
+          "synonyms": street_suffix.direction_synonyms
+        }
+      },
+      "char_filter": {
+        "punctuation" : {
+          "type" : "mapping",
+          "mappings" : punctuation.blacklist.map(function(c){
+            return c + '=>';
+          })
         }
       }
     },

--- a/street_suffix.js
+++ b/street_suffix.js
@@ -1,0 +1,35 @@
+
+module.exports.terms =  [
+  "alley", "avenue", "boulevard", "bypass", "crescent", "drive", "esplanade",
+  "expressway", "field", "freeway", "garden", "green", "grove", "heights",
+  "highway", "lane", "mews", "parade", "pike", "place", "promenade", "road",
+  "row", "street", "terrace", "turnpike", "viaduct", "way"
+];
+
+module.exports.synonyms = [
+  "avenue => ave",
+  "boulevard => blvd",
+  "circle => cir",
+  "close => cl",
+  "court => ct",
+  "crescent => cres",
+  "drive => dr",
+  "esplanade => esp",
+  "highway => hwy",
+  "lane => ln",
+  "parkway => pkwy",
+  "place => pl",
+  "road => rd",
+  "street => st",
+  "suite => ste",
+  "terrace => terr",
+  "trail => tr",
+  "way => wy"
+];
+
+module.exports.direction_synonyms = [
+  "north => n",
+  "south => s",
+  "east => e",
+  "west => w"
+];

--- a/street_suffix.js
+++ b/street_suffix.js
@@ -31,5 +31,9 @@ module.exports.direction_synonyms = [
   "north => n",
   "south => s",
   "east => e",
-  "west => w"
+  "west => w",
+  "southwest => sw",
+  "southeast => se",
+  "northwest => nw",
+  "northeast => ne"
 ];

--- a/test/compile.js
+++ b/test/compile.js
@@ -11,13 +11,40 @@ module.exports.tests.compile = function(test, common) {
   });
 };
 
-var mandatory_indeces = ['_default_'];
+// admin indeces are explicitly specified in order to specify a custom
+// dynamic_template and to avoid 'type not found' errors when deploying
+// the api codebase against an index without admin data
 module.exports.tests.indeces = function(test, common) {
-  test('contains mandatory indeces', function(t) {
-    t.plan( mandatory_indeces.length +1 );
-    t.equal(typeof schema.mappings, 'object', 'mappings present');
-    mandatory_indeces.forEach( function( index_name ){
-      t.equal( schema.mappings.hasOwnProperty(index_name), true, 'mandatory mapping defined' );
+  test('contains "_default_" index definition', function(t) {
+    t.equal(typeof schema.mappings['_default_'], 'object', 'mappings present');
+    t.equal(schema.mappings['_default_'].dynamic_templates[0].nameGram.mapping.analyzer, 'peliasTwoEdgeGram');
+    t.end();
+  });
+  test('explicitly specify some admin indeces and their analyzer', function(t) {
+    t.equal(typeof schema.mappings['admin0'], 'object', 'mappings present');
+    t.equal(schema.mappings['admin0'].dynamic_templates[0].nameGram.mapping.analyzer, 'peliasOneEdgeGram');
+    t.equal(typeof schema.mappings['admin1'], 'object', 'mappings present');
+    t.equal(schema.mappings['admin1'].dynamic_templates[0].nameGram.mapping.analyzer, 'peliasOneEdgeGram');
+    t.equal(typeof schema.mappings['admin2'], 'object', 'mappings present');
+    t.equal(schema.mappings['admin2'].dynamic_templates[0].nameGram.mapping.analyzer, 'peliasOneEdgeGram');
+    t.end();
+  });
+};
+
+// some 'admin' types allow single edgeNGrams and so have a different dynamic_template
+module.exports.tests.dynamic_templates = function(test, common) {
+  test('dynamic_templates: nameGram', function(t) {
+    t.equal(typeof schema.mappings.admin0.dynamic_templates[0].nameGram, 'object', 'nameGram template specified');
+    var template = schema.mappings.admin0.dynamic_templates[0].nameGram;
+    t.equal(template.path_match, 'name.*');
+    t.equal(template.match_mapping_type, 'string');
+    t.deepEqual(template.mapping, {
+      type: 'string',
+      analyzer: 'peliasOneEdgeGram',
+      fielddata: {
+        format: 'fst',
+        loading: 'eager_global_ordinals'
+      }
     });
     t.end();
   });

--- a/test/document.js
+++ b/test/document.js
@@ -21,15 +21,41 @@ module.exports.tests.properties = function(test, common) {
 
 // should contain the correct field definitions
 module.exports.tests.fields = function(test, common) {
-  var fields = ['name','address','alpha3','admin0','admin1','admin1_abbr','admin2','local_admin','locality','neighborhood','center_point','shape','category','population','popularity','suggest'];
+  var fields = ['name','shingle','address','alpha3','admin0','admin1','admin1_abbr','admin2','local_admin','locality','neighborhood','center_point','shape','category','population','popularity','suggest'];
   test('fields specified', function(t) {
-    fields.forEach( function( field ){
-      t.equal(schema.properties.hasOwnProperty(field), true, field + ' field specified');
+    t.deepEqual(Object.keys(schema.properties), fields);
+    t.end();
+  });
+};
+
+module.exports.tests.dynamic_templates = function(test, common) {
+  test('dynamic_templates: nameGram', function(t) {
+    t.equal(typeof schema.dynamic_templates[0].nameGram, 'object', 'nameGram template specified');
+    var template = schema.dynamic_templates[0].nameGram;
+    t.equal(template.path_match, 'name.*');
+    t.equal(template.match_mapping_type, 'string');
+    t.deepEqual(template.mapping, {
+      type: 'string',
+      analyzer: 'peliasTwoEdgeGram',
+      fielddata: {
+        format: 'fst',
+        loading: 'eager_global_ordinals'
+      }
     });
     t.end();
   });
-  test('fields length', function(t) {
-    t.equal(Object.keys(schema.properties).length, fields.length, 'equal');
+  test('dynamic_templates: shingle', function(t) {
+    t.equal(typeof schema.dynamic_templates[1].shingle, 'object', 'shingle template specified');
+    var template = schema.dynamic_templates[1].shingle;
+    t.equal(template.path_match, 'shingle.*');
+    t.equal(template.match_mapping_type, 'string');
+    t.deepEqual(template.mapping, {
+      type: 'string',
+      analyzer: 'peliasShingles',
+      fielddata: {
+        loading: 'eager_global_ordinals'
+      }
+    });
     t.end();
   });
 };
@@ -42,11 +68,11 @@ module.exports.tests.all_disabled = function(test, common) {
   });
 };
 
-// dynamic should be strict
+// dynamic should be true in order for dynamic_templates to function properly
 // @see: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/mapping-dynamic-mapping.html
 module.exports.tests.dynamic_disabled = function(test, common) {
-  test('dynamic strict', function(t) {
-    t.equal(schema.dynamic, 'strict', 'dynamic strict');
+  test('dynamic true', function(t) {
+    t.equal(schema.dynamic, 'true', 'dynamic true');
     t.end();
   });
 };
@@ -56,6 +82,7 @@ module.exports.tests._source = function(test, common) {
   test('_source', function(t) {
     t.ok(Array.isArray(schema._source.excludes), 'exclusions specified');
     t.equal(schema._source.excludes[0], 'shape', 'exclude shape');
+    t.equal(schema._source.excludes[1], 'shingle', 'exclude shingle');
     t.end();
   });
 };

--- a/test/document.js
+++ b/test/document.js
@@ -21,7 +21,7 @@ module.exports.tests.properties = function(test, common) {
 
 // should contain the correct field definitions
 module.exports.tests.fields = function(test, common) {
-  var fields = ['name','shingle','address','alpha3','admin0','admin1','admin1_abbr','admin2','local_admin','locality','neighborhood','center_point','shape','category','population','popularity','suggest'];
+  var fields = ['name','phrase','address','alpha3','admin0','admin1','admin1_abbr','admin2','local_admin','locality','neighborhood','center_point','shape','category','population','popularity','suggest'];
   test('fields specified', function(t) {
     t.deepEqual(Object.keys(schema.properties), fields);
     t.end();
@@ -44,14 +44,14 @@ module.exports.tests.dynamic_templates = function(test, common) {
     });
     t.end();
   });
-  test('dynamic_templates: shingle', function(t) {
-    t.equal(typeof schema.dynamic_templates[1].shingle, 'object', 'shingle template specified');
-    var template = schema.dynamic_templates[1].shingle;
-    t.equal(template.path_match, 'shingle.*');
+  test('dynamic_templates: phrase', function(t) {
+    t.equal(typeof schema.dynamic_templates[1].phrase, 'object', 'phrase template specified');
+    var template = schema.dynamic_templates[1].phrase;
+    t.equal(template.path_match, 'phrase.*');
     t.equal(template.match_mapping_type, 'string');
     t.deepEqual(template.mapping, {
       type: 'string',
-      analyzer: 'peliasShingles',
+      analyzer: 'peliasPhrase',
       fielddata: {
         loading: 'eager_global_ordinals'
       }
@@ -82,7 +82,7 @@ module.exports.tests._source = function(test, common) {
   test('_source', function(t) {
     t.ok(Array.isArray(schema._source.excludes), 'exclusions specified');
     t.equal(schema._source.excludes[0], 'shape', 'exclude shape');
-    t.equal(schema._source.excludes[1], 'shingle', 'exclude shingle');
+    t.equal(schema._source.excludes[1], 'phrase', 'exclude phrase');
     t.end();
   });
 };

--- a/test/partial-centroid.js
+++ b/test/partial-centroid.js
@@ -9,7 +9,7 @@ module.exports.tests.compile = function(test, common) {
     t.equal(Object.keys(schema).length>0, true, 'schema has body');
     t.end();
   });
-}
+};
 
 // this should never need to change
 module.exports.tests.type = function(test, common) {
@@ -17,7 +17,7 @@ module.exports.tests.type = function(test, common) {
     t.equal(schema.type, 'geo_point', 'correct value');
     t.end();
   });
-}
+};
 
 // this should always be enabled for geo_distance filter
 // queries to execute correctly
@@ -26,15 +26,35 @@ module.exports.tests.latlon = function(test, common) {
     t.equal(schema.lat_lon, true, 'correct value');
     t.end();
   });
-}
+};
+
+// this should always be enabled for geohash_cell filter
+// queries to execute correctly
+module.exports.tests.geohash = function(test, common) {
+  test('geohash enabled', function(t) {
+    t.equal(schema.geohash, true, 'correct value');
+    t.equal(schema.geohash_prefix, true, 'correct value');
+    t.equal(schema.geohash_precision, 18, 'correct value');
+    t.end();
+  });
+};
+
+// this should be set to 'eager_global_ordinals' in order
+// to build caches at index time rather than query time
+module.exports.tests.fielddata = function(test, common) {
+  test('fielddata configured', function(t) {
+    t.equal(schema.fielddata.loading, 'eager_global_ordinals', 'correct value');
+    t.end();
+  });
+};
 
 module.exports.all = function (tape, common) {
 
   function test(name, testFunction) {
-    return tape('centroid: ' + name, testFunction)
+    return tape('centroid: ' + name, testFunction);
   }
 
   for( var testCase in module.exports.tests ){
     module.exports.tests[testCase](test, common);
   }
-}
+};

--- a/test/settings.js
+++ b/test/settings.js
@@ -110,19 +110,19 @@ module.exports.tests.peliasTwoEdgeGramAnalyzer = function(test, common) {
   });
 };
 
-module.exports.tests.peliasShinglesAnalyzer = function(test, common) {
-  test('has peliasShingles analyzer', function(t) {
+module.exports.tests.peliasPhraseAnalyzer = function(test, common) {
+  test('has peliasPhrase analyzer', function(t) {
     var s = settings();
-    t.equal(typeof s.analysis.analyzer.peliasShingles, 'object', 'there is a peliasShingles analyzer');
-    var analyzer = s.analysis.analyzer.peliasShingles;
+    t.equal(typeof s.analysis.analyzer.peliasPhrase, 'object', 'there is a peliasPhrase analyzer');
+    var analyzer = s.analysis.analyzer.peliasPhrase;
     t.equal(analyzer.type, 'custom', 'custom analyzer');
     t.equal(typeof analyzer.tokenizer, 'string', 'tokenizer specified');
     t.deepEqual(analyzer.char_filter, ["punctuation"], 'punctuation filter specified');
     t.true(Array.isArray(analyzer.filter), 'filters specified');
     t.end();
   });
-  test('peliasShingles token filters', function(t) {
-    var analyzer = settings().analysis.analyzer.peliasShingles;
+  test('peliasPhrase token filters', function(t) {
+    var analyzer = settings().analysis.analyzer.peliasPhrase;
     t.deepEqual( analyzer.filter, [
       "lowercase",
       "asciifolding",
@@ -196,9 +196,9 @@ module.exports.tests.peliasTwoEdgeGramFilter = function(test, common) {
 
 // this filter creates shingles
 module.exports.tests.peliasShinglesFilter = function(test, common) {
-  test('has peliasShingles filter', function(t) {
+  test('has peliasShinglesFilter filter', function(t) {
     var s = settings();
-    t.equal(typeof s.analysis.filter.peliasShinglesFilter, 'object', 'there is a peliasShingles filter');
+    t.equal(typeof s.analysis.filter.peliasShinglesFilter, 'object', 'there is a peliasShinglesFilter filter');
     var filter = s.analysis.filter.peliasShinglesFilter;
     t.equal(filter.type, 'shingle');
     t.equal(filter.min_shingle_size, 2);

--- a/test/settings.js
+++ b/test/settings.js
@@ -263,7 +263,7 @@ module.exports.tests.directionSynonymFilter = function(test, common) {
     var filter = s.analysis.filter.direction_synonym;
     t.equal(filter.type, 'synonym');
     t.true(Array.isArray(filter.synonyms));
-    t.equal(filter.synonyms.length, 4);
+    t.equal(filter.synonyms.length, 8);
     t.end();
   });
 };

--- a/test/settings.js
+++ b/test/settings.js
@@ -30,14 +30,261 @@ module.exports.tests.analysis = function(test, common) {
   });
 };
 
-module.exports.tests.peliasAnalyzer = function(test, common) {
-  test('has custom analyzer', function(t) {
+// -- analyzers --
+
+module.exports.tests.pluginAnalyzer = function(test, common) {
+  test('has plugin analyzer', function(t) {
     var s = settings();
-    t.equal(typeof s.analysis.analyzer.pelias, 'object', 'there is a pelias analyzer');
-    t.equal(typeof s.analysis.filter, 'object', 'there are custom filters');
+    t.equal(typeof s.analysis.analyzer.plugin, 'object', 'there is a plugin analyzer');
     t.end();
   });
 };
+
+module.exports.tests.peliasAnalyzer = function(test, common) {
+  test('has pelias analyzer', function(t) {
+    var s = settings();
+    t.equal(typeof s.analysis.analyzer.pelias, 'object', 'there is a pelias analyzer');
+    var analyzer = s.analysis.analyzer.pelias;
+    t.equal(analyzer.type, 'custom', 'custom analyzer');
+    t.equal(typeof analyzer.tokenizer, 'string', 'tokenizer specified');
+    t.true(Array.isArray(analyzer.filter), 'filters specified');
+    t.end();
+  });
+};
+
+module.exports.tests.peliasOneEdgeGramAnalyzer = function(test, common) {
+  test('has peliasOneEdgeGram analyzer', function(t) {
+    var s = settings();
+    t.equal(typeof s.analysis.analyzer.peliasOneEdgeGram, 'object', 'there is a peliasOneEdgeGram analyzer');
+    var analyzer = s.analysis.analyzer.peliasOneEdgeGram;
+    t.equal(analyzer.type, 'custom', 'custom analyzer');
+    t.equal(typeof analyzer.tokenizer, 'string', 'tokenizer specified');
+    t.deepEqual(analyzer.char_filter, ["punctuation"], 'punctuation filter specified');
+    t.true(Array.isArray(analyzer.filter), 'filters specified');
+    t.end();
+  });
+  test('peliasOneEdgeGram token filters', function(t) {
+    var analyzer = settings().analysis.analyzer.peliasOneEdgeGram;
+    t.deepEqual( analyzer.filter, [
+      "lowercase",
+      "asciifolding",
+      "trim",
+      "address_stop",
+      "ampersand",
+      "removeAllZeroNumericPrefix",
+      "kstem",
+      "peliasOneEdgeGramFilter",
+      "unique",
+      "notnull"
+    ]);
+    t.end();
+  });
+};
+
+module.exports.tests.peliasTwoEdgeGramAnalyzer = function(test, common) {
+  test('has peliasTwoEdgeGram analyzer', function(t) {
+    var s = settings();
+    t.equal(typeof s.analysis.analyzer.peliasTwoEdgeGram, 'object', 'there is a peliasTwoEdgeGram analyzer');
+    var analyzer = s.analysis.analyzer.peliasTwoEdgeGram;
+    t.equal(analyzer.type, 'custom', 'custom analyzer');
+    t.equal(typeof analyzer.tokenizer, 'string', 'tokenizer specified');
+    t.deepEqual(analyzer.char_filter, ["punctuation"], 'punctuation filter specified');
+    t.true(Array.isArray(analyzer.filter), 'filters specified');
+    t.end();
+  });
+  test('peliasTwoEdgeGram token filters', function(t) {
+    var analyzer = settings().analysis.analyzer.peliasTwoEdgeGram;
+    t.deepEqual( analyzer.filter, [
+      "lowercase",
+      "asciifolding",
+      "trim",
+      "address_stop",
+      "ampersand",
+      "removeAllZeroNumericPrefix",
+      "kstem",
+      "peliasTwoEdgeGramFilter",
+      "unique",
+      "notnull"
+    ]);
+    t.end();
+  });
+};
+
+module.exports.tests.peliasShinglesAnalyzer = function(test, common) {
+  test('has peliasShingles analyzer', function(t) {
+    var s = settings();
+    t.equal(typeof s.analysis.analyzer.peliasShingles, 'object', 'there is a peliasShingles analyzer');
+    var analyzer = s.analysis.analyzer.peliasShingles;
+    t.equal(analyzer.type, 'custom', 'custom analyzer');
+    t.equal(typeof analyzer.tokenizer, 'string', 'tokenizer specified');
+    t.deepEqual(analyzer.char_filter, ["punctuation"], 'punctuation filter specified');
+    t.true(Array.isArray(analyzer.filter), 'filters specified');
+    t.end();
+  });
+  test('peliasShingles token filters', function(t) {
+    var analyzer = settings().analysis.analyzer.peliasShingles;
+    t.deepEqual( analyzer.filter, [
+      "lowercase",
+      "asciifolding",
+      "trim",
+      "ampersand",
+      "kstem",
+      "street_synonym",
+      "direction_synonym",
+      "peliasShinglesFilter",
+      "unique",
+      "notnull"
+    ]);
+    t.end();
+  });
+};
+
+// -- filters --
+
+// note: pattern/replace should not have surrounding whitespace
+// we convert and->& rather than &->and to save memory/disk
+module.exports.tests.ampersandFilter = function(test, common) {
+  test('has ampersand filter', function(t) {
+    var s = settings();
+    t.equal(typeof s.analysis.filter.ampersand, 'object', 'there is a ampersand filter');
+    var filter = s.analysis.filter.ampersand;
+    t.equal(filter.type, 'pattern_replace');
+    t.equal(filter.pattern, 'and');
+    t.equal(filter.replacement, '&');
+    t.end();
+  });
+};
+
+// this filter simply removes empty tokens which can occur when other
+// filters do weird things, so just to be sure, we explicitly get rid of them
+module.exports.tests.notnullFilter = function(test, common) {
+  test('has notnull filter', function(t) {
+    var s = settings();
+    t.equal(typeof s.analysis.filter.notnull, 'object', 'there is a notnull filter');
+    var filter = s.analysis.filter.notnull;
+    t.equal(filter.type, 'length');
+    t.equal(filter.min, 1);
+    t.end();
+  });
+};
+
+// this filter creates edgeNGrams with the minimum size of 1
+module.exports.tests.peliasOneEdgeGramFilter = function(test, common) {
+  test('has peliasOneEdgeGram filter', function(t) {
+    var s = settings();
+    t.equal(typeof s.analysis.filter.peliasOneEdgeGramFilter, 'object', 'there is a peliasOneEdgeGram filter');
+    var filter = s.analysis.filter.peliasOneEdgeGramFilter;
+    t.equal(filter.type, 'edgeNGram');
+    t.equal(filter.min_gram, 1);
+    t.equal(filter.max_gram, 10);
+    t.end();
+  });
+};
+
+// this filter creates edgeNGrams with the minimum size of 2
+module.exports.tests.peliasTwoEdgeGramFilter = function(test, common) {
+  test('has peliasTwoEdgeGram filter', function(t) {
+    var s = settings();
+    t.equal(typeof s.analysis.filter.peliasTwoEdgeGramFilter, 'object', 'there is a peliasTwoEdgeGram filter');
+    var filter = s.analysis.filter.peliasTwoEdgeGramFilter;
+    t.equal(filter.type, 'edgeNGram');
+    t.equal(filter.min_gram, 2);
+    t.equal(filter.max_gram, 10);
+    t.end();
+  });
+};
+
+// this filter creates shingles
+module.exports.tests.peliasShinglesFilter = function(test, common) {
+  test('has peliasShingles filter', function(t) {
+    var s = settings();
+    t.equal(typeof s.analysis.filter.peliasShinglesFilter, 'object', 'there is a peliasShingles filter');
+    var filter = s.analysis.filter.peliasShinglesFilter;
+    t.equal(filter.type, 'shingle');
+    t.equal(filter.min_shingle_size, 2);
+    t.equal(filter.max_shingle_size, 2);
+    t.equal(filter.output_unigrams, false); // this should be disabled to reduce index size
+    t.end();
+  });
+};
+
+// this filter removed leading 0 characters. eg. 0001 -> 1
+module.exports.tests.removeAllZeroNumericPrefixFilter = function(test, common) {
+  test('has removeAllZeroNumericPrefix filter', function(t) {
+    var s = settings();
+    t.equal(typeof s.analysis.filter.removeAllZeroNumericPrefix, 'object', 'there is a removeAllZeroNumericPrefix filter');
+    var filter = s.analysis.filter.removeAllZeroNumericPrefix;
+    t.equal(filter.type, 'pattern_replace');
+    t.equal(filter.pattern, '^(0*)');
+    t.equal(filter.replacement, '');
+    t.end();
+  });
+};
+
+// this filter can be used to remove certain common words in order to keep
+// the index size down and the execution speed quick.
+// note: it is not intended to be used with shingles, but useful for ngrams
+module.exports.tests.addressStopFilter = function(test, common) {
+  test('has address_stop filter', function(t) {
+    var s = settings();
+    t.equal(typeof s.analysis.filter.address_stop, 'object', 'there is an address_stop filter');
+    var filter = s.analysis.filter.address_stop;
+    t.equal(filter.type, 'stop');
+    t.deepEqual(filter.stopwords, [
+      "alley", "avenue", "boulevard", "bypass", "crescent", "drive", "esplanade",
+      "expressway", "field", "freeway", "garden", "green", "grove", "heights",
+      "highway", "lane", "mews", "parade", "pike", "place", "promenade", "road",
+      "row", "street", "terrace", "turnpike", "viaduct", "way"
+    ]);
+    t.end();
+  });
+};
+
+// this filter stems common street suffixes
+// eg. road=>rd and street=>st
+module.exports.tests.streetSynonymFilter = function(test, common) {
+  test('has street_synonym filter', function(t) {
+    var s = settings();
+    t.equal(typeof s.analysis.filter.street_synonym, 'object', 'there is an street_synonym filter');
+    var filter = s.analysis.filter.street_synonym;
+    t.equal(filter.type, 'synonym');
+    t.true(Array.isArray(filter.synonyms));
+    t.equal(filter.synonyms.length, 18);
+    t.end();
+  });
+};
+
+// this filter stems common directional terms
+// eg. north=>n and south=>s
+module.exports.tests.directionSynonymFilter = function(test, common) {
+  test('has direction_synonym filter', function(t) {
+    var s = settings();
+    t.equal(typeof s.analysis.filter.direction_synonym, 'object', 'there is an direction_synonym filter');
+    var filter = s.analysis.filter.direction_synonym;
+    t.equal(filter.type, 'synonym');
+    t.true(Array.isArray(filter.synonyms));
+    t.equal(filter.synonyms.length, 4);
+    t.end();
+  });
+};
+
+// -- char filters --
+
+// we use a custom punctuation filter in order to allow the ampersand
+// character which would otherwise be stripped by the standard tokenizer
+module.exports.tests.punctuationCharFilter = function(test, common) {
+  test('has punctuation char_filter', function(t) {
+    var s = settings();
+    t.equal(typeof s.analysis.char_filter.punctuation, 'object', 'there is a punctuation char_filter');
+    var char_filter = s.analysis.char_filter.punctuation;
+    t.equal(char_filter.type, 'mapping');
+    t.true(Array.isArray(char_filter.mappings));
+    t.equal(char_filter.mappings.length, 50);
+    t.end();
+  });
+};
+
+// -- etc --
 
 // index should always be set
 module.exports.tests.index = function(test, common) {
@@ -61,7 +308,7 @@ module.exports.tests.overrides = function(test, common) {
     // set the PELIAS_CONFIG env var
     process.env['PELIAS_CONFIG'] = path.resolve( __dirname + '/fixtures/config.json' );
 
-    var s = settings();
+    s = settings();
     t.equal(s.index['number_of_replicas'], '999', 'changed');
     t.end();
 


### PR DESCRIPTION
@pelias/owners I'm removing the 'DO NOT MERGE' tag from this repo, it's ready for review and merge now.

The PR ended up becoming quite large, it covers a complete review and re-factoring of our linguistic analysis while also migrating the autocomplete from an FST structure to edgeNgrams+inverted index.

I've also introduced a new type of test suite which can be executed with `npm run integration`, this is a super easy way to test the effects of adding/removing algorithms from the analysis pipeline and it let's you send text string to ES and get back the tokens it produces.

The easiest way to explore the changes is via these tests, there is one for each analyzer:
https://github.com/pelias/schema/tree/ngram/integration

Also included in this PR is
- better support for geohashes https://github.com/pelias/schema/blob/ngram/mappings/partial/centroid.js
- explicit definitions of how field data is to be stored
- improved punctuation https://github.com/pelias/schema/blob/ngram/punctuation.js
- improved synonyms: https://github.com/pelias/schema/blob/ngram/street_suffix.js

Closes pelias/pelias#97