### PR TITLE
Experimental Elasticsearch 2.x support

### DIFF
--- a/mappings/document.js
+++ b/mappings/document.js
@@ -111,7 +111,6 @@ var schema = {
         type: 'string',
         analyzer: 'peliasOneEdgeGram',
         fielddata : {
-          format : 'fst',
           loading: 'eager_global_ordinals'
         }
       }

--- a/mappings/document.js
+++ b/mappings/document.js
@@ -24,23 +24,19 @@ var schema = {
       properties: {
         name: {
           type: 'string',
-          index_analyzer: 'keyword',
-          search_analyzer: 'keyword'
+          analyzer: 'keyword'
         },
         number: {
           type: 'string',
-          index_analyzer: 'peliasHousenumber',
-          search_analyzer: 'peliasHousenumber',
+          analyzer: 'peliasHousenumber',
         },
         street: {
           type: 'string',
-          index_analyzer: 'peliasStreet',
-          search_analyzer: 'peliasStreet'
+          analyzer: 'peliasStreet'
         },
         zip: {
           type: 'string',
-          index_analyzer: 'peliasZip',
-          search_analyzer: 'peliasZip'
+          analyzer: 'peliasZip'
         }
       }
     },

--- a/mappings/document.js
+++ b/mappings/document.js
@@ -109,7 +109,7 @@ var schema = {
       match_mapping_type: 'string',
       mapping: {
         type: 'string',
-        analyzer: 'peliasTwoEdgeGram',
+        analyzer: 'peliasOneEdgeGram',
         fielddata : {
           format : 'fst',
           loading: 'eager_global_ordinals'

--- a/mappings/partial/literal.json
+++ b/mappings/partial/literal.json
@@ -1,6 +1,5 @@
 {
   "type": "string",
-  "index_analyzer": "keyword",
-  "search_analyzer": "keyword",
+  "analyzer": "keyword",
   "store": "yes"
 }

--- a/schema.js
+++ b/schema.js
@@ -1,55 +1,21 @@
 var doc = require('./mappings/document');
 
-var oneGramMapping = {
-  dynamic_templates: [{
-    nameGram: {
-      path_match: 'name.*',
-      match_mapping_type: 'string',
-      mapping: {
-        type: 'string',
-        analyzer: 'peliasOneEdgeGram',
-        fielddata : {
-          format : 'fst',
-          loading: 'eager_global_ordinals'
-        }
-      }
-    }
-  }]
-};
-
 var schema = {
   settings: require('./settings')(),
   mappings: {
     /**
       the _default_ mapping is applied to all new _type dynamically added after
-      the index was created, see comment below for more info.
+      the index was created.
     **/
     _default_: doc,
 
     /**
-      these 3 _type are created when the index is created, while all other _type
-      are dynamically created as required at run time, this served two purposes:
+      creating at least one _type to avoid errors when searching against
+      an empty database. Having at least one _type means that 0 documents are
+      returned instead of a error from elasticsearch.
 
-      1) creating at least one _type will avoid errors when searching against
-         an empty database. Having at least one _type means that 0 documents are
-         returned instead of a error from elasticsearch.
-
-      2) allows us to define their analysis differently from the other _type.
-         in this case, we will elect to use the $oneGramMapping so that these
-         _type can be searched with a single character. doing so on *all* _type
-         would result in much larger indeces and decreased search performance.
     **/
-    country: oneGramMapping,
-    region: oneGramMapping,
-    county: oneGramMapping,
-
-    /**
-      legacy _type for quattroshapes.
-      @todo: remove these once quattroshapes has been decomissioned.
-    **/
-    admin0: oneGramMapping,
-    admin1: oneGramMapping,
-    admin2: oneGramMapping
+    country: doc
   }
 };
 

--- a/test/compile.js
+++ b/test/compile.js
@@ -19,7 +19,7 @@ module.exports.tests.compile = function(test, common) {
 module.exports.tests.indeces = function(test, common) {
   test('contains "_default_" index definition', function(t) {
     t.equal(typeof schema.mappings._default_, 'object', 'mappings present');
-    t.equal(schema.mappings._default_.dynamic_templates[0].nameGram.mapping.analyzer, 'peliasTwoEdgeGram');
+    t.equal(schema.mappings._default_.dynamic_templates[0].nameGram.mapping.analyzer, 'peliasOneEdgeGram');
     t.end();
   });
   test('explicitly specify some admin indeces and their analyzer', function(t) {

--- a/test/compile.js
+++ b/test/compile.js
@@ -22,60 +22,9 @@ module.exports.tests.indeces = function(test, common) {
     t.equal(schema.mappings._default_.dynamic_templates[0].nameGram.mapping.analyzer, 'peliasOneEdgeGram');
     t.end();
   });
-  test('explicitly specify some admin indeces and their analyzer', function(t) {
+  test('explicitly specify one admin indeces and their analyzer', function(t) {
     t.equal(typeof schema.mappings.country, 'object', 'mappings present');
     t.equal(schema.mappings.country.dynamic_templates[0].nameGram.mapping.analyzer, 'peliasOneEdgeGram');
-    t.equal(typeof schema.mappings.region, 'object', 'mappings present');
-    t.equal(schema.mappings.region.dynamic_templates[0].nameGram.mapping.analyzer, 'peliasOneEdgeGram');
-    t.equal(typeof schema.mappings.county, 'object', 'mappings present');
-    t.equal(schema.mappings.county.dynamic_templates[0].nameGram.mapping.analyzer, 'peliasOneEdgeGram');
-    t.end();
-  });
-  test('explicitly specify some admin indeces and their analyzer (legacy)', function(t) {
-    t.equal(typeof schema.mappings.admin0, 'object', 'mappings present');
-    t.equal(schema.mappings.admin0.dynamic_templates[0].nameGram.mapping.analyzer, 'peliasOneEdgeGram');
-    t.equal(typeof schema.mappings.admin1, 'object', 'mappings present');
-    t.equal(schema.mappings.admin1.dynamic_templates[0].nameGram.mapping.analyzer, 'peliasOneEdgeGram');
-    t.equal(typeof schema.mappings.admin2, 'object', 'mappings present');
-    t.equal(schema.mappings.admin2.dynamic_templates[0].nameGram.mapping.analyzer, 'peliasOneEdgeGram');
-    t.end();
-  });
-};
-
-// some 'admin' types allow single edgeNGrams and so have a different dynamic_template
-module.exports.tests.dynamic_templates = function(test, common) {
-  test('dynamic_templates: nameGram', function(t) {
-    t.equal(typeof schema.mappings.country.dynamic_templates[0].nameGram, 'object', 'nameGram template specified');
-    var template = schema.mappings.country.dynamic_templates[0].nameGram;
-    t.equal(template.path_match, 'name.*');
-    t.equal(template.match_mapping_type, 'string');
-    t.deepEqual(template.mapping, {
-      type: 'string',
-      analyzer: 'peliasOneEdgeGram',
-      fielddata: {
-        format: 'fst',
-        loading: 'eager_global_ordinals'
-      }
-    });
-    t.end();
-  });
-};
-
-// as above for the legacy quattroshapes _types
-module.exports.tests.dynamic_templates_legacy = function(test, common) {
-  test('dynamic_templates: nameGram (legacy)', function(t) {
-    t.equal(typeof schema.mappings.admin0.dynamic_templates[0].nameGram, 'object', 'nameGram template specified');
-    var template = schema.mappings.admin0.dynamic_templates[0].nameGram;
-    t.equal(template.path_match, 'name.*');
-    t.equal(template.match_mapping_type, 'string');
-    t.deepEqual(template.mapping, {
-      type: 'string',
-      analyzer: 'peliasOneEdgeGram',
-      fielddata: {
-        format: 'fst',
-        loading: 'eager_global_ordinals'
-      }
-    });
     t.end();
   });
 };

--- a/test/document.js
+++ b/test/document.js
@@ -125,7 +125,6 @@ module.exports.tests.dynamic_templates = function(test, common) {
       type: 'string',
       analyzer: 'peliasOneEdgeGram',
       fielddata: {
-        format: 'fst',
         loading: 'eager_global_ordinals'
       }
     });

--- a/test/document.js
+++ b/test/document.js
@@ -123,7 +123,7 @@ module.exports.tests.dynamic_templates = function(test, common) {
     t.equal(template.match_mapping_type, 'string');
     t.deepEqual(template.mapping, {
       type: 'string',
-      analyzer: 'peliasTwoEdgeGram',
+      analyzer: 'peliasOneEdgeGram',
       fielddata: {
         format: 'fst',
         loading: 'eager_global_ordinals'

--- a/test/document.js
+++ b/test/document.js
@@ -46,24 +46,21 @@ module.exports.tests.address_analysis = function(test, common) {
   // at time of writing this field was not used by any API queries.
   test('name', function(t) {
     t.equal(prop.name.type, 'string');
-    t.equal(prop.name.index_analyzer, 'keyword');
-    t.equal(prop.name.search_analyzer, 'keyword');
+    t.equal(prop.name.analyzer, 'keyword');
     t.end();
   });
 
   // $number analysis is discussed in: https://github.com/pelias/schema/pull/77
   test('number', function(t) {
     t.equal(prop.number.type, 'string');
-    t.equal(prop.number.index_analyzer, 'peliasHousenumber');
-    t.equal(prop.number.search_analyzer, 'peliasHousenumber');
+    t.equal(prop.number.analyzer, 'peliasHousenumber');
     t.end();
   });
 
   // $street analysis is discussed in: https://github.com/pelias/schema/pull/77
   test('street', function(t) {
     t.equal(prop.street.type, 'string');
-    t.equal(prop.street.index_analyzer, 'peliasStreet');
-    t.equal(prop.street.search_analyzer, 'peliasStreet');
+    t.equal(prop.street.analyzer, 'peliasStreet');
     t.end();
   });
 
@@ -72,8 +69,7 @@ module.exports.tests.address_analysis = function(test, common) {
   // generic term such as $postalcode as it is not specific to the USA.
   test('zip', function(t) {
     t.equal(prop.zip.type, 'string');
-    t.equal(prop.zip.index_analyzer, 'peliasZip');
-    t.equal(prop.zip.search_analyzer, 'peliasZip');
+    t.equal(prop.zip.analyzer, 'peliasZip');
     t.end();
   });
 };
@@ -99,8 +95,7 @@ module.exports.tests.parent_analysis = function(test, common) {
       t.equal(prop[field+'_abbr'].type, 'string');
       t.equal(prop[field+'_abbr'].analyzer, 'peliasAdmin');
       t.equal(prop[field+'_id'].type, 'string');
-      t.equal(prop[field+'_id'].index_analyzer, 'keyword');
-      t.equal(prop[field+'_id'].search_analyzer, 'keyword');
+      t.equal(prop[field+'_id'].analyzer, 'keyword');
       t.end();
     });
   });

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -1591,7 +1591,7 @@
             "match_mapping_type": "string",
             "mapping": {
               "type": "string",
-              "analyzer": "peliasTwoEdgeGram",
+              "analyzer": "peliasOneEdgeGram",
               "fielddata": {
                 "format": "fst",
                 "loading": "eager_global_ordinals"

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -1357,14 +1357,12 @@
       "properties": {
         "source": {
           "type": "string",
-          "index_analyzer": "keyword",
-          "search_analyzer": "keyword",
+          "analyzer": "keyword",
           "store": "yes"
         },
         "layer": {
           "type": "string",
-          "index_analyzer": "keyword",
-          "search_analyzer": "keyword",
+          "analyzer": "keyword",
           "store": "yes"
         },
         "alpha3": {
@@ -1386,23 +1384,19 @@
           "properties": {
             "name": {
               "type": "string",
-              "index_analyzer": "keyword",
-              "search_analyzer": "keyword"
+              "analyzer": "keyword"
             },
             "number": {
               "type": "string",
-              "index_analyzer": "peliasHousenumber",
-              "search_analyzer": "peliasHousenumber"
+              "analyzer": "peliasHousenumber"
             },
             "street": {
               "type": "string",
-              "index_analyzer": "peliasStreet",
-              "search_analyzer": "peliasStreet"
+              "analyzer": "peliasStreet"
             },
             "zip": {
               "type": "string",
-              "index_analyzer": "peliasZip",
-              "search_analyzer": "peliasZip"
+              "analyzer": "peliasZip"
             }
           }
         },
@@ -1457,8 +1451,7 @@
             },
             "country_id": {
               "type": "string",
-              "index_analyzer": "keyword",
-              "search_analyzer": "keyword",
+              "analyzer": "keyword",
               "store": "yes"
             },
             "region": {
@@ -1473,8 +1466,7 @@
             },
             "region_id": {
               "type": "string",
-              "index_analyzer": "keyword",
-              "search_analyzer": "keyword",
+              "analyzer": "keyword",
               "store": "yes"
             },
             "county": {
@@ -1489,8 +1481,7 @@
             },
             "county_id": {
               "type": "string",
-              "index_analyzer": "keyword",
-              "search_analyzer": "keyword",
+              "analyzer": "keyword",
               "store": "yes"
             },
             "locality": {
@@ -1505,8 +1496,7 @@
             },
             "locality_id": {
               "type": "string",
-              "index_analyzer": "keyword",
-              "search_analyzer": "keyword",
+              "analyzer": "keyword",
               "store": "yes"
             },
             "localadmin": {
@@ -1521,8 +1511,7 @@
             },
             "localadmin_id": {
               "type": "string",
-              "index_analyzer": "keyword",
-              "search_analyzer": "keyword",
+              "analyzer": "keyword",
               "store": "yes"
             },
             "neighbourhood": {
@@ -1537,8 +1526,7 @@
             },
             "neighbourhood_id": {
               "type": "string",
-              "index_analyzer": "keyword",
-              "search_analyzer": "keyword",
+              "analyzer": "keyword",
               "store": "yes"
             }
           }
@@ -1565,14 +1553,12 @@
         },
         "source_id": {
           "type": "string",
-          "index_analyzer": "keyword",
-          "search_analyzer": "keyword",
+          "analyzer": "keyword",
           "store": "yes"
         },
         "category": {
           "type": "string",
-          "index_analyzer": "keyword",
-          "search_analyzer": "keyword",
+          "analyzer": "keyword",
           "store": "yes"
         },
         "population": {
@@ -1627,14 +1613,12 @@
       "properties": {
         "source": {
           "type": "string",
-          "index_analyzer": "keyword",
-          "search_analyzer": "keyword",
+          "analyzer": "keyword",
           "store": "yes"
         },
         "layer": {
           "type": "string",
-          "index_analyzer": "keyword",
-          "search_analyzer": "keyword",
+          "analyzer": "keyword",
           "store": "yes"
         },
         "alpha3": {
@@ -1656,23 +1640,19 @@
           "properties": {
             "name": {
               "type": "string",
-              "index_analyzer": "keyword",
-              "search_analyzer": "keyword"
+              "analyzer": "keyword"
             },
             "number": {
               "type": "string",
-              "index_analyzer": "peliasHousenumber",
-              "search_analyzer": "peliasHousenumber"
+              "analyzer": "peliasHousenumber"
             },
             "street": {
               "type": "string",
-              "index_analyzer": "peliasStreet",
-              "search_analyzer": "peliasStreet"
+              "analyzer": "peliasStreet"
             },
             "zip": {
               "type": "string",
-              "index_analyzer": "peliasZip",
-              "search_analyzer": "peliasZip"
+              "analyzer": "peliasZip"
             }
           }
         },
@@ -1727,8 +1707,7 @@
             },
             "country_id": {
               "type": "string",
-              "index_analyzer": "keyword",
-              "search_analyzer": "keyword",
+              "analyzer": "keyword",
               "store": "yes"
             },
             "region": {
@@ -1743,8 +1722,7 @@
             },
             "region_id": {
               "type": "string",
-              "index_analyzer": "keyword",
-              "search_analyzer": "keyword",
+              "analyzer": "keyword",
               "store": "yes"
             },
             "county": {
@@ -1759,8 +1737,7 @@
             },
             "county_id": {
               "type": "string",
-              "index_analyzer": "keyword",
-              "search_analyzer": "keyword",
+              "analyzer": "keyword",
               "store": "yes"
             },
             "locality": {
@@ -1775,8 +1752,7 @@
             },
             "locality_id": {
               "type": "string",
-              "index_analyzer": "keyword",
-              "search_analyzer": "keyword",
+              "analyzer": "keyword",
               "store": "yes"
             },
             "localadmin": {
@@ -1791,8 +1767,7 @@
             },
             "localadmin_id": {
               "type": "string",
-              "index_analyzer": "keyword",
-              "search_analyzer": "keyword",
+              "analyzer": "keyword",
               "store": "yes"
             },
             "neighbourhood": {
@@ -1807,8 +1782,7 @@
             },
             "neighbourhood_id": {
               "type": "string",
-              "index_analyzer": "keyword",
-              "search_analyzer": "keyword",
+              "analyzer": "keyword",
               "store": "yes"
             }
           }
@@ -1835,14 +1809,12 @@
         },
         "source_id": {
           "type": "string",
-          "index_analyzer": "keyword",
-          "search_analyzer": "keyword",
+          "analyzer": "keyword",
           "store": "yes"
         },
         "category": {
           "type": "string",
-          "index_analyzer": "keyword",
-          "search_analyzer": "keyword",
+          "analyzer": "keyword",
           "store": "yes"
         },
         "population": {

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -1593,7 +1593,6 @@
               "type": "string",
               "analyzer": "peliasOneEdgeGram",
               "fielddata": {
-                "format": "fst",
                 "loading": "eager_global_ordinals"
               }
             }
@@ -1864,7 +1863,6 @@
               "type": "string",
               "analyzer": "peliasOneEdgeGram",
               "fielddata": {
-                "format": "fst",
                 "loading": "eager_global_ordinals"
               }
             }

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -1625,6 +1625,236 @@
       "dynamic": "true"
     },
     "country": {
+      "properties": {
+        "source": {
+          "type": "string",
+          "index_analyzer": "keyword",
+          "search_analyzer": "keyword",
+          "store": "yes"
+        },
+        "layer": {
+          "type": "string",
+          "index_analyzer": "keyword",
+          "search_analyzer": "keyword",
+          "store": "yes"
+        },
+        "alpha3": {
+          "type": "string",
+          "analyzer": "peliasAdmin",
+          "store": "yes"
+        },
+        "name": {
+          "type": "object",
+          "dynamic": true
+        },
+        "phrase": {
+          "type": "object",
+          "dynamic": true
+        },
+        "address": {
+          "type": "object",
+          "dynamic": true,
+          "properties": {
+            "name": {
+              "type": "string",
+              "index_analyzer": "keyword",
+              "search_analyzer": "keyword"
+            },
+            "number": {
+              "type": "string",
+              "index_analyzer": "peliasHousenumber",
+              "search_analyzer": "peliasHousenumber"
+            },
+            "street": {
+              "type": "string",
+              "index_analyzer": "peliasStreet",
+              "search_analyzer": "peliasStreet"
+            },
+            "zip": {
+              "type": "string",
+              "index_analyzer": "peliasZip",
+              "search_analyzer": "peliasZip"
+            }
+          }
+        },
+        "admin0": {
+          "type": "string",
+          "analyzer": "peliasAdmin",
+          "store": "yes"
+        },
+        "admin1": {
+          "type": "string",
+          "analyzer": "peliasAdmin",
+          "store": "yes"
+        },
+        "admin1_abbr": {
+          "type": "string",
+          "analyzer": "peliasAdmin",
+          "store": "yes"
+        },
+        "admin2": {
+          "type": "string",
+          "analyzer": "peliasAdmin",
+          "store": "yes"
+        },
+        "local_admin": {
+          "type": "string",
+          "analyzer": "peliasAdmin",
+          "store": "yes"
+        },
+        "locality": {
+          "type": "string",
+          "analyzer": "peliasAdmin",
+          "store": "yes"
+        },
+        "neighborhood": {
+          "type": "string",
+          "analyzer": "peliasAdmin",
+          "store": "yes"
+        },
+        "parent": {
+          "type": "object",
+          "dynamic": true,
+          "properties": {
+            "country": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "country_abbr": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "country_id": {
+              "type": "string",
+              "index_analyzer": "keyword",
+              "search_analyzer": "keyword",
+              "store": "yes"
+            },
+            "region": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "region_abbr": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "region_id": {
+              "type": "string",
+              "index_analyzer": "keyword",
+              "search_analyzer": "keyword",
+              "store": "yes"
+            },
+            "county": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "county_abbr": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "county_id": {
+              "type": "string",
+              "index_analyzer": "keyword",
+              "search_analyzer": "keyword",
+              "store": "yes"
+            },
+            "locality": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "locality_abbr": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "locality_id": {
+              "type": "string",
+              "index_analyzer": "keyword",
+              "search_analyzer": "keyword",
+              "store": "yes"
+            },
+            "localadmin": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "localadmin_abbr": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "localadmin_id": {
+              "type": "string",
+              "index_analyzer": "keyword",
+              "search_analyzer": "keyword",
+              "store": "yes"
+            },
+            "neighbourhood": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "neighbourhood_abbr": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "neighbourhood_id": {
+              "type": "string",
+              "index_analyzer": "keyword",
+              "search_analyzer": "keyword",
+              "store": "yes"
+            }
+          }
+        },
+        "center_point": {
+          "type": "geo_point",
+          "lat_lon": true,
+          "geohash": true,
+          "geohash_prefix": true,
+          "geohash_precision": 18,
+          "fielddata": {
+            "loading": "eager_global_ordinals"
+          }
+        },
+        "shape": {
+          "type": "geo_shape",
+          "tree": "quadtree",
+          "tree_levels": "20"
+        },
+        "bounding_box": {
+          "type": "string",
+          "index": "no",
+          "store": "yes"
+        },
+        "source_id": {
+          "type": "string",
+          "index_analyzer": "keyword",
+          "search_analyzer": "keyword",
+          "store": "yes"
+        },
+        "category": {
+          "type": "string",
+          "index_analyzer": "keyword",
+          "search_analyzer": "keyword",
+          "store": "yes"
+        },
+        "population": {
+          "type": "long",
+          "null_value": 0
+        },
+        "popularity": {
+          "type": "long",
+          "null_value": 0
+        }
+      },
       "dynamic_templates": [
         {
           "nameGram": {
@@ -1639,98 +1869,31 @@
               }
             }
           }
-        }
-      ]
-    },
-    "region": {
-      "dynamic_templates": [
+        },
         {
-          "nameGram": {
-            "path_match": "name.*",
+          "phrase": {
+            "path_match": "phrase.*",
             "match_mapping_type": "string",
             "mapping": {
               "type": "string",
-              "analyzer": "peliasOneEdgeGram",
+              "analyzer": "peliasPhrase",
               "fielddata": {
-                "format": "fst",
                 "loading": "eager_global_ordinals"
               }
             }
           }
         }
-      ]
-    },
-    "county": {
-      "dynamic_templates": [
-        {
-          "nameGram": {
-            "path_match": "name.*",
-            "match_mapping_type": "string",
-            "mapping": {
-              "type": "string",
-              "analyzer": "peliasOneEdgeGram",
-              "fielddata": {
-                "format": "fst",
-                "loading": "eager_global_ordinals"
-              }
-            }
-          }
-        }
-      ]
-    },
-    "admin0": {
-      "dynamic_templates": [
-        {
-          "nameGram": {
-            "path_match": "name.*",
-            "match_mapping_type": "string",
-            "mapping": {
-              "type": "string",
-              "analyzer": "peliasOneEdgeGram",
-              "fielddata": {
-                "format": "fst",
-                "loading": "eager_global_ordinals"
-              }
-            }
-          }
-        }
-      ]
-    },
-    "admin1": {
-      "dynamic_templates": [
-        {
-          "nameGram": {
-            "path_match": "name.*",
-            "match_mapping_type": "string",
-            "mapping": {
-              "type": "string",
-              "analyzer": "peliasOneEdgeGram",
-              "fielddata": {
-                "format": "fst",
-                "loading": "eager_global_ordinals"
-              }
-            }
-          }
-        }
-      ]
-    },
-    "admin2": {
-      "dynamic_templates": [
-        {
-          "nameGram": {
-            "path_match": "name.*",
-            "match_mapping_type": "string",
-            "mapping": {
-              "type": "string",
-              "analyzer": "peliasOneEdgeGram",
-              "fielddata": {
-                "format": "fst",
-                "loading": "eager_global_ordinals"
-              }
-            }
-          }
-        }
-      ]
+      ],
+      "_source": {
+        "excludes": [
+          "shape",
+          "phrase"
+        ]
+      },
+      "_all": {
+        "enabled": false
+      },
+      "dynamic": "true"
     }
   }
 }

