### PR TITLE
better remove_ordinals regex pattern

### DIFF
--- a/integration/analyzer_peliasStreet.js
+++ b/integration/analyzer_peliasStreet.js
@@ -76,6 +76,30 @@ module.exports.tests.remove_ordinals = function(test, common){
     assertAnalysis( 'ordindals', "4444th", ["4444"] );
     assertAnalysis( 'ordindals', "2500th", ["2500"] );
 
+    // teens
+    assertAnalysis( 'teens', "11th", ["11"] );
+    assertAnalysis( 'teens', "12th", ["12"] );
+    assertAnalysis( 'teens', "13th", ["13"] );
+    assertAnalysis( 'teens', "14th", ["14"] );
+    assertAnalysis( 'teens', "15th", ["15"] );
+    assertAnalysis( 'teens', "16th", ["16"] );
+    assertAnalysis( 'teens', "17th", ["17"] );
+    assertAnalysis( 'teens', "18th", ["18"] );
+    assertAnalysis( 'teens', "19th", ["19"] );
+    assertAnalysis( 'teens', "20th", ["20"] );
+
+    // teens (hundreds)
+    assertAnalysis( 'teens - hundreds', "111th", ["111"] );
+    assertAnalysis( 'teens - hundreds', "112th", ["112"] );
+    assertAnalysis( 'teens - hundreds', "113th", ["113"] );
+    assertAnalysis( 'teens - hundreds', "114th", ["114"] );
+    assertAnalysis( 'teens - hundreds', "115th", ["115"] );
+    assertAnalysis( 'teens - hundreds', "116th", ["116"] );
+    assertAnalysis( 'teens - hundreds', "117th", ["117"] );
+    assertAnalysis( 'teens - hundreds', "118th", ["118"] );
+    assertAnalysis( 'teens - hundreds', "119th", ["119"] );
+    assertAnalysis( 'teens - hundreds', "120th", ["120"] );
+
     assertAnalysis( 'uppercase', "1ST", ["1"] );
     assertAnalysis( 'uppercase', "22ND", ["22"] );
     assertAnalysis( 'uppercase', "333RD", ["333"] );

--- a/integration/analyzer_peliasStreet.js
+++ b/integration/analyzer_peliasStreet.js
@@ -63,6 +63,45 @@ module.exports.tests.normalize_punctuation = function(test, common){
   });
 };
 
