### PR TITLE
phrase slop

### DIFF
--- a/integration/analyzer_peliasPhrase.js
+++ b/integration/analyzer_peliasPhrase.js
@@ -15,36 +15,37 @@ module.exports.tests.analyze = function(test, common){
     var assertAnalysis = analyze.bind( null, suite, t, 'peliasPhrase' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
-    assertAnalysis( 'lowercase', 'F f', ['f f']);
-    assertAnalysis( 'asciifolding', 'é é', ['e e']);
-    assertAnalysis( 'asciifolding', 'ß ß', ['ss ss']);
-    assertAnalysis( 'asciifolding', 'æ æ', ['ae ae']);
-    assertAnalysis( 'asciifolding', 'ł ł', ['l l']);
-    assertAnalysis( 'asciifolding', 'ɰ ɰ', ['m m']);
-    assertAnalysis( 'trim', ' f f ', ['f f'] );
-    assertAnalysis( 'stop_words (disabled)', 'a st b ave c', ['a st', 'st b', 'b ave', 'ave c'] );
-    assertAnalysis( 'ampersand', 'a and b', ['a &','& b'] );
-    assertAnalysis( 'ampersand', 'a & b', ['a &','& b'] );
+    assertAnalysis( 'lowercase', 'F', ['f']);
+    assertAnalysis( 'asciifolding', 'é', ['e']);
+    assertAnalysis( 'asciifolding', 'ß', ['ss']);
+    assertAnalysis( 'asciifolding', 'æ', ['ae']);
+    assertAnalysis( 'asciifolding', 'ł', ['l']);
+    assertAnalysis( 'asciifolding', 'ɰ', ['m']);
+    assertAnalysis( 'trim', ' f ', ['f'] );
+    assertAnalysis( 'stop_words (disabled)', 'a st b ave c', ['a','st','b','ave','c'] );
+    assertAnalysis( 'ampersand', 'a and b', ['a','&','b'] );
+    assertAnalysis( 'ampersand', 'a & b', ['a','&','b'] );
+    assertAnalysis( 'ampersand', 'a and & and b', ['a','&','b'] );
 
     // @todo: handle multiple consecutive 'and'
     // assertAnalysis( 'ampersand', 'a and & and b', ['a &','& b'] );
 
-    assertAnalysis( 'kstem', 'mcdonalds restaurant', ['mcdonald restaurant'] );
-    assertAnalysis( 'kstem', 'McDonald\'s Restaurant', ['mcdonald restaurant'] );
-    assertAnalysis( 'kstem', 'walking peoples', ['walking people'] );
+    assertAnalysis( 'kstem', 'mcdonalds restaurant', ['mcdonald','restaurant'] );
+    assertAnalysis( 'kstem', 'McDonald\'s Restaurant', ['mcdonald','restaurant'] );
+    assertAnalysis( 'kstem', 'walking peoples', ['walking','people'] );
     
-    assertAnalysis( 'peliasShinglesFilter', '1 a ab abc abcdefghijk', ['1 a', 'a ab', 'ab abc', 'abc abcdefghijk'] );
-    assertAnalysis( 'unique', '1 1 1', ['1 1'] );
-    assertAnalysis( 'notnull', ' a ', [] );
+    assertAnalysis( 'peliasShinglesFilter', '1 a ab abc abcdefghijk', ['1','a','ab','abc','abcdefghijk'] );
+    assertAnalysis( 'unique', '1 1 1', ['1'] );
+    assertAnalysis( 'notnull', ' ^ ', [] );
 
-    assertAnalysis( 'stem street suffixes', 'streets avenue', ['st ave'] );
-    assertAnalysis( 'stem street suffixes', 'boulevard roads', ['blvd rd'] );
+    assertAnalysis( 'stem street suffixes', 'streets avenue', ['st','ave'] );
+    assertAnalysis( 'stem street suffixes', 'boulevard roads', ['blvd','rd'] );
 
-    assertAnalysis( 'stem direction synonyms', 'south by southwest', ['s by', 'by sw'] );
-    assertAnalysis( 'stem direction synonyms', '20 bear road northeast', ['20 bear', 'bear rd', 'rd ne'] );
+    assertAnalysis( 'stem direction synonyms', 'south by southwest', ['s','by','sw'] );
+    assertAnalysis( 'stem direction synonyms', '20 bear road northeast', ['20','bear','rd','ne'] );
 
     // remove punctuation (handled by the char_filter)
-    assertAnalysis( 'punctuation', punctuation.all.join(''), [] );
+    assertAnalysis( 'punctuation', punctuation.all.join(''), [ '-&' ] );
 
     suite.run( t.end );
   });
