### PR TITLE
Remove ordinals

### DIFF
--- a/integration/analyzer_peliasOneEdgeGram.js
+++ b/integration/analyzer_peliasOneEdgeGram.js
@@ -35,6 +35,8 @@ module.exports.tests.analyze = function(test, common){
     assertAnalysis( 'kstem', 'McDonald\'s', ['m', 'mc', 'mcd', 'mcdo', 'mcdon', 'mcdona', 'mcdonal', 'mcdonald'] );
     assertAnalysis( 'kstem', 'peoples', ['p', 'pe', 'peo', 'peop', 'peopl', 'people'] );
 
+    assertAnalysis( 'remove_ordinals', '20th 21st 22nd 23rd', ['2','20','21','22','23'] );
+
     // remove punctuation (handled by the char_filter)
     assertAnalysis( 'punctuation', punctuation.all.join(''), ['-','-&'] );
 

--- a/integration/analyzer_peliasPhrase.js
+++ b/integration/analyzer_peliasPhrase.js
@@ -33,7 +33,7 @@ module.exports.tests.analyze = function(test, common){
     assertAnalysis( 'kstem', 'mcdonalds restaurant', ['mcdonald','restaurant'] );
     assertAnalysis( 'kstem', 'McDonald\'s Restaurant', ['mcdonald','restaurant'] );
     assertAnalysis( 'kstem', 'walking peoples', ['walking','people'] );
-    
+
     assertAnalysis( 'peliasShinglesFilter', '1 a ab abc abcdefghijk', ['1','a','ab','abc','abcdefghijk'] );
     assertAnalysis( 'unique', '1 1 1', ['1'] );
     assertAnalysis( 'notnull', ' ^ ', [] );
@@ -43,6 +43,8 @@ module.exports.tests.analyze = function(test, common){
 
     assertAnalysis( 'stem direction synonyms', 'south by southwest', ['s','by','sw'] );
     assertAnalysis( 'stem direction synonyms', '20 bear road northeast', ['20','bear','rd','ne'] );
+
+    assertAnalysis( 'remove_ordinals', '20th 21st 22nd 23rd', ['20','21','22','23'] );
 
     // remove punctuation (handled by the char_filter)
     assertAnalysis( 'punctuation', punctuation.all.join(''), [ '-&' ] );
@@ -71,8 +73,8 @@ module.exports.tests.functional = function(test, common){
     ]);
 
     // both terms should map to same tokens
-    var expected1 = [ '325', 'n', '12th', 'st' ];
-    assertAnalysis( 'address', '325 N 12th St', expected1 );
+    var expected1 = [ '325', 'n', '12', 'st' ];
+    assertAnalysis( 'address', '325 N 12 St', expected1 );
     assertAnalysis( 'address', '325 North 12th Street', expected1 );
 
     // both terms should map to same tokens

--- a/integration/analyzer_peliasTwoEdgeGram.js
+++ b/integration/analyzer_peliasTwoEdgeGram.js
@@ -43,6 +43,8 @@ module.exports.tests.analyze = function(test, common){
     // remove punctuation (handled by the char_filter)
     assertAnalysis( 'punctuation', punctuation.all.join(''), ['-&'] );
 
+    assertAnalysis( 'remove_ordinals', '20th 21st 22nd 23rd', ['20','21','22','23'] );
+
     // ensure that single grams are not created
     assertAnalysis( '1grams', 'a aa b bb 1 11', ['aa','bb','11'] );
 

--- a/integration/dynamic_templates.js
+++ b/integration/dynamic_templates.js
@@ -45,6 +45,8 @@ function nameAssertion( type, analyzer ){
       }, done );
     });
 
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
+
     // check dynamically created mapping has
     // inherited from the dynamic_template
     suite.assert( function( done ){
@@ -78,6 +80,8 @@ function phraseAssertion( type, analyzer ){
         body: { phrase: { default: 'foo', alt: 'bar' } }
       }, done );
     });
+
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     // check dynamically created mapping has
     // inherited from the dynamic_template

--- a/settings.js
+++ b/settings.js
@@ -37,6 +37,7 @@ function generate(){
             "ampersand",
             "removeAllZeroNumericPrefix",
             "kstem",
+            "remove_ordinals",
             "peliasOneEdgeGramFilter",
             "unique",
             "notnull"
@@ -54,6 +55,7 @@ function generate(){
             "ampersand",
             "removeAllZeroNumericPrefix",
             "kstem",
+            "remove_ordinals",
             "peliasTwoEdgeGramFilter",
             "unique",
             "notnull"
@@ -71,6 +73,7 @@ function generate(){
             "kstem",
             "street_synonym",
             "direction_synonym",
+            "remove_ordinals",
             "unique",
             "notnull"
           ]

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -30,6 +30,7 @@
             "ampersand",
             "removeAllZeroNumericPrefix",
             "kstem",
+            "remove_ordinals",
             "peliasOneEdgeGramFilter",
             "unique",
             "notnull"
@@ -49,6 +50,7 @@
             "ampersand",
             "removeAllZeroNumericPrefix",
             "kstem",
+            "remove_ordinals",
             "peliasTwoEdgeGramFilter",
             "unique",
             "notnull"
@@ -68,6 +70,7 @@
             "kstem",
             "street_synonym",
             "direction_synonym",
+            "remove_ordinals",
             "unique",
             "notnull"
           ]

--- a/test/settings.js
+++ b/test/settings.js
@@ -65,6 +65,7 @@ module.exports.tests.peliasOneEdgeGramAnalyzer = function(test, common) {
       "ampersand",
       "removeAllZeroNumericPrefix",
       "kstem",
+      "remove_ordinals",
       "peliasOneEdgeGramFilter",
       "unique",
       "notnull"
@@ -94,6 +95,7 @@ module.exports.tests.peliasTwoEdgeGramAnalyzer = function(test, common) {
       "ampersand",
       "removeAllZeroNumericPrefix",
       "kstem",
+      "remove_ordinals",
       "peliasTwoEdgeGramFilter",
       "unique",
       "notnull"
@@ -123,6 +125,7 @@ module.exports.tests.peliasPhraseAnalyzer = function(test, common) {
       "kstem",
       "street_synonym",
       "direction_synonym",
+      "remove_ordinals",
       "unique",
       "notnull"
     ]);


### PR DESCRIPTION
enable `remove_ordinals` filter for many analyzers

```
'20th 21st 22nd 23rd' -> ['20','21','22','23']
```

was previously only enabled for `peliasStreet` and is now enabled for `peliasOneEdgeGram`, `peliasTwoEdgeGram` and `peliasPhrase` also.