### PR TITLE
Remove kstem analysis filter

### DIFF
--- a/integration/analyzer_peliasIndexOneEdgeGram.js
+++ b/integration/analyzer_peliasIndexOneEdgeGram.js
@@ -36,9 +36,9 @@ module.exports.tests.analyze = function(test, common){
     assertAnalysis( 'unique', '1 1 1', ['1'] );
     assertAnalysis( 'notnull', ' / / ', [] );
 
-    assertAnalysis( 'kstem', 'mcdonalds', ['m', 'mc', 'mcd', 'mcdo', 'mcdon', 'mcdona', 'mcdonal', 'mcdonald'] );
-    assertAnalysis( 'kstem', 'McDonald\'s', ['m', 'mc', 'mcd', 'mcdo', 'mcdon', 'mcdona', 'mcdonal', 'mcdonald'] );
-    assertAnalysis( 'kstem', 'peoples', ['p', 'pe', 'peo', 'peop', 'peopl', 'people'] );
+    assertAnalysis( 'no kstem', 'mcdonalds', ['m', 'mc', 'mcd', 'mcdo', 'mcdon', 'mcdona', 'mcdonal', 'mcdonald', 'mcdonalds'] );
+    assertAnalysis( 'no kstem', 'McDonald\'s', ['m', 'mc', 'mcd', 'mcdo', 'mcdon', 'mcdona', 'mcdonal', 'mcdonald', 'mcdonalds'] );
+    assertAnalysis( 'no kstem', 'peoples', ['p', 'pe', 'peo', 'peop', 'peopl', 'people', 'peoples'] );
 
     // remove punctuation (handled by the char_filter)
     assertAnalysis( 'punctuation', punctuation.all.join(''), ['-','-&'] );
@@ -115,7 +115,7 @@ module.exports.tests.functional = function(test, common){
     ]);
 
     assertAnalysis( 'place', 'Toys "R" Us!', [
-      't', 'to', 'toy', 'r', 'u', 'us'
+      't', 'to', 'toy', 'toys', 'r', 'u', 'us'
     ]);
 
     assertAnalysis( 'address', '101 mapzen place', [

--- a/integration/analyzer_peliasIndexTwoEdgeGram.js
+++ b/integration/analyzer_peliasIndexTwoEdgeGram.js
@@ -41,9 +41,9 @@ module.exports.tests.analyze = function(test, common){
     assertAnalysis( 'unique', '11 11 11', ['11'] );
     assertAnalysis( 'notnull', ' / / ', [] );
 
-    assertAnalysis( 'kstem', 'mcdonalds', ['mc', 'mcd', 'mcdo', 'mcdon', 'mcdona', 'mcdonal', 'mcdonald'] );
-    assertAnalysis( 'kstem', 'McDonald\'s', ['mc', 'mcd', 'mcdo', 'mcdon', 'mcdona', 'mcdonal', 'mcdonald'] );
-    assertAnalysis( 'kstem', 'peoples', ['pe', 'peo', 'peop', 'peopl', 'people'] );
+    assertAnalysis( 'no kstem', 'mcdonalds', ['mc', 'mcd', 'mcdo', 'mcdon', 'mcdona', 'mcdonal', 'mcdonald', 'mcdonalds'] );
+    assertAnalysis( 'no kstem', 'McDonald\'s', ['mc', 'mcd', 'mcdo', 'mcdon', 'mcdona', 'mcdonal', 'mcdonald', 'mcdonalds'] );
+    assertAnalysis( 'no kstem', 'peoples', [ 'pe', 'peo', 'peop', 'peopl', 'people', 'peoples'] );
 
     // remove punctuation (handled by the char_filter)
     assertAnalysis( 'punctuation', punctuation.all.join(''), ['-&'] );
@@ -129,7 +129,7 @@ module.exports.tests.functional = function(test, common){
     ]);
 
     assertAnalysis( 'place', 'Toys "R" Us!', [
-      'to', 'toy', 'us'
+      'to', 'toy', 'toys', 'us'
     ]);
 
     assertAnalysis( 'address', '101 mapzen place', [

--- a/integration/analyzer_peliasPhrase.js
+++ b/integration/analyzer_peliasPhrase.js
@@ -31,16 +31,16 @@ module.exports.tests.analyze = function(test, common){
     // @todo: handle multiple consecutive 'and'
     // assertAnalysis( 'ampersand', 'a and & and b', ['a &','& b'] );
 
-    assertAnalysis( 'kstem', 'mcdonalds restaurant', ['mcdonald','restaurant'] );
-    assertAnalysis( 'kstem', 'McDonald\'s Restaurant', ['mcdonald','restaurant'] );
-    assertAnalysis( 'kstem', 'walking peoples', ['walking','people'] );
+    assertAnalysis( 'no kstem', 'mcdonalds', ['mcdonalds'] );
+    assertAnalysis( 'no kstem', 'McDonald\'s', ['mcdonalds'] );
+    assertAnalysis( 'no kstem', 'peoples', ['peoples'] );
 
     assertAnalysis( 'peliasShinglesFilter', '1 a ab abc abcdefghijk', ['1','a','ab','abc','abcdefghijk'] );
     assertAnalysis( 'unique', '1 1 1', ['1'] );
     assertAnalysis( 'notnull', ' ^ ', [] );
 
-    assertAnalysis( 'stem street suffixes', 'streets avenue', ['st','ave'] );
-    assertAnalysis( 'stem street suffixes', 'boulevard roads', ['blvd','rd'] );
+    assertAnalysis( 'stem street suffixes', 'streets avenue', ['streets','ave'] );
+    assertAnalysis( 'stem street suffixes', 'boulevard roads', ['blvd','roads'] );
 
     assertAnalysis( 'stem direction synonyms', 'south by southwest', ['s','by','sw'] );
     assertAnalysis( 'stem direction synonyms', '20 bear road northeast', ['20','bear','rd','ne'] );
@@ -64,7 +64,7 @@ module.exports.tests.functional = function(test, common){
     ]);
 
     assertAnalysis( 'place', 'Toys "R" Us!', [
-      'toy', 'r', 'us'
+      'toys', 'r', 'us'
     ]);
 
     assertAnalysis( 'address', '101 mapzen pl', [

--- a/integration/analyzer_peliasQueryFullToken.js
+++ b/integration/analyzer_peliasQueryFullToken.js
@@ -36,9 +36,9 @@ module.exports.tests.analyze = function(test, common){
     assertAnalysis( 'unique', '1 1 1', ['1'] );
     assertAnalysis( 'notnull', ' / / ', [] );
 
-    assertAnalysis( 'kstem', 'mcdonalds', ['mcdonald'] );
-    assertAnalysis( 'kstem', 'McDonald\'s', ['mcdonald'] );
-    assertAnalysis( 'kstem', 'peoples', ['people'] );
+    assertAnalysis( 'no kstem', 'mcdonalds', ['mcdonalds'] );
+    assertAnalysis( 'no kstem', 'McDonald\'s', ['mcdonalds'] );
+    assertAnalysis( 'no kstem', 'peoples', ['peoples'] );
 
     // remove punctuation (handled by the char_filter)
     assertAnalysis( 'punctuation', punctuation.all.join(''), ['-&'] );
@@ -99,7 +99,7 @@ module.exports.tests.functional = function(test, common){
     ]);
 
     assertAnalysis( 'place', 'Toys "R" Us!', [
-      'toy', 'r', 'us'
+      'toys', 'r', 'us'
     ]);
 
     assertAnalysis( 'address', '101 mapzen place', [

--- a/integration/analyzer_peliasQueryPartialToken.js
+++ b/integration/analyzer_peliasQueryPartialToken.js
@@ -36,9 +36,9 @@ module.exports.tests.analyze = function(test, common){
     assertAnalysis( 'unique', '1 1 1', ['1'] );
     assertAnalysis( 'notnull', ' / / ', [] );
 
-    assertAnalysis( 'kstem', 'mcdonalds', ['mcdonald'] );
-    assertAnalysis( 'kstem', 'McDonald\'s', ['mcdonald'] );
-    assertAnalysis( 'kstem', 'peoples', ['people'] );
+    assertAnalysis( 'no kstem', 'mcdonalds', ['mcdonalds'] );
+    assertAnalysis( 'no kstem', 'McDonald\'s', ['mcdonalds'] );
+    assertAnalysis( 'no kstem', 'peoples', ['peoples'] );
 
     // remove punctuation (handled by the char_filter)
     assertAnalysis( 'punctuation', punctuation.all.join(''), ['-&'] );
@@ -92,7 +92,7 @@ module.exports.tests.functional = function(test, common){
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     assertAnalysis( 'country', 'Trinidad and Tobago', [ 'trinidad', '&', 'tobago' ]);
-    assertAnalysis( 'place', 'Toys "R" Us!', [ 'toy', 'r', 'us' ]);
+    assertAnalysis( 'place', 'Toys "R" Us!', [ 'toys', 'r', 'us' ]);
     assertAnalysis( 'address', '101 mapzen place', [ '101', 'mapzen', 'place' ]);
 
     suite.run( t.end );

--- a/settings.js
+++ b/settings.js
@@ -47,7 +47,6 @@ function generate(){
             "ampersand",
             "remove_ordinals",
             "removeAllZeroNumericPrefix",
-            "kstem",
             "peliasOneEdgeGramFilter",
             "unique",
             "notnull"
@@ -65,7 +64,6 @@ function generate(){
             "ampersand",
             "remove_ordinals",
             "removeAllZeroNumericPrefix",
-            "kstem",
             "prefixZeroToSingleDigitNumbers",
             "peliasTwoEdgeGramFilter",
             "removeAllZeroNumericPrefix",
@@ -86,7 +84,6 @@ function generate(){
             "ampersand",
             "remove_ordinals",
             "removeAllZeroNumericPrefix",
-            "kstem",
             "unique",
             "notnull"
           ]
@@ -103,7 +100,6 @@ function generate(){
             "full_token_address_suffix_expansion",
             "ampersand",
             "removeAllZeroNumericPrefix",
-            "kstem",
             "unique",
             "notnull"
           ]
@@ -117,7 +113,6 @@ function generate(){
             "asciifolding",
             "trim",
             "ampersand",
-            "kstem",
             "street_synonym",
             "direction_synonym",
             "unique",

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -38,7 +38,6 @@
             "ampersand",
             "remove_ordinals",
             "removeAllZeroNumericPrefix",
-            "kstem",
             "peliasOneEdgeGramFilter",
             "unique",
             "notnull"
@@ -56,7 +55,6 @@
             "ampersand",
             "remove_ordinals",
             "removeAllZeroNumericPrefix",
-            "kstem",
             "prefixZeroToSingleDigitNumbers",
             "peliasTwoEdgeGramFilter",
             "removeAllZeroNumericPrefix",
@@ -77,7 +75,6 @@
             "ampersand",
             "remove_ordinals",
             "removeAllZeroNumericPrefix",
-            "kstem",
             "unique",
             "notnull"
           ]
@@ -94,7 +91,6 @@
             "full_token_address_suffix_expansion",
             "ampersand",
             "removeAllZeroNumericPrefix",
-            "kstem",
             "unique",
             "notnull"
           ]
@@ -110,7 +106,6 @@
             "asciifolding",
             "trim",
             "ampersand",
-            "kstem",
             "street_synonym",
             "direction_synonym",
             "unique",

--- a/test/settings.js
+++ b/test/settings.js
@@ -65,7 +65,6 @@ module.exports.tests.peliasIndexOneEdgeGramAnalyzer = function(test, common) {
       "ampersand",
       "remove_ordinals",
       "removeAllZeroNumericPrefix",
-      "kstem",
       "peliasOneEdgeGramFilter",
       "unique",
       "notnull"
@@ -95,7 +94,6 @@ module.exports.tests.peliasIndexTwoEdgeGramAnalyzer = function(test, common) {
       "ampersand",
       "remove_ordinals",
       "removeAllZeroNumericPrefix",
-      "kstem",
       "prefixZeroToSingleDigitNumbers",
       "peliasTwoEdgeGramFilter",
       "removeAllZeroNumericPrefix",
@@ -125,7 +123,6 @@ module.exports.tests.peliasPhraseAnalyzer = function(test, common) {
       "asciifolding",
       "trim",
       "ampersand",
-      "kstem",
       "street_synonym",
       "direction_synonym",
       "unique",
@@ -190,7 +187,7 @@ module.exports.tests.peliasStreetAnalyzer = function(test, common) {
 // cycle through all analyzers and ensure the corrsponding token filters are defined
 module.exports.tests.allTokenFiltersPresent = function(test, common) {
   var ES_INBUILT_FILTERS = [
-    'lowercase', 'asciifolding', 'trim', 'word_delimiter', 'kstem', 'unique'
+    'lowercase', 'asciifolding', 'trim', 'word_delimiter', 'unique'
   ];
   test('all token filters present', function(t) {
     var s = settings();


### PR DESCRIPTION
This PR completely removes the kstem analysis filter, just as an experiment to see what sort of effect it has on search quality.

_Update:_ after running this on dev, I now propose that we actually remove kstem. Full rationale below.

I was a bit amazed when I ran our acceptance tests and found that removing kstem slightly improves the results

![screenshot from 2016-01-11 14-10-36](https://cloud.githubusercontent.com/assets/111716/12244739/1056a7c0-b873-11e5-816d-9ec3440d57fb.png)

I've gone through all the tests to see where the differences are, and here are my conclusions. I'm _really_ looking for people to help by finding other cases that don't work as well on dev right now, as if there are any serious issues, we should hold off on merging this. That said I haven't really found any.


## Better

### [daly city](http://pelias.github.io/compare/#/v1/autocomplete%3Ftext=daly%20city)

This is the original query that got us looking at kstem. Daly is stemmed to dale which causes dale city to match above daly city

### [brooklyn](http://pelias.github.io/compare/#/v1/autocomplete%3Ftext=brookly)

While the full query for brooklyn works fine, there is jumpiness when using autocomplete. `brook` is replaced with `brk` by our synonym matching. However, kstem also replaces `brookly` with `brook`, so the jumpiness appears twice in the query.

## Worse
### [statue of liberty](http://pelias.github.io/compare/#/v1/autocomplete%3Ftext=statue%20of%20liberty)

I haven't fully dug into this one, but there are only minor changes in the ordering of results, and I don't see any weird stemming behavior, so it might be a data issue.

### [101 saint mark place](http://pelias.github.io/compare#/v1/autocomplete%3Ftext=101%20saint%20mark%20pl)

This test either has a typo or was written assuming kstemming means plurals never matter (the street is called St. Mark's Place). It's a good example of some fragility that does come from not handling plurals. I think we can either build a very conservative stemmer or do some magic at the API level to fix this. If you do a query for [101 saint marks pl](http://pelias.github.io/compare/#/v1/autocomplete%3Ftext=101%20saint%20marks%20pl), everything works.

### Bad tests discovered
### [whole foods ny](http://pelias.github.io/compare/#/v1/autocomplete%3Ftext=whole%20foods%20n)
This test has [no location bias](https://github.com/pelias/acceptance-tests/blob/master/test_cases/address_parsing.json#L295) and is searching for a chain with [431](https://en.wikipedia.org/wiki/Whole_Foods_Market) locations across the US. The " ny" at the end isn't currently enough signal for Pelias to prefer New York locations, however since the priority threshold is 5 and there are lots of Whole Foods locations in New York state, it usually passes. Note that with kstemming turned off, it's now possible to search for places that [actually have "whole food" in the name](http://pelias.github.io/compare/#/v1/autocomplete%3Ftext=whole%20food), with kstemming, they are overwhelmed by Whole Foods.
  
  

## Conclusions

### Stemming isn't really for geocoding

Stemming was designed so that information retrieval systems can find documents that pertain to a similar topic to some keywords. With geocoding, users are entering something's name. While we want to allow some leeway in the name, the strategies for doing so seem to differ in a lot of ways.

### Kstem and possibly stemming in general isn't autocomplete friendly

As we saw with the Brooklyn test, kstem implicitly assumes it is given full words, so it will do strange things n the middle of words that lead to jumpy results




Fixes pelias/schema#89