@@ -58,36 +59,149 @@ module.exports.tests.functional = function(test, common){
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     assertAnalysis( 'country', 'Trinidad and Tobago', [
-      'trinidad &', '& tobago'
+      'trinidad', '&', 'tobago'
     ]);
 
     assertAnalysis( 'place', 'Toys "R" Us!', [
-      'toy r', 'r us'
+      'toy', 'r', 'us'
     ]);
 
     assertAnalysis( 'address', '101 mapzen pl', [
-      '101 mapzen', 'mapzen pl'
+      '101', 'mapzen', 'pl'
     ]);
 
     // both terms should map to same tokens
-    var expected1 = [ '325 n', 'n 12th', '12th st' ];
+    var expected1 = [ '325', 'n', '12th', 'st' ];
     assertAnalysis( 'address', '325 N 12th St', expected1 );
     assertAnalysis( 'address', '325 North 12th Street', expected1 );
 
     // both terms should map to same tokens
-    var expected2 = [ '13509 colfax', 'colfax ave', 'ave s' ];
+    var expected2 = [ '13509', 'colfax', 'ave', 's' ];
     assertAnalysis( 'address', '13509 Colfax Ave S', expected2 );
     assertAnalysis( 'address', '13509 Colfax Avenue South', expected2 );
 
     // both terms should map to same tokens
-    var expected3 = [ '100 s', 's lake', 'lake dr' ];
+    var expected3 = [ '100', 's', 'lake', 'dr' ];
     assertAnalysis( 'address', '100 S Lake Dr', expected3 );
     assertAnalysis( 'address', '100 South Lake Drive', expected3 );
 
     // both terms should map to same tokens
-    var expected4 = [ '100 nw', 'nw hwy' ];
+    var expected4 = [ '100', 'nw', 'hwy' ];
     assertAnalysis( 'address', '100 northwest highway', expected4 );
     assertAnalysis( 'address', '100 nw hwy', expected4 );
+
+    suite.run( t.end );
+  });
+};
+
+// @ref: https://www.elastic.co/guide/en/elasticsearch/guide/current/phrase-matching.html
+// @ref: https://www.elastic.co/guide/en/elasticsearch/guide/current/slop.html
+module.exports.tests.slop = function(test, common){
+  test( 'slop', function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+    var assertAnalysis = analyze.bind( null, suite, t, 'peliasPhrase' );
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
+
+    // no index-time slop operations performed
+    assertAnalysis( 'place', 'Lake Cayuga', [ 'lake', 'cayuga' ]);
+    assertAnalysis( 'place', 'Cayuga Lake', [ 'cayuga', 'lake' ]);
+
+    suite.run( t.end );
+  });
+};
+
+// balance scoring for similar terms 'Lake Cayuga', 'Cayuga Lake' and '7991 Lake Cayuga Dr'
+// @ref: https://www.elastic.co/guide/en/elasticsearch/guide/current/phrase-matching.html
+// @ref: https://www.elastic.co/guide/en/elasticsearch/guide/current/slop.html
+module.exports.tests.slop_query = function(test, common){
+  test( 'slop query', function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+    var assertAnalysis = analyze.bind( null, suite, t, 'peliasPhrase' );
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
+
+    // index 'Lake Cayuga'
+    suite.action( function( done ){
+      suite.client.index({
+        index: suite.props.index,
+        type: 'mytype',
+        id: '1',
+        body: { name: { default: 'Lake Cayuga' }, phrase: { default: 'Lake Cayuga' } }
+      }, done );
+    });
+
+    // index 'Cayuga Lake'
+    suite.action( function( done ){
+      suite.client.index({
+        index: suite.props.index,
+        type: 'mytype',
+        id: '2',
+        body: { name: { default: 'Cayuga Lake' }, phrase: { default: 'Cayuga Lake' } }
+      }, done );
+    });
+
+    // index '7991 Lake Cayuga Dr'
+    suite.action( function( done ){
+      suite.client.index({
+        index: suite.props.index,
+        type: 'mytype',
+        id: '3',
+        body: { name: { default: '7991 Lake Cayuga Dr' }, phrase: { default: '7991 Lake Cayuga Dr' } }
+      }, done );
+    });
+
+    function buildQuery( i ){
+      return {
+        "query": {
+          "filtered": {
+            "query": {
+              "bool": {
+                "must": [
+                  {
+                    "match": {
+                      "name.default": {
+                        "query": i
+                      }
+                    }
+                  }
+                ],
+                "should": [
+                  {
+                    "match": {
+                      "phrase.default": {
+                        "query": i,
+                        "type": "phrase",
+                        "slop": 2
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      };
+    }
+
+    suite.assert( function( done ){
+      suite.client.search({
+        index: suite.props.index,
+        type: 'mytype',
+        body: buildQuery('Lake Cayuga')
+      }, function( err, res ){
+        t.equal( res.hits.total, 3 );
+        var hits = res.hits.hits;
+
+        t.equal( hits[0]._source.name.default, 'Lake Cayuga' );
+        t.equal( hits[1]._source.name.default, 'Cayuga Lake' );
+        t.equal( hits[2]._source.name.default, '7991 Lake Cayuga Dr' );
+
+        t.true( hits[0]._score > hits[1]._score );
+        t.true( hits[1]._score > hits[2]._score );
+        done();
+      });
+    });
 
     suite.run( t.end );
   });

--- a/settings.js
+++ b/settings.js
@@ -71,7 +71,6 @@ function generate(){
             "kstem",
             "street_synonym",
             "direction_synonym",
-            "peliasShinglesFilter",
             "unique",
             "notnull"
           ]
@@ -101,12 +100,6 @@ function generate(){
           "type" : "pattern_replace",
           "pattern" : "^(0*)",
           "replacement" : ""
-        },
-        "peliasShinglesFilter": {
-          "type": "shingle",
-          "min_shingle_size": 2,
-          "max_shingle_size": 2,
-          "output_unigrams": false
         },
         "address_stop": {
           "type": "stop",

--- a/test/settings.js
+++ b/test/settings.js
@@ -123,7 +123,6 @@ module.exports.tests.peliasPhraseAnalyzer = function(test, common) {
       "kstem",
       "street_synonym",
       "direction_synonym",
-      "peliasShinglesFilter",
       "unique",
       "notnull"
     ]);
@@ -182,20 +181,6 @@ module.exports.tests.peliasTwoEdgeGramFilter = function(test, common) {
     t.equal(filter.type, 'edgeNGram');
     t.equal(filter.min_gram, 2);
     t.equal(filter.max_gram, 10);
-    t.end();
-  });
-};
-
-// this filter creates shingles
-module.exports.tests.peliasShinglesFilter = function(test, common) {
-  test('has peliasShinglesFilter filter', function(t) {
-    var s = settings();
-    t.equal(typeof s.analysis.filter.peliasShinglesFilter, 'object', 'there is a peliasShinglesFilter filter');
-    var filter = s.analysis.filter.peliasShinglesFilter;
-    t.equal(filter.type, 'shingle');
-    t.equal(filter.min_shingle_size, 2);
-    t.equal(filter.max_shingle_size, 2);
-    t.equal(filter.output_unigrams, false); // this should be disabled to reduce index size
     t.end();
   });
 };


### PR DESCRIPTION
This PR addresses the 'phrase slop' problem as described briefly in https://github.com/pelias/schema/issues/66

The background here is that Pelias uses 2 different linguistic matching techniques when dealing with `names` (there are more for admin areas etc. but that's another story), this only applies to `name` matching (ie. nothing after the first comma)

We have a `prefix ngram` matching analysis which works great for autocomplete but falls short in a couple of areas:
- setting the `min_gram` value to `2` or `3` will discard street numbers grams (eg. `1`, `2b` and/or `11`)
- it is not `phrase aware`, meaning it does not consider the order in which tokens are typed.
- it does not score on `slop`, meaning it does not favour tokens which lie next to each other over those which appear further away from each other.

So in order to address those issues we released a basic phrase matching analyzer with the ngrams release which was based on the [shingle token filter](https://www.elastic.co/guide/en/elasticsearch/reference/1.6/analysis-shingle-tokenfilter.html), this worked really well for addresses (ensuring that queries like `110 main street` appeared higher than `200 main street` and `1001 main street`) but it doesn't provide very good phrase 'sloppiness' and the `Lake Cayuga vs. Cayuga Lake` issue is a great example of this.

The shingles also take up a large amout of space in the index, for that reason they were limited to `max_shingle_size:2` and `output_unigrams` was set to `false`, this kept the index to a reasonable size (an important consideration at planet scale).

I chose 3x like terms to test against:
- Lake Cayuga
- Cayuga Lake
- 7991 Lake Cayuga Dr

I tried a few different indexing techniques
- shingles with `output_unigrams:false`
- shingles with `output_unigrams:true`
- disabling shingles completely

In combination with 2x different query techniques (with variable settings)
- regular `match` queries
- `phrase_match` queries (with variable levels of `slop`)

using the default analysis (what we have now), the scoring for input `"Lake Cayuga"` looks like this:

Position | Name | Score
------------ | ------------- | -------------
1 | Lake Cayuga | 1.5725095
2 | 7991 Lake Cayuga Dr | 1.1246306
3 | Cayuga Lake | 0.56395954

this is not ideal since the address record contains more tokens and so should therefore score lower than the sloppy version which came in 3rd.

this is what happens if you just remove the `peliasShinglesFilter` completely (no shingles, just tokenized words)

Position | Name | Score
------------ | ------------- | -------------
1 | Lake Cayuga | 1.407842
2 | Cayuga Lake | 1.407842
3 | 7991 Lake Cayuga Dr | 1.1262736

this is better because we scored both the sloppy and the exact match higher than the street address, while also not scoring the address so low that it would completely fall off the resultset. but we can do better, the 2 terms are not exactly the same and we should be able to score `Lake Cayuga` a little higher than `Cayuga Lake` because we don't want things like "NW Southwest Rd" and "SW Northwest Rd" getting the same score for the same input.

this time with `peliasShinglesFilter` enabled but `output_unigrams:true`, which means that a phrase like "hello map world" would result in `[ "hello", "hello map", "map", "map world", "world" ]` instead of just `[ "hello map", "map world" ]`

Position | Name | Score
------------ | ------------- | -------------
1 | Lake Cayuga | 1.5403388
2 | Cayuga Lake | 1.286742
3 | 7991 Lake Cayuga Dr | 1.232271

this is better than before, we pushed the score for the sloppy result further down but now it's uncomfortably close to the address record and it's likely that removing a single token from that record could upset the balance and change the ordering again. this approach also blows up the index size by more than double, which is going to require more RAM, disk and will result in slower lookups.

enter [phrase match](https://www.elastic.co/guide/en/elasticsearch/guide/current/phrase-matching.html) which is a way of getting elasticsearch to consider `term positions` when analyzing the text (at query time!), it looks something like this:

```javascript
"match": {
  "phrase.default": {
    "query": "Lake Cayuga",
    "type": "phrase",
    "slop": 2
  }
}
```

running the same setup as above again, but this time using a `phrase_match` (with the default slop of 2) instead of a `match` query results in:

Position | Name | Score
------------ | ------------- | -------------
1 | Lake Cayuga |  1.9702904
2 | Cayuga Lake | 1.5762323
3 | 7991 Lake Cayuga Dr | 1.4776802

this is pretty nice, but very similar to the above, the `output_unigrams:true` is now starting to have weird effects on the scoring and should be disabled again to reduce the query time, while we're at it, let's just get rid of `peliasShinglesFilter` completely and instead do phrase indexing on a single token basis.

with `peliasShinglesFilter` removed and a `phrase_match` slop of `1`:

Position | Name | Score
------------ | ------------- | -------------
1 | Lake Cayuga |  1.5422134
2 | 7991 Lake Cayuga Dr | 1.2337708
3 | Cayuga Lake | 0.51407117

this is super bad, setting `slop:1` is a bad idea.

try again with a slop of `2` (input: "Lake Cayuga"):

Position | Name | Score
------------ | ------------- | -------------
1 | Lake Cayuga |  1.5422134
2 | Cayuga Lake | 1.3249414
3 | 7991 Lake Cayuga Dr | 1.2337708

slop of `2` (input: "Lake Cayuga Dr"):

Position | Name | Score
------------ | ------------- | -------------
1 | 7991 Lake Cayuga Dr | 1.8737649
2 | Lake Cayuga |  0.22565839
3 | Cayuga Lake | 0.22565839

slop of `2` (input: "Cayuga Lake"):

Position | Name | Score
------------ | ------------- | -------------
1 | Cayuga Lake | 1.5422134
2 | Lake Cayuga |  1.3249414
3 | 7991 Lake Cayuga Dr | 1.0599532

this looks ideal, it seems to sort the less sloppy matches higher while not scoring the other results too much lower (except for the `Lake Cayuga Dr` input, which is also a nice behaviour)

we can go on and increase the `slop` value to `3` or more, from my tests above I got the exact same scores with `slop:3` as I did with `slop:2`, I'm a little worried about the effects it might have when setting it to a higher value, but it might be interesting to try none-the-less. for more info on how the slop setting works see: https://www.elastic.co/guide/en/elasticsearch/guide/current/slop.html

I'm hoping that this will provide better sloppiness for european street numbers such as `grolmanstr. 51` vs. `51 grolmanstrasse`

Closes #66