+module.exports.tests.remove_ordinals = function(test, common){
+  test( 'remove ordinals', function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+    var assertAnalysis = analyze.bind( null, suite, t, 'peliasStreet' );
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
+
+    assertAnalysis( 'ordindals', "1st", ["1"] );
+    assertAnalysis( 'ordindals', "22nd", ["22"] );
+    assertAnalysis( 'ordindals', "333rd", ["333"] );
+    assertAnalysis( 'ordindals', "4444th", ["4444"] );
+    assertAnalysis( 'ordindals', "2500th", ["2500"] );
+
+    assertAnalysis( 'uppercase', "1ST", ["1"] );
+    assertAnalysis( 'uppercase', "22ND", ["22"] );
+    assertAnalysis( 'uppercase', "333RD", ["333"] );
+    assertAnalysis( 'uppercase', "4444TH", ["4444"] );
+
+    assertAnalysis( 'autocomplete', "26", ["26"] );
+    assertAnalysis( 'autocomplete', "26t", ["26"] );
+    assertAnalysis( 'autocomplete', "26th", ["26"] );
+    assertAnalysis( 'autocomplete', "3", ["3"] );
+    assertAnalysis( 'autocomplete', "3r", ["3"] );
+    assertAnalysis( 'autocomplete', "3rd", ["3"] );
+
+    assertAnalysis( 'wrong suffix (do nothing)', "0th", ["0th"] );
+    assertAnalysis( 'wrong suffix (do nothing)', "26s", ["26s"] );
+    assertAnalysis( 'wrong suffix (do nothing)', "26st", ["26st"] );
+    assertAnalysis( 'wrong suffix (do nothing)', "31t", ["31t"] );
+    assertAnalysis( 'wrong suffix (do nothing)', "31th", ["31th"] );
+    assertAnalysis( 'wrong suffix (do nothing)', "21r", ["21r"] );
+    assertAnalysis( 'wrong suffix (do nothing)', "21rd", ["21rd"] );
+    assertAnalysis( 'wrong suffix (do nothing)', "29n", ["29n"] );
+    assertAnalysis( 'wrong suffix (do nothing)', "29nd", ["29nd"] );
+
+    suite.run( t.end );
+  });
+};
+
 module.exports.all = function (tape, common) {
 
   function test(name, testFunction) {

--- a/integration/analyzer_peliasStreet.js
+++ b/integration/analyzer_peliasStreet.js
@@ -100,11 +100,21 @@ module.exports.tests.remove_ordinals = function(test, common){
     assertAnalysis( 'teens - hundreds', "119th", ["119"] );
     assertAnalysis( 'teens - hundreds', "120th", ["120"] );
 
+    // teens (wrong suffix)
+    assertAnalysis( 'teens - wrong suffix', "11st", ["11st"] );
+    assertAnalysis( 'teens - wrong suffix', "12nd", ["12nd"] );
+    assertAnalysis( 'teens - wrong suffix', "13rd", ["13rd"] );
+    assertAnalysis( 'teens - wrong suffix', "111st", ["111st"] );
+    assertAnalysis( 'teens - wrong suffix', "112nd", ["112nd"] );
+    assertAnalysis( 'teens - wrong suffix', "113rd", ["113rd"] );
+
+    // uppercase
     assertAnalysis( 'uppercase', "1ST", ["1"] );
     assertAnalysis( 'uppercase', "22ND", ["22"] );
     assertAnalysis( 'uppercase', "333RD", ["333"] );
     assertAnalysis( 'uppercase', "4444TH", ["4444"] );
 
+    // autocomplete
     assertAnalysis( 'autocomplete', "26", ["26"] );
     assertAnalysis( 'autocomplete', "26t", ["26"] );
     assertAnalysis( 'autocomplete', "26th", ["26"] );
@@ -112,6 +122,7 @@ module.exports.tests.remove_ordinals = function(test, common){
     assertAnalysis( 'autocomplete', "3r", ["3"] );
     assertAnalysis( 'autocomplete', "3rd", ["3"] );
 
+    // wrong suffix
     assertAnalysis( 'wrong suffix (do nothing)', "0th", ["0th"] );
     assertAnalysis( 'wrong suffix (do nothing)', "26s", ["26s"] );
     assertAnalysis( 'wrong suffix (do nothing)', "26st", ["26st"] );

--- a/settings.js
+++ b/settings.js
@@ -148,8 +148,8 @@ function generate(){
         },
         "remove_ordinals" : {
           "type" : "pattern_replace",
-          "pattern": "(([0-9]*1)st?|([0-9]*2)nd?|([0-9]*3)rd?|([0-9]*[456789])th?|([0-9]+0)th?|([0-9]*1[0-9])th?)",
-          "replacement": "$2$3$4$5$6$7"
+          "pattern": "(?i)((^| )((1)st?|(2)nd?|(3)rd?|([4-9])th?)|(([0-9]*)(1[0-9])th?)|(([0-9]*[02-9])((1)st?|(2)nd?|(3)rd?|([04-9])th?))($| ))",
+          "replacement": "$2$4$5$6$7$9$10$12$14$15$16$17$18"
         },
         "remove_duplicate_spaces" : {
           "type" : "pattern_replace",

--- a/settings.js
+++ b/settings.js
@@ -148,8 +148,8 @@ function generate(){
         },
         "remove_ordinals" : {
           "type" : "pattern_replace",
-          "pattern": "(([0-9]*1)st?|([0-9]*2)nd?|([0-9]*3)rd?|([0-9]*[456789])th?|([0-9]+0)th?)",
-          "replacement": "$2$3$4$5$6"
+          "pattern": "(([0-9]*1)st?|([0-9]*2)nd?|([0-9]*3)rd?|([0-9]*[456789])th?|([0-9]+0)th?|([0-9]*1[0-9])th?)",
+          "replacement": "$2$3$4$5$6$7"
         },
         "remove_duplicate_spaces" : {
           "type" : "pattern_replace",

--- a/settings.js
+++ b/settings.js
@@ -148,8 +148,8 @@ function generate(){
         },
         "remove_ordinals" : {
           "type" : "pattern_replace",
-          "pattern": "(([0-9])(st|nd|rd|th))",
-          "replacement": "$2"
+          "pattern": "(([0-9]*1)st?|([0-9]*2)nd?|([0-9]*3)rd?|([0-9]*[456789])th?|([0-9]+0)th?)",
+          "replacement": "$2$3$4$5$6"
         },
         "remove_duplicate_spaces" : {
           "type" : "pattern_replace",

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -629,8 +629,8 @@
         },
         "remove_ordinals": {
           "type": "pattern_replace",
-          "pattern": "(([0-9]*1)st?|([0-9]*2)nd?|([0-9]*3)rd?|([0-9]*[456789])th?|([0-9]+0)th?|([0-9]*1[0-9])th?)",
-          "replacement": "$2$3$4$5$6$7"
+          "pattern": "(?i)((^| )((1)st?|(2)nd?|(3)rd?|([4-9])th?)|(([0-9]*)(1[0-9])th?)|(([0-9]*[02-9])((1)st?|(2)nd?|(3)rd?|([04-9])th?))($| ))",
+          "replacement": "$2$4$5$6$7$9$10$12$14$15$16$17$18"
         },
         "remove_duplicate_spaces": {
           "type": "pattern_replace",

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -629,8 +629,8 @@
         },
         "remove_ordinals": {
           "type": "pattern_replace",
-          "pattern": "(([0-9])(st|nd|rd|th))",
-          "replacement": "$2"
+          "pattern": "(([0-9]*1)st?|([0-9]*2)nd?|([0-9]*3)rd?|([0-9]*[456789])th?|([0-9]+0)th?|([0-9]*1[0-9])th?)",
+          "replacement": "$2$3$4$5$6$7"
         },
         "remove_duplicate_spaces": {
           "type": "pattern_replace",

--- a/test/settings.js
+++ b/test/settings.js
@@ -365,8 +365,8 @@ module.exports.tests.removeOrdinalsFilter = function(test, common) {
     t.equal(typeof s.analysis.filter.remove_ordinals, 'object', 'there is an remove_ordinals filter');
     var filter = s.analysis.filter.remove_ordinals;
     t.equal(filter.type, 'pattern_replace');
-    t.equal(filter.pattern, '(([0-9]*1)st?|([0-9]*2)nd?|([0-9]*3)rd?|([0-9]*[456789])th?|([0-9]+0)th?|([0-9]*1[0-9])th?)');
-    t.equal(filter.replacement, '$2$3$4$5$6$7');
+    t.equal(filter.pattern, '(?i)((^| )((1)st?|(2)nd?|(3)rd?|([4-9])th?)|(([0-9]*)(1[0-9])th?)|(([0-9]*[02-9])((1)st?|(2)nd?|(3)rd?|([04-9])th?))($| ))');
+    t.equal(filter.replacement, '$2$4$5$6$7$9$10$12$14$15$16$17$18');
     t.end();
   });
 };

--- a/test/settings.js
+++ b/test/settings.js
@@ -365,8 +365,8 @@ module.exports.tests.removeOrdinalsFilter = function(test, common) {
     t.equal(typeof s.analysis.filter.remove_ordinals, 'object', 'there is an remove_ordinals filter');
     var filter = s.analysis.filter.remove_ordinals;
     t.equal(filter.type, 'pattern_replace');
-    t.equal(filter.pattern, '(([0-9])(st|nd|rd|th))');
-    t.equal(filter.replacement, '$2');
+    t.equal(filter.pattern, '(([0-9]*1)st?|([0-9]*2)nd?|([0-9]*3)rd?|([0-9]*[456789])th?|([0-9]+0)th?|([0-9]*1[0-9])th?)');
+    t.equal(filter.replacement, '$2$3$4$5$6$7');
     t.end();
   });
 };


### PR DESCRIPTION
see https://github.com/pelias/schema/issues/94 for more info.

@orangejulius could you review this plz?

closes https://github.com/pelias/schema/issues/94

[edit] so after much yak shaving I have come up with the perfect megaregex `replace( "(?i)((^| )((1)st?|(2)nd?|(3)rd?|([4-9])th?)|(([0-9]*)(1[0-9])th?)|(([0-9]*[02-9])((1)st?|(2)nd?|(3)rd?|([04-9])th?))($| ))", "$2$4$5$6$7$9$10$12$14$15$16$17$18"`

...which makes my eyes hurt but makes all the tests pass.

@trescube suggested we should maybe leave it a bit more relaxed so that users who are not perfect at english can still find what they need.

so there are 2 options, either we go with the super complex one above or we modify the existing one to support autocomplete with the simpler: `replace( "(([0-9])(st?|nd?|rd?|th?))", "$2" )` or similar