### PR TITLE
use WOF placetypes instead of quattroshapes placetypes

### DIFF
--- a/integration/address_matching.js
+++ b/integration/address_matching.js
@@ -8,8 +8,8 @@ var tape = require('tape'),
 
 module.exports.tests = {};
 
-module.exports.tests.source_filter = function(test, common){
-  test( 'mapzen hq', function(t){
+module.exports.tests.functional = function(test, common){
+  test( 'functional', function(t){
 
     var suite = new elastictest.Suite( null, { schema: schema } );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up

--- a/integration/admin_matching.js
+++ b/integration/admin_matching.js
@@ -1,0 +1,113 @@
+
+// validate analyzer is behaving as expected
+
+var tape = require('tape'),
+    elastictest = require('elastictest'),
+    schema = require('../schema'),
+    punctuation = require('../punctuation');
+
+module.exports.tests = {};
+
+module.exports.tests.functional = function(test, common){
+  test( 'functional', function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
+
+    // index a document with all admin values
+    suite.action( function( done ){
+      suite.client.index({
+        index: suite.props.index, type: 'test',
+        id: '1', body: { admin: {
+          alpha3: 'TST',
+          country: 'Test Country',
+          country_abbr: 'TestCountry',
+          country_id: '100',
+          region: 'Test Region',
+          region_abbr: 'TestRegion',
+          region_id: '200',
+          county: 'Test County',
+          county_abbr: 'TestCounty',
+          county_id: '300',
+          locality: 'Test Locality',
+          locality_abbr: 'TestLocality',
+          locality_id: '400',
+          localadmin: 'Test LocalAdmin',
+          localadmin_abbr: 'TestLocalAdmin',
+          localadmin_id: '500',
+          neighbourhood: 'Test Neighbourhood',
+          neighbourhood_abbr: 'TestNeighbourhood',
+          neighbourhood_id: '600',
+        }}
+      }, done );
+    });
+
+    // search by alpha3
+    suite.assert( function( done ){
+      suite.client.search({
+        index: suite.props.index,
+        type: 'test',
+        body: { query: { match: { 'admin.alpha3': 'TST' } } }
+      }, function( err, res ){
+        t.equal( err, undefined );
+        t.equal( res.hits.total, 1, 'document found' );
+        done();
+      });
+    });
+
+    // search by country
+    suite.assert( function( done ){
+      suite.client.search({
+        index: suite.props.index,
+        type: 'test',
+        body: { query: { match: { 'admin.country': 'Test Country' } } }
+      }, function( err, res ){
+        t.equal( err, undefined );
+        t.equal( res.hits.total, 1, 'document found' );
+        done();
+      });
+    });
+
+    // search by country_abbr
+    suite.assert( function( done ){
+      suite.client.search({
+        index: suite.props.index,
+        type: 'test',
+        body: { query: { match: { 'admin.country_abbr': 'TestCountry' } } }
+      }, function( err, res ){
+        t.equal( err, undefined );
+        t.equal( res.hits.total, 1, 'document found' );
+        done();
+      });
+    });
+
+    // search by country_id
+    suite.assert( function( done ){
+      suite.client.search({
+        index: suite.props.index,
+        type: 'test',
+        body: { query: { match: { 'admin.country_id': '100' } } }
+      }, function( err, res ){
+        t.equal( err, undefined );
+        t.equal( res.hits.total, 1, 'document found' );
+        done();
+      });
+    });
+
+    // ... the remaining admin fields are identical and so their assertions
+    // have been omitted for the sake of brevity.
+
+    suite.run( t.end );
+  });
+};
+
+module.exports.all = function (tape, common) {
+
+  function test(name, testFunction) {
+    return tape('admin matching: ' + name, testFunction);
+  }
+
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/integration/dynamic_templates.js
+++ b/integration/dynamic_templates.js
@@ -9,13 +9,13 @@ module.exports.tests = {};
 
 // 'admin' mappings have a different 'name' dynamic_template to the other types
 module.exports.tests.dynamic_templates_name = function(test, common){
-  test( 'admin->name', nameAssertion( 'admin0', 'peliasOneEdgeGram' ) );
+  test( 'admin->name', nameAssertion( 'country', 'peliasOneEdgeGram' ) );
   test( 'document->name', nameAssertion( 'myType', 'peliasTwoEdgeGram' ) );
 };
 
 // all types share the same phrase mapping
 module.exports.tests.dynamic_templates_phrase = function(test, common){
-  test( 'admin->phrase', phraseAssertion( 'admin0', 'peliasPhrase' ) );
+  test( 'admin->phrase', phraseAssertion( 'country', 'peliasPhrase' ) );
   test( 'document->phrase', phraseAssertion( 'myType', 'peliasPhrase' ) );
 };
 

--- a/integration/dynamic_templates.js
+++ b/integration/dynamic_templates.js
@@ -9,12 +9,14 @@ module.exports.tests = {};
 
 // 'admin' mappings have a different 'name' dynamic_template to the other types
 module.exports.tests.dynamic_templates_name = function(test, common){
+  test( 'admin->name (legacy)', nameAssertion( 'admin0', 'peliasOneEdgeGram' ) );
   test( 'admin->name', nameAssertion( 'country', 'peliasOneEdgeGram' ) );
   test( 'document->name', nameAssertion( 'myType', 'peliasTwoEdgeGram' ) );
 };
 
 // all types share the same phrase mapping
 module.exports.tests.dynamic_templates_phrase = function(test, common){
+  test( 'admin->phrase (legacy)', phraseAssertion( 'admin0', 'peliasPhrase' ) );
   test( 'admin->phrase', phraseAssertion( 'country', 'peliasPhrase' ) );
   test( 'document->phrase', phraseAssertion( 'myType', 'peliasPhrase' ) );
 };

--- a/integration/run.js
+++ b/integration/run.js
@@ -13,6 +13,7 @@ var tests = [
   require('./analyzer_peliasZip.js'),
   require('./analyzer_peliasStreet.js'),
   require('./address_matching.js'),
+  require('./admin_matching.js'),
   require('./source_layer_sourceid_filtering.js'),
   require('./bounding_box.js')
 ];

--- a/mappings/document.js
+++ b/mappings/document.js
@@ -44,17 +44,45 @@ var schema = {
       }
     },
 
-    // generic topology
-    alpha3: admin,
+    // hierarchy
+    parent: {
+      type: 'object',
+      dynamic: true,
+      properties: {
+        // https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3
+        alpha3: admin,
 
-    // quattroshapes topology
-    admin0: admin,
-    admin1: admin,
-    admin1_abbr: admin,
-    admin2: admin,
-    local_admin: admin,
-    locality: admin,
-    neighborhood: admin,
+        // https://github.com/whosonfirst/whosonfirst-placetypes#country
+        country: admin,
+        country_abbr: admin,
+        country_id: literal,
+
+        // https://github.com/whosonfirst/whosonfirst-placetypes#region
+        region: admin,
+        region_abbr: admin,
+        region_id: literal,
+
+        // https://github.com/whosonfirst/whosonfirst-placetypes#county
+        county: admin,
+        county_abbr: admin,
+        county_id: literal,
+
+        // https://github.com/whosonfirst/whosonfirst-placetypes#locality
+        locality: admin,
+        locality_abbr: admin,
+        locality_id: literal,
+
+        // https://github.com/whosonfirst/whosonfirst-placetypes#localadmin
+        localadmin: admin,
+        localadmin_abbr: admin,
+        localadmin_id: literal,
+
+        // https://github.com/whosonfirst/whosonfirst-placetypes#neighbourhood
+        neighbourhood: admin,
+        neighbourhood_abbr: admin,
+        neighbourhood_id: literal
+      }
+    },
 
     // geography
     center_point: require('./partial/centroid'),

--- a/mappings/document.js
+++ b/mappings/document.js
@@ -9,6 +9,7 @@ var schema = {
     // data partitioning
     source: literal,
     layer: literal,
+    alpha3: admin,
 
     // place name (ngram analysis)
     name: hash,
@@ -44,13 +45,20 @@ var schema = {
       }
     },
 
+    // quattroshapes (legacy) hierarchy
+    admin0: admin,
+    admin1: admin,
+    admin1_abbr: admin,
+    admin2: admin,
+    local_admin: admin,
+    locality: admin,
+    neighborhood: admin,
+
     // hierarchy
     parent: {
       type: 'object',
       dynamic: true,
       properties: {
-        // https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3
-        alpha3: admin,
 
         // https://github.com/whosonfirst/whosonfirst-placetypes#country
         country: admin,

--- a/mappings/partial/foreignkey.json
+++ b/mappings/partial/foreignkey.json
@@ -1,4 +1,0 @@
-{
-  "type": "long",
-  "index": "no"
-}

--- a/schema.js
+++ b/schema.js
@@ -41,7 +41,15 @@ var schema = {
     **/
     country: oneGramMapping,
     region: oneGramMapping,
-    county: oneGramMapping
+    county: oneGramMapping,
+
+    /**
+      legacy _type for quattroshapes.
+      @todo: remove these once quattroshapes has been decomissioned.
+    **/
+    admin0: oneGramMapping,
+    admin1: oneGramMapping,
+    admin2: oneGramMapping
   }
 };
 

--- a/schema.js
+++ b/schema.js
@@ -20,11 +20,28 @@ var oneGramMapping = {
 var schema = {
   settings: require('./settings')(),
   mappings: {
+    /**
+      the _default_ mapping is applied to all new _type dynamically added after
+      the index was created, see comment below for more info.
+    **/
     _default_: doc,
 
-    admin0: oneGramMapping,
-    admin1: oneGramMapping,
-    admin2: oneGramMapping
+    /**
+      these 3 _type are created when the index is created, while all other _type
+      are dynamically created as required at run time, this served two purposes:
+
+      1) creating at least one _type will avoid errors when searching against
+         an empty database. Having at least one _type means that 0 documents are
+         returned instead of a error from elasticsearch.
+
+      2) allows us to define their analysis differently from the other _type.
+         in this case, we will elect to use the $oneGramMapping so that these
+         _type can be searched with a single character. doing so on *all* _type
+         would result in much larger indeces and decreased search performance.
+    **/
+    country: oneGramMapping,
+    region: oneGramMapping,
+    county: oneGramMapping
   }
 };
 

--- a/test/compile.js
+++ b/test/compile.js
@@ -23,12 +23,12 @@ module.exports.tests.indeces = function(test, common) {
     t.end();
   });
   test('explicitly specify some admin indeces and their analyzer', function(t) {
-    t.equal(typeof schema.mappings['admin0'], 'object', 'mappings present');
-    t.equal(schema.mappings['admin0'].dynamic_templates[0].nameGram.mapping.analyzer, 'peliasOneEdgeGram');
-    t.equal(typeof schema.mappings['admin1'], 'object', 'mappings present');
-    t.equal(schema.mappings['admin1'].dynamic_templates[0].nameGram.mapping.analyzer, 'peliasOneEdgeGram');
-    t.equal(typeof schema.mappings['admin2'], 'object', 'mappings present');
-    t.equal(schema.mappings['admin2'].dynamic_templates[0].nameGram.mapping.analyzer, 'peliasOneEdgeGram');
+    t.equal(typeof schema.mappings['country'], 'object', 'mappings present');
+    t.equal(schema.mappings['country'].dynamic_templates[0].nameGram.mapping.analyzer, 'peliasOneEdgeGram');
+    t.equal(typeof schema.mappings['region'], 'object', 'mappings present');
+    t.equal(schema.mappings['region'].dynamic_templates[0].nameGram.mapping.analyzer, 'peliasOneEdgeGram');
+    t.equal(typeof schema.mappings['county'], 'object', 'mappings present');
+    t.equal(schema.mappings['county'].dynamic_templates[0].nameGram.mapping.analyzer, 'peliasOneEdgeGram');
     t.end();
   });
 };
@@ -36,8 +36,8 @@ module.exports.tests.indeces = function(test, common) {
 // some 'admin' types allow single edgeNGrams and so have a different dynamic_template
 module.exports.tests.dynamic_templates = function(test, common) {
   test('dynamic_templates: nameGram', function(t) {
-    t.equal(typeof schema.mappings.admin0.dynamic_templates[0].nameGram, 'object', 'nameGram template specified');
-    var template = schema.mappings.admin0.dynamic_templates[0].nameGram;
+    t.equal(typeof schema.mappings.country.dynamic_templates[0].nameGram, 'object', 'nameGram template specified');
+    var template = schema.mappings.country.dynamic_templates[0].nameGram;
     t.equal(template.path_match, 'name.*');
     t.equal(template.match_mapping_type, 'string');
     t.deepEqual(template.mapping, {

--- a/test/compile.js
+++ b/test/compile.js
@@ -1,6 +1,6 @@
 
 var path = require('path'),
-    schema = require('../')
+    schema = require('../'),
     fixture = require('./fixtures/expected.json');
 
 module.exports.tests = {};
@@ -18,17 +18,26 @@ module.exports.tests.compile = function(test, common) {
 // the api codebase against an index without admin data
 module.exports.tests.indeces = function(test, common) {
   test('contains "_default_" index definition', function(t) {
-    t.equal(typeof schema.mappings['_default_'], 'object', 'mappings present');
-    t.equal(schema.mappings['_default_'].dynamic_templates[0].nameGram.mapping.analyzer, 'peliasTwoEdgeGram');
+    t.equal(typeof schema.mappings._default_, 'object', 'mappings present');
+    t.equal(schema.mappings._default_.dynamic_templates[0].nameGram.mapping.analyzer, 'peliasTwoEdgeGram');
     t.end();
   });
   test('explicitly specify some admin indeces and their analyzer', function(t) {
-    t.equal(typeof schema.mappings['country'], 'object', 'mappings present');
-    t.equal(schema.mappings['country'].dynamic_templates[0].nameGram.mapping.analyzer, 'peliasOneEdgeGram');
-    t.equal(typeof schema.mappings['region'], 'object', 'mappings present');
-    t.equal(schema.mappings['region'].dynamic_templates[0].nameGram.mapping.analyzer, 'peliasOneEdgeGram');
-    t.equal(typeof schema.mappings['county'], 'object', 'mappings present');
-    t.equal(schema.mappings['county'].dynamic_templates[0].nameGram.mapping.analyzer, 'peliasOneEdgeGram');
+    t.equal(typeof schema.mappings.country, 'object', 'mappings present');
+    t.equal(schema.mappings.country.dynamic_templates[0].nameGram.mapping.analyzer, 'peliasOneEdgeGram');
+    t.equal(typeof schema.mappings.region, 'object', 'mappings present');
+    t.equal(schema.mappings.region.dynamic_templates[0].nameGram.mapping.analyzer, 'peliasOneEdgeGram');
+    t.equal(typeof schema.mappings.county, 'object', 'mappings present');
+    t.equal(schema.mappings.county.dynamic_templates[0].nameGram.mapping.analyzer, 'peliasOneEdgeGram');
+    t.end();
+  });
+  test('explicitly specify some admin indeces and their analyzer (legacy)', function(t) {
+    t.equal(typeof schema.mappings.admin0, 'object', 'mappings present');
+    t.equal(schema.mappings.admin0.dynamic_templates[0].nameGram.mapping.analyzer, 'peliasOneEdgeGram');
+    t.equal(typeof schema.mappings.admin1, 'object', 'mappings present');
+    t.equal(schema.mappings.admin1.dynamic_templates[0].nameGram.mapping.analyzer, 'peliasOneEdgeGram');
+    t.equal(typeof schema.mappings.admin2, 'object', 'mappings present');
+    t.equal(schema.mappings.admin2.dynamic_templates[0].nameGram.mapping.analyzer, 'peliasOneEdgeGram');
     t.end();
   });
 };
@@ -52,6 +61,25 @@ module.exports.tests.dynamic_templates = function(test, common) {
   });
 };
 
+// as above for the legacy quattroshapes _types
+module.exports.tests.dynamic_templates_legacy = function(test, common) {
+  test('dynamic_templates: nameGram (legacy)', function(t) {
+    t.equal(typeof schema.mappings.admin0.dynamic_templates[0].nameGram, 'object', 'nameGram template specified');
+    var template = schema.mappings.admin0.dynamic_templates[0].nameGram;
+    t.equal(template.path_match, 'name.*');
+    t.equal(template.match_mapping_type, 'string');
+    t.deepEqual(template.mapping, {
+      type: 'string',
+      analyzer: 'peliasOneEdgeGram',
+      fielddata: {
+        format: 'fst',
+        loading: 'eager_global_ordinals'
+      }
+    });
+    t.end();
+  });
+};
+
 // current schema (compiled) - requires schema to be copied and settings to
 // be regenerated from a fixture in order to pass in CI environments.
 module.exports.tests.current_schema = function(test, common) {
@@ -61,9 +89,9 @@ module.exports.tests.current_schema = function(test, common) {
     var schemaCopy = JSON.parse( JSON.stringify( schema ) );
 
     // use the pelias config fixture instead of the local config
-    process.env['PELIAS_CONFIG'] = path.resolve( __dirname + '/fixtures/config.json' );
-    schemaCopy.settings = require('../settings')()
-    delete process.env['PELIAS_CONFIG'];
+    process.env.PELIAS_CONFIG = path.resolve( __dirname + '/fixtures/config.json' );
+    schemaCopy.settings = require('../settings')();
+    delete process.env.PELIAS_CONFIG;
 
     // code intentionally commented to allow quick debugging of expected.json
     // console.log( JSON.stringify( schemaCopy, null, 2 ) );

--- a/test/document.js
+++ b/test/document.js
@@ -88,7 +88,7 @@ module.exports.tests.parent_fields = function(test, common) {
 };
 
 // parent field analysis
-// ref: @todo add PR reference url
+// ref: https://github.com/pelias/schema/pull/95
 module.exports.tests.parent_analysis = function(test, common) {
   var prop = schema.properties.parent.properties;
 

--- a/test/document.js
+++ b/test/document.js
@@ -21,7 +21,7 @@ module.exports.tests.properties = function(test, common) {
 
 // should contain the correct field definitions
 module.exports.tests.fields = function(test, common) {
-  var fields = ['source','layer','name','phrase','address','parent','center_point','shape','bounding_box','source_id','category','population','popularity'];
+  var fields = ['source', 'layer', 'alpha3', 'name', 'phrase', 'address', 'admin0', 'admin1', 'admin1_abbr', 'admin2', 'local_admin', 'locality', 'neighborhood', 'parent', 'center_point', 'shape', 'bounding_box', 'source_id', 'category', 'population', 'popularity'];
   test('fields specified', function(t) {
     t.deepEqual(Object.keys(schema.properties), fields);
     t.end();
@@ -80,7 +80,7 @@ module.exports.tests.address_analysis = function(test, common) {
 
 // should contain the correct parent field definitions
 module.exports.tests.parent_fields = function(test, common) {
-  var fields = ['alpha3', 'country', 'country_abbr', 'country_id', 'region', 'region_abbr', 'region_id', 'county', 'county_abbr', 'county_id', 'locality', 'locality_abbr', 'locality_id', 'localadmin', 'localadmin_abbr', 'localadmin_id', 'neighbourhood', 'neighbourhood_abbr', 'neighbourhood_id'];
+  var fields = ['country', 'country_abbr', 'country_id', 'region', 'region_abbr', 'region_id', 'county', 'county_abbr', 'county_id', 'locality', 'locality_abbr', 'locality_id', 'localadmin', 'localadmin_abbr', 'localadmin_id', 'neighbourhood', 'neighbourhood_abbr', 'neighbourhood_id'];
   test('parent fields specified', function(t) {
     t.deepEqual(Object.keys(schema.properties.parent.properties), fields);
     t.end();
@@ -91,13 +91,6 @@ module.exports.tests.parent_fields = function(test, common) {
 // ref: https://github.com/pelias/schema/pull/95
 module.exports.tests.parent_analysis = function(test, common) {
   var prop = schema.properties.parent.properties;
-
-  test('alpha3', function(t) {
-    t.equal(prop.alpha3.type, 'string');
-    t.equal(prop.alpha3.analyzer, 'peliasAdmin');
-    t.end();
-  });
-
   var fields = ['country','region','county','locality','localadmin','neighbourhood'];
   fields.forEach( function( field ){
     test(field, function(t) {
@@ -110,6 +103,15 @@ module.exports.tests.parent_analysis = function(test, common) {
       t.equal(prop[field+'_id'].search_analyzer, 'keyword');
       t.end();
     });
+  });
+};
+
+module.exports.tests.alpha3_analysis = function(test, common) {
+  var prop = schema.properties.alpha3;
+  test('alpha3', function(t) {
+    t.equal(prop.type, 'string');
+    t.equal(prop.analyzer, 'peliasAdmin');
+    t.end();
   });
 };
 

--- a/test/document.js
+++ b/test/document.js
@@ -21,10 +21,95 @@ module.exports.tests.properties = function(test, common) {
 
 // should contain the correct field definitions
 module.exports.tests.fields = function(test, common) {
-  var fields = ['source','layer','name','phrase','address','alpha3','admin0','admin1','admin1_abbr','admin2','local_admin','locality','neighborhood','center_point','shape','bounding_box','source_id','category','population','popularity'];
+  var fields = ['source','layer','name','phrase','address','parent','center_point','shape','bounding_box','source_id','category','population','popularity'];
   test('fields specified', function(t) {
     t.deepEqual(Object.keys(schema.properties), fields);
     t.end();
+  });
+};
+
+// should contain the correct address field definitions
+module.exports.tests.address_fields = function(test, common) {
+  var fields = ['name','number','street','zip'];
+  test('address fields specified', function(t) {
+    t.deepEqual(Object.keys(schema.properties.address.properties), fields);
+    t.end();
+  });
+};
+
+// address field analysis
+// ref: https://github.com/pelias/schema/pull/77
+module.exports.tests.address_analysis = function(test, common) {
+  var prop = schema.properties.address.properties;
+
+  // $name analysis is pretty basic, work can be done to improve this, although
+  // at time of writing this field was not used by any API queries.
+  test('name', function(t) {
+    t.equal(prop.name.type, 'string');
+    t.equal(prop.name.index_analyzer, 'keyword');
+    t.equal(prop.name.search_analyzer, 'keyword');
+    t.end();
+  });
+
+  // $number analysis is discussed in: https://github.com/pelias/schema/pull/77
+  test('number', function(t) {
+    t.equal(prop.number.type, 'string');
+    t.equal(prop.number.index_analyzer, 'peliasHousenumber');
+    t.equal(prop.number.search_analyzer, 'peliasHousenumber');
+    t.end();
+  });
+
+  // $street analysis is discussed in: https://github.com/pelias/schema/pull/77
+  test('street', function(t) {
+    t.equal(prop.street.type, 'string');
+    t.equal(prop.street.index_analyzer, 'peliasStreet');
+    t.equal(prop.street.search_analyzer, 'peliasStreet');
+    t.end();
+  });
+
+  // $zip analysis is discussed in: https://github.com/pelias/schema/pull/77
+  // note: this is a poor name, it would be better to rename this field to a more
+  // generic term such as $postalcode as it is not specific to the USA.
+  test('zip', function(t) {
+    t.equal(prop.zip.type, 'string');
+    t.equal(prop.zip.index_analyzer, 'peliasZip');
+    t.equal(prop.zip.search_analyzer, 'peliasZip');
+    t.end();
+  });
+};
+
+// should contain the correct parent field definitions
+module.exports.tests.parent_fields = function(test, common) {
+  var fields = ['alpha3', 'country', 'country_abbr', 'country_id', 'region', 'region_abbr', 'region_id', 'county', 'county_abbr', 'county_id', 'locality', 'locality_abbr', 'locality_id', 'localadmin', 'localadmin_abbr', 'localadmin_id', 'neighbourhood', 'neighbourhood_abbr', 'neighbourhood_id'];
+  test('parent fields specified', function(t) {
+    t.deepEqual(Object.keys(schema.properties.parent.properties), fields);
+    t.end();
+  });
+};
+
+// parent field analysis
+// ref: @todo add PR reference url
+module.exports.tests.parent_analysis = function(test, common) {
+  var prop = schema.properties.parent.properties;
+
+  test('alpha3', function(t) {
+    t.equal(prop.alpha3.type, 'string');
+    t.equal(prop.alpha3.analyzer, 'peliasAdmin');
+    t.end();
+  });
+
+  var fields = ['country','region','county','locality','localadmin','neighbourhood'];
+  fields.forEach( function( field ){
+    test(field, function(t) {
+      t.equal(prop[field].type, 'string');
+      t.equal(prop[field].analyzer, 'peliasAdmin');
+      t.equal(prop[field+'_abbr'].type, 'string');
+      t.equal(prop[field+'_abbr'].analyzer, 'peliasAdmin');
+      t.equal(prop[field+'_id'].type, 'string');
+      t.equal(prop[field+'_id'].index_analyzer, 'keyword');
+      t.equal(prop[field+'_id'].search_analyzer, 'keyword');
+      t.end();
+    });
   });
 };
 

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -1401,45 +1401,112 @@
             }
           }
         },
-        "alpha3": {
-          "type": "string",
-          "analyzer": "peliasAdmin",
-          "store": "yes"
-        },
-        "admin0": {
-          "type": "string",
-          "analyzer": "peliasAdmin",
-          "store": "yes"
-        },
-        "admin1": {
-          "type": "string",
-          "analyzer": "peliasAdmin",
-          "store": "yes"
-        },
-        "admin1_abbr": {
-          "type": "string",
-          "analyzer": "peliasAdmin",
-          "store": "yes"
-        },
-        "admin2": {
-          "type": "string",
-          "analyzer": "peliasAdmin",
-          "store": "yes"
-        },
-        "local_admin": {
-          "type": "string",
-          "analyzer": "peliasAdmin",
-          "store": "yes"
-        },
-        "locality": {
-          "type": "string",
-          "analyzer": "peliasAdmin",
-          "store": "yes"
-        },
-        "neighborhood": {
-          "type": "string",
-          "analyzer": "peliasAdmin",
-          "store": "yes"
+        "parent": {
+          "type": "object",
+          "dynamic": true,
+          "properties": {
+            "alpha3": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "country": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "country_abbr": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "country_id": {
+              "type": "string",
+              "index_analyzer": "keyword",
+              "search_analyzer": "keyword",
+              "store": "yes"
+            },
+            "region": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "region_abbr": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "region_id": {
+              "type": "string",
+              "index_analyzer": "keyword",
+              "search_analyzer": "keyword",
+              "store": "yes"
+            },
+            "county": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "county_abbr": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "county_id": {
+              "type": "string",
+              "index_analyzer": "keyword",
+              "search_analyzer": "keyword",
+              "store": "yes"
+            },
+            "locality": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "locality_abbr": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "locality_id": {
+              "type": "string",
+              "index_analyzer": "keyword",
+              "search_analyzer": "keyword",
+              "store": "yes"
+            },
+            "localadmin": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "localadmin_abbr": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "localadmin_id": {
+              "type": "string",
+              "index_analyzer": "keyword",
+              "search_analyzer": "keyword",
+              "store": "yes"
+            },
+            "neighbourhood": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "neighbourhood_abbr": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "neighbourhood_id": {
+              "type": "string",
+              "index_analyzer": "keyword",
+              "search_analyzer": "keyword",
+              "store": "yes"
+            }
+          }
         },
         "center_point": {
           "type": "geo_point",
@@ -1521,7 +1588,7 @@
       },
       "dynamic": "true"
     },
-    "admin0": {
+    "country": {
       "dynamic_templates": [
         {
           "nameGram": {
@@ -1539,7 +1606,7 @@
         }
       ]
     },
-    "admin1": {
+    "region": {
       "dynamic_templates": [
         {
           "nameGram": {
@@ -1557,7 +1624,7 @@
         }
       ]
     },
-    "admin2": {
+    "county": {
       "dynamic_templates": [
         {
           "nameGram": {

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -1367,6 +1367,11 @@
           "search_analyzer": "keyword",
           "store": "yes"
         },
+        "alpha3": {
+          "type": "string",
+          "analyzer": "peliasAdmin",
+          "store": "yes"
+        },
         "name": {
           "type": "object",
           "dynamic": true
@@ -1401,15 +1406,45 @@
             }
           }
         },
+        "admin0": {
+          "type": "string",
+          "analyzer": "peliasAdmin",
+          "store": "yes"
+        },
+        "admin1": {
+          "type": "string",
+          "analyzer": "peliasAdmin",
+          "store": "yes"
+        },
+        "admin1_abbr": {
+          "type": "string",
+          "analyzer": "peliasAdmin",
+          "store": "yes"
+        },
+        "admin2": {
+          "type": "string",
+          "analyzer": "peliasAdmin",
+          "store": "yes"
+        },
+        "local_admin": {
+          "type": "string",
+          "analyzer": "peliasAdmin",
+          "store": "yes"
+        },
+        "locality": {
+          "type": "string",
+          "analyzer": "peliasAdmin",
+          "store": "yes"
+        },
+        "neighborhood": {
+          "type": "string",
+          "analyzer": "peliasAdmin",
+          "store": "yes"
+        },
         "parent": {
           "type": "object",
           "dynamic": true,
           "properties": {
-            "alpha3": {
-              "type": "string",
-              "analyzer": "peliasAdmin",
-              "store": "yes"
-            },
             "country": {
               "type": "string",
               "analyzer": "peliasAdmin",
@@ -1625,6 +1660,60 @@
       ]
     },
     "county": {
+      "dynamic_templates": [
+        {
+          "nameGram": {
+            "path_match": "name.*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "string",
+              "analyzer": "peliasOneEdgeGram",
+              "fielddata": {
+                "format": "fst",
+                "loading": "eager_global_ordinals"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "admin0": {
+      "dynamic_templates": [
+        {
+          "nameGram": {
+            "path_match": "name.*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "string",
+              "analyzer": "peliasOneEdgeGram",
+              "fielddata": {
+                "format": "fst",
+                "loading": "eager_global_ordinals"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "admin1": {
+      "dynamic_templates": [
+        {
+          "nameGram": {
+            "path_match": "name.*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "string",
+              "analyzer": "peliasOneEdgeGram",
+              "fielddata": {
+                "format": "fst",
+                "loading": "eager_global_ordinals"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "admin2": {
       "dynamic_templates": [
         {
           "nameGram": {


### PR DESCRIPTION
**[edit]** this PR has been updated in order to support both quattroshapes and WOF *simultaneously* and should now be good-to-release.

this PR changes the terminology used to refer to the 'administrative' hierarchy of geographic regions which parent a document.

prior to this PR these document fields were named:

```
admin0
admin1
admin1_abbr
admin2
local_admin
locality
neighborhood
```

the proposal in this PR is to **add** the following fields:

```
parent.country
parent.country_abbr
parent.country_id
parent.region
parent.region_abbr
parent.region_id
parent.county
parent.county_abbr
parent.county_id
parent.locality
parent.locality_abbr
parent.locality_id
parent.localadmin
parent.localadmin_abbr
parent.localadmin_id
parent.neighbourhood
parent.neighbourhood_abbr
parent.neighbourhood_id
```

I chose to store the fields inside an 'object' type (kind of like a namespace) called `"parent"`, I personally think this is 'nicer' simply because it's easier to distinguish these fields from the other fields in the document.

The `alpha3` field remains unchanged.

I added 3x fields per place type, the default being the 'name' and the other 2 being `id` and `abbr`. In the past only `admin1` allowed for state abbreviations.

One further consideration is the names of the elasticsearch `_type` that we tell to use a single gram analysis. Prior to this PR we created 3x `_type` at index time named `admin0, admin1, admin2` which were set up to index single grams (so the first keypress returns something).

These `_type` are now named `country, region, county` respectively. It's important that when importing WOF placetypes that the `_type` they get stored in is named the same, failing to do so will return 0 results for the first keypress.

For more info about this see my comment https://github.com/pelias/schema/blob/admin_field_naming/schema.js, the simple solution is to use the WOF placetype as the first argument to the pelias/model constructor such as:
```javascript
// good
var poi = new Document( 'wof', 'country', 1 )

// bad
var poi = new Document( 'wof', 'wof:country', 1 )
```

I also took the opportunity to do a little housekeeping and add some code comments.