--- a/test/partial-literal.js
+++ b/test/partial-literal.js
@@ -29,8 +29,7 @@ module.exports.tests.store = function(test, common) {
 // do not perform analysis on categories
 module.exports.tests.analysis = function(test, common) {
   test('index analysis', function(t) {
-    t.equal(schema.index_analyzer, 'keyword', 'should be keyword');
-    t.equal(schema.search_analyzer, 'keyword', 'should be keyword');
+    t.equal(schema.analyzer, 'keyword', 'should be keyword');
     t.end();
   });
 };


### PR DESCRIPTION
After Elasticon last week I spent an hour or so trying out Elasticsearch 2.2 on my machine. There were only a few changes to be made, and for the most part they are fairly trivial.

There is one exception: as detailed in [3fa56ef](https://github.com/pelias/schema/commit/3fa56ef695705bec1563ef749fd6d0680f6f4738), we can't use different mappings on fields of the same name in different types. This is extremely unfortunate for us, since we currently use the peliasOneEdgeGram analyzer in mappings for city, country, region, and other admin fields where we want autocomplete to perform really well, but the peliasTwoEdgeGram analyzer in mappings for all other _types.

We can't do this anymore so I've made this PR switch everythithing to peliasOneEdgeGram. This might increase our index size a bit and more importantly, will reduce query performance since the number of documents for each of the 1 character n-grams will be huge, and Elasticsearch will have to score all of them.

Before this is merged I intend to do some analysis of index size and search performance. We probably want to take another look at the [completion suggester](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters-completion.html) again, since in 2.x it supports better geo flitering than 1.x.

Fixes #106