### PR TITLE
add address_suffix_expansion to peliasOneEdgeGram analysis, add tests

### DIFF
--- a/integration/analyzer_peliasOneEdgeGram.js
+++ b/integration/analyzer_peliasOneEdgeGram.js
@@ -49,6 +49,35 @@ module.exports.tests.analyze = function(test, common){
   });
 };
 
+// address suffix expansions should only performed in a way that is
+// safe for 'partial tokens'.
+module.exports.tests.address_suffix_expansions = function(test, common){
+  test( 'address suffix expansions', function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+    var assertAnalysis = analyze.bind( null, suite, t, 'peliasOneEdgeGram' );
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
+
+    assertAnalysis( 'safe expansions', 'aly', [
+      'a', 'al', 'all', 'alle', 'alley'
+    ]);
+
+    assertAnalysis( 'safe expansions', 'xing', [
+      'c', 'cr', 'cro', 'cros', 'cross', 'crossi', 'crossin', 'crossing'
+    ]);
+
+    assertAnalysis( 'safe expansions', 'rd', [
+      'r', 'ro', 'roa', 'road'
+    ]);
+
+    assertAnalysis( 'unsafe expansion', 'ct st', [
+      'c', 'ct', 's', 'st'
+    ]);
+
+    suite.run( t.end );
+  });
+};
+
 // stop words should be disabled so that the entire street prefix is indexed as ngrams
 module.exports.tests.stop_words = function(test, common){
   test( 'stop words', function(t){

--- a/integration/analyzer_peliasTwoEdgeGram.js
+++ b/integration/analyzer_peliasTwoEdgeGram.js
@@ -57,6 +57,35 @@ module.exports.tests.analyze = function(test, common){
   });
 };
 
+// address suffix expansions should only performed in a way that is
+// safe for 'partial tokens'.
+module.exports.tests.address_suffix_expansions = function(test, common){
+  test( 'address suffix expansions', function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+    var assertAnalysis = analyze.bind( null, suite, t, 'peliasTwoEdgeGram' );
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
+
+    assertAnalysis( 'safe expansions', 'aly', [
+      'al', 'all', 'alle', 'alley'
+    ]);
+
+    assertAnalysis( 'safe expansions', 'xing', [
+      'cr', 'cro', 'cros', 'cross', 'crossi', 'crossin', 'crossing'
+    ]);
+
+    assertAnalysis( 'safe expansions', 'rd', [
+      'ro', 'roa', 'road'
+    ]);
+
+    assertAnalysis( 'unsafe expansion', 'ct st', [
+      'ct', 'st'
+    ]);
+
+    suite.run( t.end );
+  });
+};
+
 // stop words should be disabled so that the entire street prefix is indexed as ngrams
 module.exports.tests.stop_words = function(test, common){
   test( 'stop words', function(t){

--- a/settings.js
+++ b/settings.js
@@ -33,6 +33,7 @@ function generate(){
             "lowercase",
             "asciifolding",
             "trim",
+            "address_suffix_expansion",
             "ampersand",
             "removeAllZeroNumericPrefix",
             "kstem",

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -26,6 +26,7 @@
             "lowercase",
             "asciifolding",
             "trim",
+            "address_suffix_expansion",
             "ampersand",
             "removeAllZeroNumericPrefix",
             "kstem",

--- a/test/settings.js
+++ b/test/settings.js
@@ -61,6 +61,7 @@ module.exports.tests.peliasOneEdgeGramAnalyzer = function(test, common) {
       "lowercase",
       "asciifolding",
       "trim",
+      "address_suffix_expansion",
       "ampersand",
       "removeAllZeroNumericPrefix",
       "kstem",


### PR DESCRIPTION
pretty straight forward, this PR adds the existing `address_suffix_expansion` filter to the `peliasOneEdgeGram` analyzer.

the motivation comes from using the `peliasOneEdgeGram` as our default search analyzer so it's best if it works well when used against and index created using `peliasTwoEdgeGram`