### PR TITLE
increase max gram token size

### DIFF
--- a/integration/analyzer_peliasOneEdgeGram.js
+++ b/integration/analyzer_peliasOneEdgeGram.js
@@ -26,7 +26,7 @@ module.exports.tests.analyze = function(test, common){
     assertAnalysis( 'ampersand', 'a and b', ['a','&','b'] );
     assertAnalysis( 'ampersand', 'a & b', ['a','&','b'] );
     assertAnalysis( 'ampersand', 'a and & and b', ['a','&','b'] );
-    assertAnalysis( 'peliasOneEdgeGramFilter', '1 a ab abc abcdefghijk', ['1','a','ab','abc','abcd','abcde','abcdef','abcdefg','abcdefgh','abcdefghi','abcdefghij'] );
+    assertAnalysis( 'peliasOneEdgeGramFilter', '1 a ab abc abcdefghij', ['1','a','ab','abc','abcd','abcde','abcdef','abcdefg','abcdefgh','abcdefghi','abcdefghij'] );
     assertAnalysis( 'removeAllZeroNumericPrefix', '00001', ['1'] );
     assertAnalysis( 'unique', '1 1 1', ['1'] );
     assertAnalysis( 'notnull', 'avenue street', [] );
@@ -37,6 +37,13 @@ module.exports.tests.analyze = function(test, common){
 
     // remove punctuation (handled by the char_filter)
     assertAnalysis( 'punctuation', punctuation.all.join(''), ['-','-&'] );
+
+    // ensure that very large grams are created
+    assertAnalysis( 'largeGrams', 'grolmanstrasse', [
+      'g','gr','gro','grol','grolm','grolma','grolman','grolmans','grolmanst',
+      'grolmanstr','grolmanstra','grolmanstras','grolmanstrass',
+      'grolmanstrasse'
+    ]);
 
     suite.run( t.end );
   });

--- a/integration/analyzer_peliasTwoEdgeGram.js
+++ b/integration/analyzer_peliasTwoEdgeGram.js
@@ -31,7 +31,7 @@ module.exports.tests.analyze = function(test, common){
     // assertAnalysis( 'ampersand', 'aa & bb', ['aa','&','bb'] );
     // assertAnalysis( 'ampersand', 'aa and & and bb', ['aa','&','bb'] );
 
-    assertAnalysis( 'peliasTwoEdgeGramFilter', '1 a ab abc abcdefghijk', ['ab','abc','abcd','abcde','abcdef','abcdefg','abcdefgh','abcdefghi','abcdefghij'] );
+    assertAnalysis( 'peliasTwoEdgeGramFilter', '1 a ab abc abcdefghij', ['ab','abc','abcd','abcde','abcdef','abcdefg','abcdefgh','abcdefghi','abcdefghij'] );
     assertAnalysis( 'removeAllZeroNumericPrefix', '0002 00011', ['11'] );
     assertAnalysis( 'unique', '11 11 11', ['11'] );
     assertAnalysis( 'notnull', 'avenue street', [] );
@@ -45,6 +45,13 @@ module.exports.tests.analyze = function(test, common){
 
     // ensure that single grams are not created
     assertAnalysis( '1grams', 'a aa b bb 1 11', ['aa','bb','11'] );
+
+    // ensure that very large grams are created
+    assertAnalysis( 'largeGrams', 'grolmanstrasse', [
+      'gr','gro','grol','grolm','grolma','grolman','grolmans','grolmanst',
+      'grolmanstr','grolmanstra','grolmanstras','grolmanstrass',
+      'grolmanstrasse'
+    ]);
 
     suite.run( t.end );
   });

--- a/settings.js
+++ b/settings.js
@@ -120,12 +120,12 @@ function generate(){
         "peliasOneEdgeGramFilter": {
           "type" : "edgeNGram",
           "min_gram" : 1,
-          "max_gram" : 10
+          "max_gram" : 18
         },
         "peliasTwoEdgeGramFilter": {
           "type" : "edgeNGram",
           "min_gram" : 2,
-          "max_gram" : 10
+          "max_gram" : 18
         },
         "removeAllZeroNumericPrefix" :{
           "type" : "pattern_replace",

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -246,12 +246,12 @@
         "peliasOneEdgeGramFilter": {
           "type": "edgeNGram",
           "min_gram": 1,
-          "max_gram": 10
+          "max_gram": 18
         },
         "peliasTwoEdgeGramFilter": {
           "type": "edgeNGram",
           "min_gram": 2,
-          "max_gram": 10
+          "max_gram": 18
         },
         "removeAllZeroNumericPrefix": {
           "type": "pattern_replace",

--- a/test/settings.js
+++ b/test/settings.js
@@ -263,7 +263,7 @@ module.exports.tests.peliasOneEdgeGramFilter = function(test, common) {
     var filter = s.analysis.filter.peliasOneEdgeGramFilter;
     t.equal(filter.type, 'edgeNGram');
     t.equal(filter.min_gram, 1);
-    t.equal(filter.max_gram, 10);
+    t.equal(filter.max_gram, 18);
     t.end();
   });
 };
@@ -276,7 +276,7 @@ module.exports.tests.peliasTwoEdgeGramFilter = function(test, common) {
     var filter = s.analysis.filter.peliasTwoEdgeGramFilter;
     t.equal(filter.type, 'edgeNGram');
     t.equal(filter.min_gram, 2);
-    t.equal(filter.max_gram, 10);
+    t.equal(filter.max_gram, 18);
     t.end();
   });
 };


### PR DESCRIPTION
increase max ngram size.

tokens such as `grolmanstrasse` and `shuffleboard` were being truncated at 10 chars