### PR TITLE
Refactor autocomplete analysis

### DIFF
--- a/integration/analyzer_peliasIndexOneEdgeGram.js
+++ b/integration/analyzer_peliasIndexOneEdgeGram.js
@@ -1,0 +1,153 @@
+
+// validate analyzer is behaving as expected
+
+var tape = require('tape'),
+    elastictest = require('elastictest'),
+    schema = require('../schema'),
+    punctuation = require('../punctuation');
+
+module.exports.tests = {};
+
+module.exports.tests.analyze = function(test, common){
+  test( 'analyze', function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+    var assertAnalysis = analyze.bind( null, suite, t, 'peliasIndexOneEdgeGram' );
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
+
+    assertAnalysis( 'lowercase', 'F', ['f']);
+    assertAnalysis( 'asciifolding', 'é', ['e']);
+    assertAnalysis( 'asciifolding', 'ß', ['s','ss']);
+    assertAnalysis( 'asciifolding', 'æ', ['a','ae']);
+    assertAnalysis( 'asciifolding', 'ł', ['l']);
+    assertAnalysis( 'asciifolding', 'ɰ', ['m']);
+    assertAnalysis( 'trim', ' f ', ['f'] );
+    assertAnalysis( 'ampersand', 'a and b', ['a','&','b'] );
+    assertAnalysis( 'ampersand', 'a & b', ['a','&','b'] );
+    assertAnalysis( 'ampersand', 'a and & and b', ['a','&','b'] );
+    assertAnalysis( 'ampersand', 'land', ['l','la','lan','land'] ); // should not replace inside tokens
+    assertAnalysis( 'peliasIndexOneEdgeGramFilter', '1 a ab abc abcdefghij', ['1','a','ab','abc','abcd','abcde','abcdef','abcdefg','abcdefgh','abcdefghi','abcdefghij'] );
+    assertAnalysis( 'removeAllZeroNumericPrefix', '00001', ['1'] );
+    assertAnalysis( 'unique', '1 1 1', ['1'] );
+    assertAnalysis( 'notnull', ' / / ', [] );
+
+    assertAnalysis( 'kstem', 'mcdonalds', ['m', 'mc', 'mcd', 'mcdo', 'mcdon', 'mcdona', 'mcdonal', 'mcdonald'] );
+    assertAnalysis( 'kstem', 'McDonald\'s', ['m', 'mc', 'mcd', 'mcdo', 'mcdon', 'mcdona', 'mcdonal', 'mcdonald'] );
+    assertAnalysis( 'kstem', 'peoples', ['p', 'pe', 'peo', 'peop', 'peopl', 'people'] );
+
+    // remove punctuation (handled by the char_filter)
+    assertAnalysis( 'punctuation', punctuation.all.join(''), ['-','-&'] );
+
+    // ensure that very large grams are created
+    assertAnalysis( 'largeGrams', 'grolmanstrasse', [
+      'g','gr','gro','grol','grolm','grolma','grolman','grolmans','grolmanst',
+      'grolmanstr','grolmanstra','grolmanstras','grolmanstrass',
+      'grolmanstrasse'
+    ]);
+
+    suite.run( t.end );
+  });
+};
+
+// address suffix expansions should only performed in a way that is
+// safe for 'partial tokens'.
+module.exports.tests.address_suffix_expansions = function(test, common){
+  test( 'address suffix expansions', function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+    var assertAnalysis = analyze.bind( null, suite, t, 'peliasIndexOneEdgeGram' );
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
+
+    assertAnalysis( 'safe expansions', 'aly', [
+      'a', 'al', 'all', 'alle', 'alley'
+    ]);
+
+    assertAnalysis( 'safe expansions', 'xing', [
+      'c', 'cr', 'cro', 'cros', 'cross', 'crossi', 'crossin', 'crossing'
+    ]);
+
+    assertAnalysis( 'safe expansions', 'rd', [
+      'r', 'ro', 'roa', 'road'
+    ]);
+
+    assertAnalysis( 'unsafe expansion', 'ct st', [
+      'c', 'ct', 's', 'st'
+    ]);
+
+    suite.run( t.end );
+  });
+};
+
+// stop words should be disabled so that the entire street prefix is indexed as ngrams
+module.exports.tests.stop_words = function(test, common){
+  test( 'stop words', function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+    var assertAnalysis = analyze.bind( null, suite, t, 'peliasIndexOneEdgeGram' );
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
+
+    assertAnalysis( 'street suffix', 'AB street', [
+      'a', 'ab', 's', 'st', 'str', 'stre', 'stree', 'street'
+    ]);
+
+    assertAnalysis( 'street suffix (abbreviation)', 'AB st', [
+      'a', 'ab', 's', 'st'
+    ]);
+
+    suite.run( t.end );
+  });
+};
+
+module.exports.tests.functional = function(test, common){
+  test( 'functional', function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+    var assertAnalysis = analyze.bind( null, suite, t, 'peliasIndexOneEdgeGram' );
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
+
+    assertAnalysis( 'country', 'Trinidad and Tobago', [
+      't', 'tr', 'tri', 'trin', 'trini', 'trinid', 'trinida', 'trinidad', '&', 'to', 'tob', 'toba', 'tobag', 'tobago'
+    ]);
+
+    assertAnalysis( 'place', 'Toys "R" Us!', [
+      't', 'to', 'toy', 'r', 'u', 'us'
+    ]);
+
+    assertAnalysis( 'address', '101 mapzen place', [
+      '1', '10', '101', 'm', 'ma', 'map', 'mapz', 'mapze', 'mapzen', 'p', 'pl', 'pla', 'plac', 'place'
+    ]);
+
+    suite.run( t.end );
+  });
+};
+
+module.exports.all = function (tape, common) {
+
+  function test(name, testFunction) {
+    return tape('peliasIndexOneEdgeGram: ' + name, testFunction);
+  }
+
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};
+
+function analyze( suite, t, analyzer, comment, text, expected ){
+  suite.assert( function( done ){
+    suite.client.indices.analyze({
+      index: suite.props.index,
+      analyzer: analyzer,
+      text: text
+    }, function( err, res ){
+      if( err ) console.error( err );
+      t.deepEqual( simpleTokens( res.tokens ), expected, comment );
+      done();
+    });
+  });
+}
+
+function simpleTokens( tokens ){
+  return tokens.map( function( t ){
+    return t.token;
+  });
+}

--- a/integration/analyzer_peliasIndexOneEdgeGram.js
+++ b/integration/analyzer_peliasIndexOneEdgeGram.js
@@ -16,7 +16,7 @@ module.exports.tests.analyze = function(test, common){
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     assertAnalysis( 'lowercase', 'F', ['f']);
-    assertAnalysis( 'asciifolding', 'é', ['e']);
+    assertAnalysis( 'asciifolding', 'á', ['a']);
     assertAnalysis( 'asciifolding', 'ß', ['s','ss']);
     assertAnalysis( 'asciifolding', 'æ', ['a','ae']);
     assertAnalysis( 'asciifolding', 'ł', ['l']);
@@ -26,6 +26,11 @@ module.exports.tests.analyze = function(test, common){
     assertAnalysis( 'ampersand', 'a & b', ['a','&','b'] );
     assertAnalysis( 'ampersand', 'a and & and b', ['a','&','b'] );
     assertAnalysis( 'ampersand', 'land', ['l','la','lan','land'] ); // should not replace inside tokens
+
+    // full_token_address_suffix_expansion
+    assertAnalysis( 'full_token_address_suffix_expansion', 'rd', ['r','ro','roa','road'] );
+    assertAnalysis( 'full_token_address_suffix_expansion', 'ctr', ['c','ce','cen','cent','cente','center'] );
+
     assertAnalysis( 'peliasIndexOneEdgeGramFilter', '1 a ab abc abcdefghij', ['1','a','ab','abc','abcd','abcde','abcdef','abcdefg','abcdefgh','abcdefghi','abcdefghij'] );
     assertAnalysis( 'removeAllZeroNumericPrefix', '00001', ['1'] );
     assertAnalysis( 'unique', '1 1 1', ['1'] );

--- a/integration/analyzer_peliasIndexTwoEdgeGram.js
+++ b/integration/analyzer_peliasIndexTwoEdgeGram.js
@@ -12,7 +12,7 @@ module.exports.tests.analyze = function(test, common){
   test( 'analyze', function(t){
 
     var suite = new elastictest.Suite( null, { schema: schema } );
-    var assertAnalysis = analyze.bind( null, suite, t, 'peliasTwoEdgeGram' );
+    var assertAnalysis = analyze.bind( null, suite, t, 'peliasIndexTwoEdgeGram' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     assertAnalysis( 'lowercase', 'FA', ['fa']);
@@ -31,7 +31,7 @@ module.exports.tests.analyze = function(test, common){
     // assertAnalysis( 'ampersand', 'aa & bb', ['aa','&','bb'] );
     // assertAnalysis( 'ampersand', 'aa and & and bb', ['aa','&','bb'] );
 
-    assertAnalysis( 'peliasTwoEdgeGramFilter', '1 a ab abc abcdefghij', ['ab','abc','abcd','abcde','abcdef','abcdefg','abcdefgh','abcdefghi','abcdefghij'] );
+    assertAnalysis( 'peliasIndexTwoEdgeGramFilter', '1 a ab abc abcdefghij', ['ab','abc','abcd','abcde','abcdef','abcdefg','abcdefgh','abcdefghi','abcdefghij'] );
     assertAnalysis( 'removeAllZeroNumericPrefix', '0002 00011', ['11'] );
     assertAnalysis( 'unique', '11 11 11', ['11'] );
     assertAnalysis( 'notnull', ' / / ', [] );
@@ -63,7 +63,7 @@ module.exports.tests.address_suffix_expansions = function(test, common){
   test( 'address suffix expansions', function(t){
 
     var suite = new elastictest.Suite( null, { schema: schema } );
-    var assertAnalysis = analyze.bind( null, suite, t, 'peliasTwoEdgeGram' );
+    var assertAnalysis = analyze.bind( null, suite, t, 'peliasIndexTwoEdgeGram' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     assertAnalysis( 'safe expansions', 'aly', [
@@ -91,7 +91,7 @@ module.exports.tests.stop_words = function(test, common){
   test( 'stop words', function(t){
 
     var suite = new elastictest.Suite( null, { schema: schema } );
-    var assertAnalysis = analyze.bind( null, suite, t, 'peliasTwoEdgeGram' );
+    var assertAnalysis = analyze.bind( null, suite, t, 'peliasIndexTwoEdgeGram' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     assertAnalysis( 'street suffix', 'AB street', [
@@ -110,7 +110,7 @@ module.exports.tests.functional = function(test, common){
   test( 'functional', function(t){
 
     var suite = new elastictest.Suite( null, { schema: schema } );
-    var assertAnalysis = analyze.bind( null, suite, t, 'peliasTwoEdgeGram' );
+    var assertAnalysis = analyze.bind( null, suite, t, 'peliasIndexTwoEdgeGram' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     assertAnalysis( 'country', 'Trinidad and Tobago', [
@@ -134,7 +134,7 @@ module.exports.tests.functional = function(test, common){
   test( 'address suffix expansion', function(t){
 
     var suite = new elastictest.Suite( null, { schema: schema } );
-    var assertAnalysis = analyze.bind( null, suite, t, 'peliasTwoEdgeGram' );
+    var assertAnalysis = analyze.bind( null, suite, t, 'peliasIndexTwoEdgeGram' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     assertAnalysis( 'street', 'FOO rd', [
@@ -152,7 +152,7 @@ module.exports.tests.functional = function(test, common){
 module.exports.all = function (tape, common) {
 
   function test(name, testFunction) {
-    return tape('peliasTwoEdgeGram: ' + name, testFunction);
+    return tape('peliasIndexTwoEdgeGram: ' + name, testFunction);
   }
 
   for( var testCase in module.exports.tests ){

--- a/integration/analyzer_peliasIndexTwoEdgeGram.js
+++ b/integration/analyzer_peliasIndexTwoEdgeGram.js
@@ -16,12 +16,17 @@ module.exports.tests.analyze = function(test, common){
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     assertAnalysis( 'lowercase', 'FA', ['fa']);
-    assertAnalysis( 'asciifolding', 'éA', ['ea']);
+    assertAnalysis( 'asciifolding', 'lé', ['le']);
     assertAnalysis( 'asciifolding', 'ß', ['ss']);
     assertAnalysis( 'asciifolding', 'æ', ['ae']);
     assertAnalysis( 'asciifolding', 'łA', ['la']);
     assertAnalysis( 'asciifolding', 'ɰA', ['ma']);
     assertAnalysis( 'trim', ' fA ', ['fa'] );
+
+    // full_token_address_suffix_expansion
+    assertAnalysis( 'full_token_address_suffix_expansion', 'rd', ['ro','roa','road'] );
+    assertAnalysis( 'full_token_address_suffix_expansion', 'ctr', ['ce','cen','cent','cente','center'] );
+
     assertAnalysis( 'ampersand', 'aa and bb', ['aa','bb'] );
     assertAnalysis( 'ampersand', 'land', ['la','lan','land'] ); // should not replace inside tokens
 
@@ -45,6 +50,12 @@ module.exports.tests.analyze = function(test, common){
 
     // ensure that single grams are not created
     assertAnalysis( '1grams', 'a aa b bb 1 11', ['aa','bb','11'] );
+
+    // for directionals (north/south/east/west) we allow single grams
+    assertAnalysis( 'direction_synonym_contraction_keep_original', 'a', [] );
+    assertAnalysis( 'direction_synonym_contraction_keep_original', 'n', ['no','nor','nort','north','n'] );
+    // note the single gram created below
+    assertAnalysis( 'direction_synonym_contraction_keep_original', 'north', ['no','nor','nort','north','n'] );
 
     // ensure that very large grams are created
     assertAnalysis( 'largeGrams', 'grolmanstrasse', [

--- a/integration/analyzer_peliasQueryFullToken.js
+++ b/integration/analyzer_peliasQueryFullToken.js
@@ -16,7 +16,7 @@ module.exports.tests.analyze = function(test, common){
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     assertAnalysis( 'lowercase', 'F', ['f']);
-    assertAnalysis( 'asciifolding', 'é', ['e']);
+    assertAnalysis( 'asciifolding', 'á', ['a']);
     assertAnalysis( 'asciifolding', 'ß', ['ss']);
     assertAnalysis( 'asciifolding', 'æ', ['ae']);
     assertAnalysis( 'asciifolding', 'ł', ['l']);
@@ -26,6 +26,11 @@ module.exports.tests.analyze = function(test, common){
     assertAnalysis( 'ampersand', 'a & b', ['a','&','b'] );
     assertAnalysis( 'ampersand', 'a and & and b', ['a','&','b'] );
     assertAnalysis( 'ampersand', 'land', ['land'] ); // should not replace inside tokens
+
+    // full_token_address_suffix_expansion
+    assertAnalysis( 'full_token_address_suffix_expansion', 'rd', ['road'] );
+    assertAnalysis( 'full_token_address_suffix_expansion', 'ctr', ['center'] );
+
     assertAnalysis( 'peliasQueryFullTokenFilter', '1 a ab abc abcdefghij', ['1','a','ab','abc','abcdefghij'] );
     assertAnalysis( 'removeAllZeroNumericPrefix', '00001', ['1'] );
     assertAnalysis( 'unique', '1 1 1', ['1'] );

--- a/integration/analyzer_peliasQueryFullToken.js
+++ b/integration/analyzer_peliasQueryFullToken.js
@@ -12,38 +12,34 @@ module.exports.tests.analyze = function(test, common){
   test( 'analyze', function(t){
 
     var suite = new elastictest.Suite( null, { schema: schema } );
-    var assertAnalysis = analyze.bind( null, suite, t, 'peliasOneEdgeGram' );
+    var assertAnalysis = analyze.bind( null, suite, t, 'peliasQueryFullToken' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     assertAnalysis( 'lowercase', 'F', ['f']);
     assertAnalysis( 'asciifolding', 'é', ['e']);
-    assertAnalysis( 'asciifolding', 'ß', ['s','ss']);
-    assertAnalysis( 'asciifolding', 'æ', ['a','ae']);
+    assertAnalysis( 'asciifolding', 'ß', ['ss']);
+    assertAnalysis( 'asciifolding', 'æ', ['ae']);
     assertAnalysis( 'asciifolding', 'ł', ['l']);
     assertAnalysis( 'asciifolding', 'ɰ', ['m']);
     assertAnalysis( 'trim', ' f ', ['f'] );
     assertAnalysis( 'ampersand', 'a and b', ['a','&','b'] );
     assertAnalysis( 'ampersand', 'a & b', ['a','&','b'] );
     assertAnalysis( 'ampersand', 'a and & and b', ['a','&','b'] );
-    assertAnalysis( 'ampersand', 'land', ['l','la','lan','land'] ); // should not replace inside tokens
-    assertAnalysis( 'peliasOneEdgeGramFilter', '1 a ab abc abcdefghij', ['1','a','ab','abc','abcd','abcde','abcdef','abcdefg','abcdefgh','abcdefghi','abcdefghij'] );
+    assertAnalysis( 'ampersand', 'land', ['land'] ); // should not replace inside tokens
+    assertAnalysis( 'peliasQueryFullTokenFilter', '1 a ab abc abcdefghij', ['1','a','ab','abc','abcdefghij'] );
     assertAnalysis( 'removeAllZeroNumericPrefix', '00001', ['1'] );
     assertAnalysis( 'unique', '1 1 1', ['1'] );
     assertAnalysis( 'notnull', ' / / ', [] );
 
-    assertAnalysis( 'kstem', 'mcdonalds', ['m', 'mc', 'mcd', 'mcdo', 'mcdon', 'mcdona', 'mcdonal', 'mcdonald'] );
-    assertAnalysis( 'kstem', 'McDonald\'s', ['m', 'mc', 'mcd', 'mcdo', 'mcdon', 'mcdona', 'mcdonal', 'mcdonald'] );
-    assertAnalysis( 'kstem', 'peoples', ['p', 'pe', 'peo', 'peop', 'peopl', 'people'] );
+    assertAnalysis( 'kstem', 'mcdonalds', ['mcdonald'] );
+    assertAnalysis( 'kstem', 'McDonald\'s', ['mcdonald'] );
+    assertAnalysis( 'kstem', 'peoples', ['people'] );
 
     // remove punctuation (handled by the char_filter)
-    assertAnalysis( 'punctuation', punctuation.all.join(''), ['-','-&'] );
+    assertAnalysis( 'punctuation', punctuation.all.join(''), ['-&'] );
 
-    // ensure that very large grams are created
-    assertAnalysis( 'largeGrams', 'grolmanstrasse', [
-      'g','gr','gro','grol','grolm','grolma','grolman','grolmans','grolmanst',
-      'grolmanstr','grolmanstra','grolmanstras','grolmanstrass',
-      'grolmanstrasse'
-    ]);
+    // ensure that very large tokens are created
+    assertAnalysis( 'largeGrams', 'grolmanstrasse', [ 'grolmanstrasse' ]);
 
     suite.run( t.end );
   });
@@ -55,44 +51,32 @@ module.exports.tests.address_suffix_expansions = function(test, common){
   test( 'address suffix expansions', function(t){
 
     var suite = new elastictest.Suite( null, { schema: schema } );
-    var assertAnalysis = analyze.bind( null, suite, t, 'peliasOneEdgeGram' );
+    var assertAnalysis = analyze.bind( null, suite, t, 'peliasQueryFullToken' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
-    assertAnalysis( 'safe expansions', 'aly', [
-      'a', 'al', 'all', 'alle', 'alley'
-    ]);
+    assertAnalysis( 'safe expansions', 'aly', [ 'alley' ]);
 
-    assertAnalysis( 'safe expansions', 'xing', [
-      'c', 'cr', 'cro', 'cros', 'cross', 'crossi', 'crossin', 'crossing'
-    ]);
+    assertAnalysis( 'safe expansions', 'xing', [ 'crossing' ]);
 
-    assertAnalysis( 'safe expansions', 'rd', [
-      'r', 'ro', 'roa', 'road'
-    ]);
+    assertAnalysis( 'safe expansions', 'rd', [ 'road' ]);
 
-    assertAnalysis( 'unsafe expansion', 'ct st', [
-      'c', 'ct', 's', 'st'
-    ]);
+    assertAnalysis( 'unsafe expansion', 'ct st', [ 'ct', 'st' ]);
 
     suite.run( t.end );
   });
 };
 
-// stop words should be disabled so that the entire street prefix is indexed as ngrams
+// stop words should be disabled so that the entire token is used
 module.exports.tests.stop_words = function(test, common){
   test( 'stop words', function(t){
 
     var suite = new elastictest.Suite( null, { schema: schema } );
-    var assertAnalysis = analyze.bind( null, suite, t, 'peliasOneEdgeGram' );
+    var assertAnalysis = analyze.bind( null, suite, t, 'peliasQueryFullToken' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
-    assertAnalysis( 'street suffix', 'AB street', [
-      'a', 'ab', 's', 'st', 'str', 'stre', 'stree', 'street'
-    ]);
+    assertAnalysis( 'street suffix', 'AB street', [ 'ab', 'street' ]);
 
-    assertAnalysis( 'street suffix (abbreviation)', 'AB st', [
-      'a', 'ab', 's', 'st'
-    ]);
+    assertAnalysis( 'street suffix (abbreviation)', 'AB st', [ 'ab', 'st' ]);
 
     suite.run( t.end );
   });
@@ -102,19 +86,19 @@ module.exports.tests.functional = function(test, common){
   test( 'functional', function(t){
 
     var suite = new elastictest.Suite( null, { schema: schema } );
-    var assertAnalysis = analyze.bind( null, suite, t, 'peliasOneEdgeGram' );
+    var assertAnalysis = analyze.bind( null, suite, t, 'peliasQueryFullToken' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     assertAnalysis( 'country', 'Trinidad and Tobago', [
-      't', 'tr', 'tri', 'trin', 'trini', 'trinid', 'trinida', 'trinidad', '&', 'to', 'tob', 'toba', 'tobag', 'tobago'
+      'trinidad', '&', 'tobago'
     ]);
 
     assertAnalysis( 'place', 'Toys "R" Us!', [
-      't', 'to', 'toy', 'r', 'u', 'us'
+      'toy', 'r', 'us'
     ]);
 
     assertAnalysis( 'address', '101 mapzen place', [
-      '1', '10', '101', 'm', 'ma', 'map', 'mapz', 'mapze', 'mapzen', 'p', 'pl', 'pla', 'plac', 'place'
+      '101', 'mapzen', 'place'
     ]);
 
     suite.run( t.end );
@@ -124,7 +108,7 @@ module.exports.tests.functional = function(test, common){
 module.exports.all = function (tape, common) {
 
   function test(name, testFunction) {
-    return tape('peliasOneEdgeGram: ' + name, testFunction);
+    return tape('peliasQueryFullToken: ' + name, testFunction);
   }
 
   for( var testCase in module.exports.tests ){

--- a/integration/analyzer_peliasQueryPartialToken.js
+++ b/integration/analyzer_peliasQueryPartialToken.js
@@ -17,38 +17,34 @@ module.exports.tests.analyze = function(test, common){
 
     assertAnalysis( 'lowercase', 'F', ['f']);
     assertAnalysis( 'asciifolding', 'é', ['e']);
-    assertAnalysis( 'asciifolding', 'ß', ['s','ss']);
-    assertAnalysis( 'asciifolding', 'æ', ['a','ae']);
+    assertAnalysis( 'asciifolding', 'ß', ['ss']);
+    assertAnalysis( 'asciifolding', 'æ', ['ae']);
     assertAnalysis( 'asciifolding', 'ł', ['l']);
     assertAnalysis( 'asciifolding', 'ɰ', ['m']);
     assertAnalysis( 'trim', ' f ', ['f'] );
     assertAnalysis( 'ampersand', 'a and b', ['a','&','b'] );
     assertAnalysis( 'ampersand', 'a & b', ['a','&','b'] );
     assertAnalysis( 'ampersand', 'a and & and b', ['a','&','b'] );
-    assertAnalysis( 'ampersand', 'land', ['l','la','lan','land'] ); // should not replace inside tokens
+    assertAnalysis( 'ampersand', 'land', ['land'] ); // should not replace inside tokens
 
     // partial_token_address_suffix_expansion
-    assertAnalysis( 'partial_token_address_suffix_expansion', 'rd', ['r','ro','roa','road'] );
-    assertAnalysis( 'partial_token_address_suffix_expansion', 'ctr', ['c','ce','cen','cent','cente','center'] );
+    assertAnalysis( 'partial_token_address_suffix_expansion', 'rd', ['road'] );
+    assertAnalysis( 'partial_token_address_suffix_expansion', 'ctr', ['center'] );
 
-    assertAnalysis( 'peliasQueryPartialTokenFilter', '1 a ab abc abcdefghij', ['1','a','ab','abc','abcd','abcde','abcdef','abcdefg','abcdefgh','abcdefghi','abcdefghij'] );
+    assertAnalysis( 'peliasQueryPartialTokenFilter', '1 a ab abc abcdefghij', ['1','a','ab','abc','abcdefghij'] );
     assertAnalysis( 'removeAllZeroNumericPrefix', '00001', ['1'] );
     assertAnalysis( 'unique', '1 1 1', ['1'] );
     assertAnalysis( 'notnull', ' / / ', [] );
 
-    assertAnalysis( 'kstem', 'mcdonalds', ['m', 'mc', 'mcd', 'mcdo', 'mcdon', 'mcdona', 'mcdonal', 'mcdonald'] );
-    assertAnalysis( 'kstem', 'McDonald\'s', ['m', 'mc', 'mcd', 'mcdo', 'mcdon', 'mcdona', 'mcdonal', 'mcdonald'] );
-    assertAnalysis( 'kstem', 'peoples', ['p', 'pe', 'peo', 'peop', 'peopl', 'people'] );
+    assertAnalysis( 'kstem', 'mcdonalds', ['mcdonald'] );
+    assertAnalysis( 'kstem', 'McDonald\'s', ['mcdonald'] );
+    assertAnalysis( 'kstem', 'peoples', ['people'] );
 
     // remove punctuation (handled by the char_filter)
-    assertAnalysis( 'punctuation', punctuation.all.join(''), ['-','-&'] );
+    assertAnalysis( 'punctuation', punctuation.all.join(''), ['-&'] );
 
     // ensure that very large grams are created
-    assertAnalysis( 'largeGrams', 'grolmanstrasse', [
-      'g','gr','gro','grol','grolm','grolma','grolman','grolmans','grolmanst',
-      'grolmanstr','grolmanstra','grolmanstras','grolmanstrass',
-      'grolmanstrasse'
-    ]);
+    assertAnalysis( 'largeGrams', 'grolmanstrasse', ['grolmanstrasse']);
 
     suite.run( t.end );
   });
@@ -63,21 +59,11 @@ module.exports.tests.address_suffix_expansions = function(test, common){
     var assertAnalysis = analyze.bind( null, suite, t, 'peliasQueryPartialToken' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
-    assertAnalysis( 'safe expansions', 'aly', [
-      'a', 'al', 'all', 'alle', 'alley'
-    ]);
+    assertAnalysis( 'safe expansions', 'aly', [ 'alley' ]);
+    assertAnalysis( 'safe expansions', 'xing', [ 'crossing' ]);
+    assertAnalysis( 'safe expansions', 'rd', [ 'road' ]);
 
-    assertAnalysis( 'safe expansions', 'xing', [
-      'c', 'cr', 'cro', 'cros', 'cross', 'crossi', 'crossin', 'crossing'
-    ]);
-
-    assertAnalysis( 'safe expansions', 'rd', [
-      'r', 'ro', 'roa', 'road'
-    ]);
-
-    assertAnalysis( 'unsafe expansion', 'ct st', [
-      'c', 'ct', 's', 'st'
-    ]);
+    assertAnalysis( 'unsafe expansion', 'ct st', [ 'ct', 'st' ]);
 
     suite.run( t.end );
   });
@@ -91,13 +77,8 @@ module.exports.tests.stop_words = function(test, common){
     var assertAnalysis = analyze.bind( null, suite, t, 'peliasQueryPartialToken' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
-    assertAnalysis( 'street suffix', 'AB street', [
-      'a', 'ab', 's', 'st', 'str', 'stre', 'stree', 'street'
-    ]);
-
-    assertAnalysis( 'street suffix (abbreviation)', 'AB st', [
-      'a', 'ab', 's', 'st'
-    ]);
+    assertAnalysis( 'street suffix', 'AB street', [ 'ab', 'street' ]);
+    assertAnalysis( 'street suffix (abbreviation)', 'AB st', [ 'ab', 'st' ]);
 
     suite.run( t.end );
   });
@@ -110,17 +91,9 @@ module.exports.tests.functional = function(test, common){
     var assertAnalysis = analyze.bind( null, suite, t, 'peliasQueryPartialToken' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
-    assertAnalysis( 'country', 'Trinidad and Tobago', [
-      't', 'tr', 'tri', 'trin', 'trini', 'trinid', 'trinida', 'trinidad', '&', 'to', 'tob', 'toba', 'tobag', 'tobago'
-    ]);
-
-    assertAnalysis( 'place', 'Toys "R" Us!', [
-      't', 'to', 'toy', 'r', 'u', 'us'
-    ]);
-
-    assertAnalysis( 'address', '101 mapzen place', [
-      '1', '10', '101', 'm', 'ma', 'map', 'mapz', 'mapze', 'mapzen', 'p', 'pl', 'pla', 'plac', 'place'
-    ]);
+    assertAnalysis( 'country', 'Trinidad and Tobago', [ 'trinidad', '&', 'tobago' ]);
+    assertAnalysis( 'place', 'Toys "R" Us!', [ 'toy', 'r', 'us' ]);
+    assertAnalysis( 'address', '101 mapzen place', [ '101', 'mapzen', 'place' ]);
 
     suite.run( t.end );
   });

--- a/integration/analyzer_peliasQueryPartialToken.js
+++ b/integration/analyzer_peliasQueryPartialToken.js
@@ -26,6 +26,11 @@ module.exports.tests.analyze = function(test, common){
     assertAnalysis( 'ampersand', 'a & b', ['a','&','b'] );
     assertAnalysis( 'ampersand', 'a and & and b', ['a','&','b'] );
     assertAnalysis( 'ampersand', 'land', ['l','la','lan','land'] ); // should not replace inside tokens
+
+    // partial_token_address_suffix_expansion
+    assertAnalysis( 'partial_token_address_suffix_expansion', 'rd', ['r','ro','roa','road'] );
+    assertAnalysis( 'partial_token_address_suffix_expansion', 'ctr', ['c','ce','cen','cent','cente','center'] );
+
     assertAnalysis( 'peliasQueryPartialTokenFilter', '1 a ab abc abcdefghij', ['1','a','ab','abc','abcd','abcde','abcdef','abcdefg','abcdefgh','abcdefghi','abcdefghij'] );
     assertAnalysis( 'removeAllZeroNumericPrefix', '00001', ['1'] );
     assertAnalysis( 'unique', '1 1 1', ['1'] );

--- a/integration/analyzer_peliasQueryPartialToken.js
+++ b/integration/analyzer_peliasQueryPartialToken.js
@@ -1,0 +1,153 @@
+
+// validate analyzer is behaving as expected
+
+var tape = require('tape'),
+    elastictest = require('elastictest'),
+    schema = require('../schema'),
+    punctuation = require('../punctuation');
+
+module.exports.tests = {};
+
+module.exports.tests.analyze = function(test, common){
+  test( 'analyze', function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+    var assertAnalysis = analyze.bind( null, suite, t, 'peliasQueryPartialToken' );
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
+
+    assertAnalysis( 'lowercase', 'F', ['f']);
+    assertAnalysis( 'asciifolding', 'é', ['e']);
+    assertAnalysis( 'asciifolding', 'ß', ['s','ss']);
+    assertAnalysis( 'asciifolding', 'æ', ['a','ae']);
+    assertAnalysis( 'asciifolding', 'ł', ['l']);
+    assertAnalysis( 'asciifolding', 'ɰ', ['m']);
+    assertAnalysis( 'trim', ' f ', ['f'] );
+    assertAnalysis( 'ampersand', 'a and b', ['a','&','b'] );
+    assertAnalysis( 'ampersand', 'a & b', ['a','&','b'] );
+    assertAnalysis( 'ampersand', 'a and & and b', ['a','&','b'] );
+    assertAnalysis( 'ampersand', 'land', ['l','la','lan','land'] ); // should not replace inside tokens
+    assertAnalysis( 'peliasQueryPartialTokenFilter', '1 a ab abc abcdefghij', ['1','a','ab','abc','abcd','abcde','abcdef','abcdefg','abcdefgh','abcdefghi','abcdefghij'] );
+    assertAnalysis( 'removeAllZeroNumericPrefix', '00001', ['1'] );
+    assertAnalysis( 'unique', '1 1 1', ['1'] );
+    assertAnalysis( 'notnull', ' / / ', [] );
+
+    assertAnalysis( 'kstem', 'mcdonalds', ['m', 'mc', 'mcd', 'mcdo', 'mcdon', 'mcdona', 'mcdonal', 'mcdonald'] );
+    assertAnalysis( 'kstem', 'McDonald\'s', ['m', 'mc', 'mcd', 'mcdo', 'mcdon', 'mcdona', 'mcdonal', 'mcdonald'] );
+    assertAnalysis( 'kstem', 'peoples', ['p', 'pe', 'peo', 'peop', 'peopl', 'people'] );
+
+    // remove punctuation (handled by the char_filter)
+    assertAnalysis( 'punctuation', punctuation.all.join(''), ['-','-&'] );
+
+    // ensure that very large grams are created
+    assertAnalysis( 'largeGrams', 'grolmanstrasse', [
+      'g','gr','gro','grol','grolm','grolma','grolman','grolmans','grolmanst',
+      'grolmanstr','grolmanstra','grolmanstras','grolmanstrass',
+      'grolmanstrasse'
+    ]);
+
+    suite.run( t.end );
+  });
+};
+
+// address suffix expansions should only performed in a way that is
+// safe for 'partial tokens'.
+module.exports.tests.address_suffix_expansions = function(test, common){
+  test( 'address suffix expansions', function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+    var assertAnalysis = analyze.bind( null, suite, t, 'peliasQueryPartialToken' );
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
+
+    assertAnalysis( 'safe expansions', 'aly', [
+      'a', 'al', 'all', 'alle', 'alley'
+    ]);
+
+    assertAnalysis( 'safe expansions', 'xing', [
+      'c', 'cr', 'cro', 'cros', 'cross', 'crossi', 'crossin', 'crossing'
+    ]);
+
+    assertAnalysis( 'safe expansions', 'rd', [
+      'r', 'ro', 'roa', 'road'
+    ]);
+
+    assertAnalysis( 'unsafe expansion', 'ct st', [
+      'c', 'ct', 's', 'st'
+    ]);
+
+    suite.run( t.end );
+  });
+};
+
+// stop words should be disabled so that the entire street prefix is indexed as ngrams
+module.exports.tests.stop_words = function(test, common){
+  test( 'stop words', function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+    var assertAnalysis = analyze.bind( null, suite, t, 'peliasQueryPartialToken' );
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
+
+    assertAnalysis( 'street suffix', 'AB street', [
+      'a', 'ab', 's', 'st', 'str', 'stre', 'stree', 'street'
+    ]);
+
+    assertAnalysis( 'street suffix (abbreviation)', 'AB st', [
+      'a', 'ab', 's', 'st'
+    ]);
+
+    suite.run( t.end );
+  });
+};
+
+module.exports.tests.functional = function(test, common){
+  test( 'functional', function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+    var assertAnalysis = analyze.bind( null, suite, t, 'peliasQueryPartialToken' );
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
+
+    assertAnalysis( 'country', 'Trinidad and Tobago', [
+      't', 'tr', 'tri', 'trin', 'trini', 'trinid', 'trinida', 'trinidad', '&', 'to', 'tob', 'toba', 'tobag', 'tobago'
+    ]);
+
+    assertAnalysis( 'place', 'Toys "R" Us!', [
+      't', 'to', 'toy', 'r', 'u', 'us'
+    ]);
+
+    assertAnalysis( 'address', '101 mapzen place', [
+      '1', '10', '101', 'm', 'ma', 'map', 'mapz', 'mapze', 'mapzen', 'p', 'pl', 'pla', 'plac', 'place'
+    ]);
+
+    suite.run( t.end );
+  });
+};
+
+module.exports.all = function (tape, common) {
+
+  function test(name, testFunction) {
+    return tape('peliasQueryPartialToken: ' + name, testFunction);
+  }
+
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};
+
+function analyze( suite, t, analyzer, comment, text, expected ){
+  suite.assert( function( done ){
+    suite.client.indices.analyze({
+      index: suite.props.index,
+      analyzer: analyzer,
+      text: text
+    }, function( err, res ){
+      if( err ) console.error( err );
+      t.deepEqual( simpleTokens( res.tokens ), expected, comment );
+      done();
+    });
+  });
+}
+
+function simpleTokens( tokens ){
+  return tokens.map( function( t ){
+    return t.token;
+  });
+}

--- a/integration/autocomplete_abbreviated_street_names.js
+++ b/integration/autocomplete_abbreviated_street_names.js
@@ -1,0 +1,141 @@
+
+// Tests to ensure no regressions in the way the autocomplete analyzers handle
+// synonym expansions and the corresponding matching of those tokens.
+
+// The greater issue is descriped in: https://github.com/pelias/pelias/issues/211
+// The cases tested here are described in: https://github.com/pelias/schema/issues/105
+
+var tape = require('tape'),
+    elastictest = require('elastictest'),
+    schema = require('../schema'),
+    punctuation = require('../punctuation');
+
+module.exports.tests = {};
+
+// index the name as 'Grolmanstraße' and then retrieve with partially complete token 'Grolmanstr.'
+module.exports.tests.index_expanded_form_search_contracted = function(test, common){
+  test( 'index and retrieve expanded form', function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
+
+    // index a document with a name which contains a synonym (center)
+    suite.action( function( done ){
+      suite.client.index({
+        index: suite.props.index,
+        type: 'test',
+        id: '1',
+        body: { name: { default: 'Grolmanstraße' } }
+      }, done);
+    });
+
+    // search using 'peliasQueryPartialToken'
+    suite.assert( function( done ){
+      suite.client.search({
+        index: suite.props.index,
+        type: 'test',
+        body: { query: { match: {
+          'name.default': {
+            'analyzer': 'peliasQueryPartialToken',
+            'query': 'Grolmanstr.'
+          }
+        }}}
+      }, function( err, res ){
+        t.equal( err, undefined );
+        t.equal( res.hits.total, 1, 'document found' );
+        done();
+      });
+    });
+
+    // search using 'peliasQueryFullToken'
+    suite.assert( function( done ){
+      suite.client.search({
+        index: suite.props.index,
+        type: 'test',
+        body: { query: { match: {
+          'name.default': {
+            'analyzer': 'peliasQueryFullToken',
+            'query': 'Grolmanstr.'
+          }
+        }}}
+      }, function( err, res ){
+        t.equal( err, undefined );
+        t.equal( res.hits.total, 1, 'document found' );
+        done();
+      });
+    });
+
+    suite.run( t.end );
+  });
+};
+
+// index the name as 'Grolmanstr.' and then retrieve with 'Grolmanstraße'
+module.exports.tests.index_contracted_form_search_expanded = function(test, common){
+  test( 'index and retrieve contracted form', function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
+
+    // index a document with a name which contains a synonym (center)
+    suite.action( function( done ){
+      suite.client.index({
+        index: suite.props.index,
+        type: 'test',
+        id: '1',
+        body: { name: { default: 'Grolmanstr.' } }
+      }, done);
+    });
+
+    // search using 'peliasQueryPartialToken'
+    suite.assert( function( done ){
+      suite.client.search({
+        index: suite.props.index,
+        type: 'test',
+        body: { query: { match: {
+          'name.default': {
+            'analyzer': 'peliasQueryPartialToken',
+            'query': 'Grolmanstraße'
+          }
+        }}}
+      }, function( err, res ){
+        t.equal( err, undefined );
+        t.equal( res.hits.total, 1, 'document found' );
+        done();
+      });
+    });
+
+    // search using 'peliasQueryFullToken'
+    // @note: this case is currently not supported.
+    // Please index your data in the expanded form.
+
+    // suite.assert( function( done ){
+    //   suite.client.search({
+    //     index: suite.props.index,
+    //     type: 'test',
+    //     body: { query: { match: {
+    //       'name.default': {
+    //         'analyzer': 'peliasQueryFullToken',
+    //         'query': 'Grolmanstraße'
+    //       }
+    //     }}}
+    //   }, function( err, res ){
+    //     t.equal( err, undefined );
+    //     t.equal( res.hits.total, 1, 'document found' );
+    //     done();
+    //   });
+    // });
+
+    suite.run( t.end );
+  });
+};
+
+module.exports.all = function (tape, common) {
+
+  function test(name, testFunction) {
+    return tape('autocomplete street synonym expansion: ' + name, testFunction);
+  }
+
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/integration/autocomplete_abbreviated_street_names.js
+++ b/integration/autocomplete_abbreviated_street_names.js
@@ -14,7 +14,7 @@ module.exports.tests = {};
 
 // index the name as 'Grolmanstraße' and then retrieve with partially complete token 'Grolmanstr.'
 module.exports.tests.index_expanded_form_search_contracted = function(test, common){
-  test( 'index and retrieve expanded form', function(t){
+  test( 'index expanded and retrieve contracted form', function(t){
 
     var suite = new elastictest.Suite( null, { schema: schema } );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
@@ -71,7 +71,7 @@ module.exports.tests.index_expanded_form_search_contracted = function(test, comm
 
 // index the name as 'Grolmanstr.' and then retrieve with 'Grolmanstraße'
 module.exports.tests.index_contracted_form_search_expanded = function(test, common){
-  test( 'index and retrieve contracted form', function(t){
+  test( 'index contracted and search expanded', function(t){
 
     var suite = new elastictest.Suite( null, { schema: schema } );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
@@ -86,23 +86,27 @@ module.exports.tests.index_contracted_form_search_expanded = function(test, comm
       }, done);
     });
 
-    // search using 'peliasQueryPartialToken'
-    suite.assert( function( done ){
-      suite.client.search({
-        index: suite.props.index,
-        type: 'test',
-        body: { query: { match: {
-          'name.default': {
-            'analyzer': 'peliasQueryPartialToken',
-            'query': 'Grolmanstraße'
-          }
-        }}}
-      }, function( err, res ){
-        t.equal( err, undefined );
-        t.equal( res.hits.total, 1, 'document found' );
-        done();
-      });
-    });
+    // @note: these tests are commented out, the issue would be better solved
+    // with https://github.com/pelias/openaddresses/pull/68
+
+    //
+    // // search using 'peliasQueryPartialToken'
+    // suite.assert( function( done ){
+    //   suite.client.search({
+    //     index: suite.props.index,
+    //     type: 'test',
+    //     body: { query: { match: {
+    //       'name.default': {
+    //         'analyzer': 'peliasQueryPartialToken',
+    //         'query': 'Grolmanstraße'
+    //       }
+    //     }}}
+    //   }, function( err, res ){
+    //     t.equal( err, undefined );
+    //     t.equal( res.hits.total, 1, 'document found' );
+    //     done();
+    //   });
+    // });
 
     // search using 'peliasQueryFullToken'
     // @note: this case is currently not supported.
@@ -132,7 +136,7 @@ module.exports.tests.index_contracted_form_search_expanded = function(test, comm
 module.exports.all = function (tape, common) {
 
   function test(name, testFunction) {
-    return tape('autocomplete street synonym expansion: ' + name, testFunction);
+    return tape('autocomplete abbreviated street names: ' + name, testFunction);
   }
 
   for( var testCase in module.exports.tests ){

--- a/integration/autocomplete_directional_synonym_expansion.js
+++ b/integration/autocomplete_directional_synonym_expansion.js
@@ -1,0 +1,252 @@
+
+// Tests to ensure no regressions in the way the autocomplete analyzers handle
+// synonym expansions and the corresponding matching of those tokens.
+
+// The greater issue is descriped in: https://github.com/pelias/pelias/issues/211
+// The cases tested here are described in: https://github.com/pelias/schema/issues/105
+
+var tape = require('tape'),
+    elastictest = require('elastictest'),
+    schema = require('../schema'),
+    punctuation = require('../punctuation');
+
+module.exports.tests = {};
+
+// index the name as 'north' and then retrieve with partially complete token 'nor'
+module.exports.tests.index_and_retrieve_expanded_form = function(test, common){
+  test( 'index and retrieve expanded form', function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
+
+    // index a document with a name which contains a synonym (center)
+    suite.action( function( done ){
+      suite.client.index({
+        index: suite.props.index,
+        type: 'test',
+        id: '1',
+        body: { name: { default: 'north' } }
+      }, done);
+    });
+
+    // search using 'peliasQueryPartialToken'
+    suite.assert( function( done ){
+      suite.client.search({
+        index: suite.props.index,
+        type: 'test',
+        body: { query: { match: {
+          'name.default': {
+            'analyzer': 'peliasQueryPartialToken',
+            'query': 'nor'
+          }
+        }}}
+      }, function( err, res ){
+        t.equal( err, undefined );
+        t.equal( res.hits.total, 1, 'document found' );
+        done();
+      });
+    });
+
+    // search using 'peliasQueryFullToken'
+    suite.assert( function( done ){
+      suite.client.search({
+        index: suite.props.index,
+        type: 'test',
+        body: { query: { match: {
+          'name.default': {
+            'analyzer': 'peliasQueryFullToken',
+            'query': 'north'
+          }
+        }}}
+      }, function( err, res ){
+        t.equal( err, undefined );
+        t.equal( res.hits.total, 1, 'document found' );
+        done();
+      });
+    });
+
+    suite.run( t.end );
+  });
+};
+
+// index the name as 'n' and then retrieve with 'n'
+module.exports.tests.index_and_retrieve_contracted_form = function(test, common){
+  test( 'index and retrieve contracted form', function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
+
+    // index a document with a name which contains a synonym (center)
+    suite.action( function( done ){
+      suite.client.index({
+        index: suite.props.index,
+        type: 'test',
+        id: '1',
+        body: { name: { default: 'n' } }
+      }, done);
+    });
+
+    // search using 'peliasQueryPartialToken'
+    suite.assert( function( done ){
+      suite.client.search({
+        index: suite.props.index,
+        type: 'test',
+        body: { query: { match: {
+          'name.default': {
+            'analyzer': 'peliasQueryPartialToken',
+            'query': 'n'
+          }
+        }}}
+      }, function( err, res ){
+        t.equal( err, undefined );
+        t.equal( res.hits.total, 1, 'document found' );
+        done();
+      });
+    });
+
+    // search using 'peliasQueryFullToken'
+    suite.assert( function( done ){
+      suite.client.search({
+        index: suite.props.index,
+        type: 'test',
+        body: { query: { match: {
+          'name.default': {
+            'analyzer': 'peliasQueryFullToken',
+            'query': 'n'
+          }
+        }}}
+      }, function( err, res ){
+        t.equal( err, undefined );
+        t.equal( res.hits.total, 1, 'document found' );
+        done();
+      });
+    });
+
+    suite.run( t.end );
+  });
+};
+
+// index the name as 'n' and then retrieve with partially complete token 'nor'
+module.exports.tests.index_and_retrieve_mixed_form_1 = function(test, common){
+  test( 'index and retrieve mixed form 1', function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
+
+    // index a document with a name which contains a synonym (center)
+    suite.action( function( done ){
+      suite.client.index({
+        index: suite.props.index,
+        type: 'test',
+        id: '1',
+        body: { name: { default: 'n' } }
+      }, done);
+    });
+
+    // search using 'peliasQueryPartialToken'
+    suite.assert( function( done ){
+      suite.client.search({
+        index: suite.props.index,
+        type: 'test',
+        body: { query: { match: {
+          'name.default': {
+            'analyzer': 'peliasQueryPartialToken',
+            'query': 'nor'
+          }
+        }}}
+      }, function( err, res ){
+        t.equal( err, undefined );
+        t.equal( res.hits.total, 1, 'document found' );
+        done();
+      });
+    });
+
+    // search using 'peliasQueryFullToken'
+    suite.assert( function( done ){
+      suite.client.search({
+        index: suite.props.index,
+        type: 'test',
+        body: { query: { match: {
+          'name.default': {
+            'analyzer': 'peliasQueryFullToken',
+            'query': 'north'
+          }
+        }}}
+      }, function( err, res ){
+        t.equal( err, undefined );
+        t.equal( res.hits.total, 1, 'document found' );
+        done();
+      });
+    });
+
+    suite.run( t.end );
+  });
+};
+
+// index the name as 'north' and then retrieve with 'n'
+module.exports.tests.index_and_retrieve_mixed_form_2 = function(test, common){
+  test( 'index and retrieve mixed form 2', function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
+
+    // index a document with a name which contains a synonym (center)
+    suite.action( function( done ){
+      suite.client.index({
+        index: suite.props.index,
+        type: 'test',
+        id: '1',
+        body: { name: { default: 'north' } }
+      }, done);
+    });
+
+    // search using 'peliasQueryPartialToken'
+    suite.assert( function( done ){
+      suite.client.search({
+        index: suite.props.index,
+        type: 'test',
+        body: { query: { match: {
+          'name.default': {
+            'analyzer': 'peliasQueryPartialToken',
+            'query': 'n'
+          }
+        }}}
+      }, function( err, res ){
+        t.equal( err, undefined );
+        t.equal( res.hits.total, 1, 'document found' );
+        done();
+      });
+    });
+
+    // search using 'peliasQueryFullToken'
+    suite.assert( function( done ){
+      suite.client.search({
+        index: suite.props.index,
+        type: 'test',
+        body: { query: { match: {
+          'name.default': {
+            'analyzer': 'peliasQueryFullToken',
+            'query': 'n'
+          }
+        }}}
+      }, function( err, res ){
+        t.equal( err, undefined );
+        t.equal( res.hits.total, 1, 'document found' );
+        done();
+      });
+    });
+
+    suite.run( t.end );
+  });
+};
+
+module.exports.all = function (tape, common) {
+
+  function test(name, testFunction) {
+    return tape('autocomplete directional synonym expansion: ' + name, testFunction);
+  }
+
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/integration/autocomplete_street_synonym_expansion.js
+++ b/integration/autocomplete_street_synonym_expansion.js
@@ -1,0 +1,252 @@
+
+// Tests to ensure no regressions in the way the autocomplete analyzers handle
+// synonym expansions and the corresponding matching of those tokens.
+
+// The greater issue is descriped in: https://github.com/pelias/pelias/issues/211
+// The cases tested here are described in: https://github.com/pelias/schema/issues/105
+
+var tape = require('tape'),
+    elastictest = require('elastictest'),
+    schema = require('../schema'),
+    punctuation = require('../punctuation');
+
+module.exports.tests = {};
+
+// index the name as 'center' and then retrieve with partially complete token 'cent'
+module.exports.tests.index_and_retrieve_expanded_form = function(test, common){
+  test( 'index and retrieve expanded form', function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
+
+    // index a document with a name which contains a synonym (center)
+    suite.action( function( done ){
+      suite.client.index({
+        index: suite.props.index,
+        type: 'test',
+        id: '1',
+        body: { name: { default: 'center' } }
+      }, done);
+    });
+
+    // search using 'peliasQueryPartialToken'
+    suite.assert( function( done ){
+      suite.client.search({
+        index: suite.props.index,
+        type: 'test',
+        body: { query: { match: {
+          'name.default': {
+            'analyzer': 'peliasQueryPartialToken',
+            'query': 'cent'
+          }
+        }}}
+      }, function( err, res ){
+        t.equal( err, undefined );
+        t.equal( res.hits.total, 1, 'document found' );
+        done();
+      });
+    });
+
+    // search using 'peliasQueryFullToken'
+    suite.assert( function( done ){
+      suite.client.search({
+        index: suite.props.index,
+        type: 'test',
+        body: { query: { match: {
+          'name.default': {
+            'analyzer': 'peliasQueryFullToken',
+            'query': 'center'
+          }
+        }}}
+      }, function( err, res ){
+        t.equal( err, undefined );
+        t.equal( res.hits.total, 1, 'document found' );
+        done();
+      });
+    });
+
+    suite.run( t.end );
+  });
+};
+
+// index the name as 'ctr' and then retrieve with 'ctr'
+module.exports.tests.index_and_retrieve_contracted_form = function(test, common){
+  test( 'index and retrieve contracted form', function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
+
+    // index a document with a name which contains a synonym (center)
+    suite.action( function( done ){
+      suite.client.index({
+        index: suite.props.index,
+        type: 'test',
+        id: '1',
+        body: { name: { default: 'ctr' } }
+      }, done);
+    });
+
+    // search using 'peliasQueryPartialToken'
+    suite.assert( function( done ){
+      suite.client.search({
+        index: suite.props.index,
+        type: 'test',
+        body: { query: { match: {
+          'name.default': {
+            'analyzer': 'peliasQueryPartialToken',
+            'query': 'ctr'
+          }
+        }}}
+      }, function( err, res ){
+        t.equal( err, undefined );
+        t.equal( res.hits.total, 1, 'document found' );
+        done();
+      });
+    });
+
+    // search using 'peliasQueryFullToken'
+    suite.assert( function( done ){
+      suite.client.search({
+        index: suite.props.index,
+        type: 'test',
+        body: { query: { match: {
+          'name.default': {
+            'analyzer': 'peliasQueryFullToken',
+            'query': 'ctr'
+          }
+        }}}
+      }, function( err, res ){
+        t.equal( err, undefined );
+        t.equal( res.hits.total, 1, 'document found' );
+        done();
+      });
+    });
+
+    suite.run( t.end );
+  });
+};
+
+// index the name as 'ctr' and then retrieve with partially complete token 'cent'
+module.exports.tests.index_and_retrieve_mixed_form_1 = function(test, common){
+  test( 'index and retrieve mixed form 1', function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
+
+    // index a document with a name which contains a synonym (center)
+    suite.action( function( done ){
+      suite.client.index({
+        index: suite.props.index,
+        type: 'test',
+        id: '1',
+        body: { name: { default: 'ctr' } }
+      }, done);
+    });
+
+    // search using 'peliasQueryPartialToken'
+    suite.assert( function( done ){
+      suite.client.search({
+        index: suite.props.index,
+        type: 'test',
+        body: { query: { match: {
+          'name.default': {
+            'analyzer': 'peliasQueryPartialToken',
+            'query': 'cent'
+          }
+        }}}
+      }, function( err, res ){
+        t.equal( err, undefined );
+        t.equal( res.hits.total, 1, 'document found' );
+        done();
+      });
+    });
+
+    // search using 'peliasQueryFullToken'
+    suite.assert( function( done ){
+      suite.client.search({
+        index: suite.props.index,
+        type: 'test',
+        body: { query: { match: {
+          'name.default': {
+            'analyzer': 'peliasQueryFullToken',
+            'query': 'center'
+          }
+        }}}
+      }, function( err, res ){
+        t.equal( err, undefined );
+        t.equal( res.hits.total, 1, 'document found' );
+        done();
+      });
+    });
+
+    suite.run( t.end );
+  });
+};
+
+// index the name as 'center' and then retrieve with 'ctr'
+module.exports.tests.index_and_retrieve_mixed_form_2 = function(test, common){
+  test( 'index and retrieve mixed form 2', function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
+
+    // index a document with a name which contains a synonym (center)
+    suite.action( function( done ){
+      suite.client.index({
+        index: suite.props.index,
+        type: 'test',
+        id: '1',
+        body: { name: { default: 'center' } }
+      }, done);
+    });
+
+    // search using 'peliasQueryPartialToken'
+    suite.assert( function( done ){
+      suite.client.search({
+        index: suite.props.index,
+        type: 'test',
+        body: { query: { match: {
+          'name.default': {
+            'analyzer': 'peliasQueryPartialToken',
+            'query': 'ctr'
+          }
+        }}}
+      }, function( err, res ){
+        t.equal( err, undefined );
+        t.equal( res.hits.total, 1, 'document found' );
+        done();
+      });
+    });
+
+    // search using 'peliasQueryFullToken'
+    suite.assert( function( done ){
+      suite.client.search({
+        index: suite.props.index,
+        type: 'test',
+        body: { query: { match: {
+          'name.default': {
+            'analyzer': 'peliasQueryFullToken',
+            'query': 'ctr'
+          }
+        }}}
+      }, function( err, res ){
+        t.equal( err, undefined );
+        t.equal( res.hits.total, 1, 'document found' );
+        done();
+      });
+    });
+
+    suite.run( t.end );
+  });
+};
+
+module.exports.all = function (tape, common) {
+
+  function test(name, testFunction) {
+    return tape('autocomplete street synonym expansion: ' + name, testFunction);
+  }
+
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/integration/dynamic_templates.js
+++ b/integration/dynamic_templates.js
@@ -9,9 +9,9 @@ module.exports.tests = {};
 
 // 'admin' mappings have a different 'name' dynamic_template to the other types
 module.exports.tests.dynamic_templates_name = function(test, common){
-  test( 'admin->name (legacy)', nameAssertion( 'admin0', 'peliasOneEdgeGram' ) );
-  test( 'admin->name', nameAssertion( 'country', 'peliasOneEdgeGram' ) );
-  test( 'document->name', nameAssertion( 'myType', 'peliasTwoEdgeGram' ) );
+  test( 'admin->name (legacy)', nameAssertion( 'admin0', 'peliasIndexOneEdgeGram' ) );
+  test( 'admin->name', nameAssertion( 'country', 'peliasIndexOneEdgeGram' ) );
+  test( 'document->name', nameAssertion( 'myType', 'peliasIndexTwoEdgeGram' ) );
 };
 
 // all types share the same phrase mapping

--- a/integration/run.js
+++ b/integration/run.js
@@ -5,8 +5,10 @@ var common = {};
 var tests = [
   require('./validate.js'),
   require('./dynamic_templates.js'),
-  require('./analyzer_peliasOneEdgeGram.js'),
-  require('./analyzer_peliasTwoEdgeGram.js'),
+  require('./analyzer_peliasIndexOneEdgeGram.js'),
+  require('./analyzer_peliasIndexTwoEdgeGram.js'),
+  require('./analyzer_peliasQueryPartialToken.js'),
+  require('./analyzer_peliasQueryFullToken.js'),
   require('./analyzer_peliasPhrase.js'),
   require('./analyzer_peliasAdmin.js'),
   require('./analyzer_peliasHousenumber.js'),

--- a/integration/run.js
+++ b/integration/run.js
@@ -17,7 +17,10 @@ var tests = [
   require('./address_matching.js'),
   require('./admin_matching.js'),
   require('./source_layer_sourceid_filtering.js'),
-  require('./bounding_box.js')
+  require('./bounding_box.js'),
+  require('./autocomplete_street_synonym_expansion.js'),
+  require('./autocomplete_directional_synonym_expansion.js'),
+  require('./autocomplete_abbreviated_street_names.js')
 ];
 
 tests.map(function(t) {

--- a/mappings/document.js
+++ b/mappings/document.js
@@ -109,7 +109,7 @@ var schema = {
       match_mapping_type: 'string',
       mapping: {
         type: 'string',
-        analyzer: 'peliasTwoEdgeGram',
+        analyzer: 'peliasIndexTwoEdgeGram',
         fielddata : {
           format : 'fst',
           loading: 'eager_global_ordinals'

--- a/schema.js
+++ b/schema.js
@@ -7,7 +7,7 @@ var oneGramMapping = {
       match_mapping_type: 'string',
       mapping: {
         type: 'string',
-        analyzer: 'peliasOneEdgeGram',
+        analyzer: 'peliasIndexOneEdgeGram',
         fielddata : {
           format : 'fst',
           loading: 'eager_global_ordinals'

--- a/scripts/update_settings.js
+++ b/scripts/update_settings.js
@@ -8,6 +8,7 @@ var _index = 'pelias';
 if( schema.settings.hasOwnProperty('index') &&
     schema.settings.index.hasOwnProperty('number_of_shards') ){
   delete schema.settings.index.number_of_shards;
+  delete schema.settings.index.number_of_replicas;
 }
 
 client.indices.close( { index: _index }, function( err, res ){

--- a/settings.js
+++ b/settings.js
@@ -25,7 +25,6 @@ function generate(){
             "notnull"
           ]
         },
-
         "peliasIndexOneEdgeGram" : {
           "type": "custom",
           "tokenizer" : "whitespace",
@@ -56,6 +55,7 @@ function generate(){
             "removeAllZeroNumericPrefix",
             "kstem",
             "peliasTwoEdgeGramFilter",
+            "direction_synonym_contraction_keep_original",
             "unique",
             "notnull"
           ]
@@ -175,15 +175,19 @@ function generate(){
         },
         "partial_token_address_suffix_expansion": {
           "type": "synonym",
-          "synonyms": street_suffix.safe_expansions
+          "synonyms": street_suffix.partial_token_safe_expansions
         },
         "full_token_address_suffix_expansion": {
           "type": "synonym",
-          "synonyms": street_suffix.safe_expansions
+          "synonyms": street_suffix.full_token_safe_expansions
         },
         "direction_synonym": {
           "type": "synonym",
           "synonyms": street_suffix.direction_synonyms
+        },
+        "direction_synonym_contraction_keep_original": {
+          "type": "synonym",
+          "synonyms": street_suffix.direction_synonyms_keep_original
         },
         "remove_ordinals" : {
           "type" : "pattern_replace",

--- a/settings.js
+++ b/settings.js
@@ -25,7 +25,8 @@ function generate(){
             "notnull"
           ]
         },
-        "peliasOneEdgeGram" : {
+
+        "peliasIndexOneEdgeGram" : {
           "type": "custom",
           "tokenizer" : "whitespace",
           "char_filter" : ["punctuation"],
@@ -33,7 +34,7 @@ function generate(){
             "lowercase",
             "asciifolding",
             "trim",
-            "address_suffix_expansion",
+            "full_token_address_suffix_expansion",
             "ampersand",
             "removeAllZeroNumericPrefix",
             "kstem",
@@ -42,7 +43,7 @@ function generate(){
             "notnull"
           ]
         },
-        "peliasTwoEdgeGram" : {
+        "peliasIndexTwoEdgeGram" : {
           "type": "custom",
           "tokenizer" : "whitespace",
           "char_filter" : ["punctuation"],
@@ -50,11 +51,44 @@ function generate(){
             "lowercase",
             "asciifolding",
             "trim",
-            "address_suffix_expansion",
+            "full_token_address_suffix_expansion",
             "ampersand",
             "removeAllZeroNumericPrefix",
             "kstem",
             "peliasTwoEdgeGramFilter",
+            "unique",
+            "notnull"
+          ]
+        },
+        "peliasQueryPartialToken" : {
+          "type": "custom",
+          "tokenizer" : "whitespace",
+          "char_filter" : ["punctuation"],
+          "filter": [
+            "lowercase",
+            "asciifolding",
+            "trim",
+            "partial_token_address_suffix_expansion",
+            "ampersand",
+            "removeAllZeroNumericPrefix",
+            "kstem",
+            "peliasOneEdgeGramFilter",
+            "unique",
+            "notnull"
+          ]
+        },
+        "peliasQueryFullToken" : {
+          "type": "custom",
+          "tokenizer" : "whitespace",
+          "char_filter" : ["punctuation"],
+          "filter": [
+            "lowercase",
+            "asciifolding",
+            "trim",
+            "full_token_address_suffix_expansion",
+            "ampersand",
+            "removeAllZeroNumericPrefix",
+            "kstem",
             "unique",
             "notnull"
           ]
@@ -139,7 +173,11 @@ function generate(){
           "type": "synonym",
           "synonyms": street_suffix.synonyms
         },
-        "address_suffix_expansion": {
+        "partial_token_address_suffix_expansion": {
+          "type": "synonym",
+          "synonyms": street_suffix.safe_expansions
+        },
+        "full_token_address_suffix_expansion": {
           "type": "synonym",
           "synonyms": street_suffix.safe_expansions
         },

--- a/settings.js
+++ b/settings.js
@@ -72,7 +72,6 @@ function generate(){
             "ampersand",
             "removeAllZeroNumericPrefix",
             "kstem",
-            "peliasOneEdgeGramFilter",
             "unique",
             "notnull"
           ]

--- a/street_suffix.js
+++ b/street_suffix.js
@@ -160,6 +160,15 @@ module.exports.direction_synonyms = [
   "west => w"
 ];
 
+// note: this is a bit of a hack, it can be placed AFTER an 2+ ngram filter in
+// order to allow single grams in the index.
+module.exports.direction_synonyms_keep_original = [
+  "north => north,n",
+  "south => south,s",
+  "east => east,e",
+  "west => west,w"
+];
+
 /**
   a list of 'safe' street suffix expansions.
 
@@ -183,7 +192,7 @@ module.exports.direction_synonyms = [
  please use judgement when adding new expansions as it may cause the 'jitter'
  behaviour as outlined in https://github.com/pelias/schema/pull/83
 **/
-module.exports.safe_expansions = [
+module.exports.partial_token_safe_expansions = [
   "aly => alley",
   "anx => annex",
   "byu => bayou",
@@ -283,3 +292,13 @@ module.exports.safe_expansions = [
   "vlg => village",
   "wy => way"
 ];
+
+module.exports.full_token_safe_expansions = [];
+
+// copy the unsafe expansions
+module.exports.partial_token_safe_expansions.forEach( function( expansion ){
+  module.exports.full_token_safe_expansions.push( expansion );
+});
+
+// add the expansions which are only safe on complete tokens (not partial tokens)
+module.exports.full_token_safe_expansions.push( "n => north", "s => south", "e => east", "w => west" );

--- a/test/compile.js
+++ b/test/compile.js
@@ -19,25 +19,25 @@ module.exports.tests.compile = function(test, common) {
 module.exports.tests.indeces = function(test, common) {
   test('contains "_default_" index definition', function(t) {
     t.equal(typeof schema.mappings._default_, 'object', 'mappings present');
-    t.equal(schema.mappings._default_.dynamic_templates[0].nameGram.mapping.analyzer, 'peliasTwoEdgeGram');
+    t.equal(schema.mappings._default_.dynamic_templates[0].nameGram.mapping.analyzer, 'peliasIndexTwoEdgeGram');
     t.end();
   });
   test('explicitly specify some admin indeces and their analyzer', function(t) {
     t.equal(typeof schema.mappings.country, 'object', 'mappings present');
-    t.equal(schema.mappings.country.dynamic_templates[0].nameGram.mapping.analyzer, 'peliasOneEdgeGram');
+    t.equal(schema.mappings.country.dynamic_templates[0].nameGram.mapping.analyzer, 'peliasIndexOneEdgeGram');
     t.equal(typeof schema.mappings.region, 'object', 'mappings present');
-    t.equal(schema.mappings.region.dynamic_templates[0].nameGram.mapping.analyzer, 'peliasOneEdgeGram');
+    t.equal(schema.mappings.region.dynamic_templates[0].nameGram.mapping.analyzer, 'peliasIndexOneEdgeGram');
     t.equal(typeof schema.mappings.county, 'object', 'mappings present');
-    t.equal(schema.mappings.county.dynamic_templates[0].nameGram.mapping.analyzer, 'peliasOneEdgeGram');
+    t.equal(schema.mappings.county.dynamic_templates[0].nameGram.mapping.analyzer, 'peliasIndexOneEdgeGram');
     t.end();
   });
   test('explicitly specify some admin indeces and their analyzer (legacy)', function(t) {
     t.equal(typeof schema.mappings.admin0, 'object', 'mappings present');
-    t.equal(schema.mappings.admin0.dynamic_templates[0].nameGram.mapping.analyzer, 'peliasOneEdgeGram');
+    t.equal(schema.mappings.admin0.dynamic_templates[0].nameGram.mapping.analyzer, 'peliasIndexOneEdgeGram');
     t.equal(typeof schema.mappings.admin1, 'object', 'mappings present');
-    t.equal(schema.mappings.admin1.dynamic_templates[0].nameGram.mapping.analyzer, 'peliasOneEdgeGram');
+    t.equal(schema.mappings.admin1.dynamic_templates[0].nameGram.mapping.analyzer, 'peliasIndexOneEdgeGram');
     t.equal(typeof schema.mappings.admin2, 'object', 'mappings present');
-    t.equal(schema.mappings.admin2.dynamic_templates[0].nameGram.mapping.analyzer, 'peliasOneEdgeGram');
+    t.equal(schema.mappings.admin2.dynamic_templates[0].nameGram.mapping.analyzer, 'peliasIndexOneEdgeGram');
     t.end();
   });
 };
@@ -51,7 +51,7 @@ module.exports.tests.dynamic_templates = function(test, common) {
     t.equal(template.match_mapping_type, 'string');
     t.deepEqual(template.mapping, {
       type: 'string',
-      analyzer: 'peliasOneEdgeGram',
+      analyzer: 'peliasIndexOneEdgeGram',
       fielddata: {
         format: 'fst',
         loading: 'eager_global_ordinals'
@@ -70,7 +70,7 @@ module.exports.tests.dynamic_templates_legacy = function(test, common) {
     t.equal(template.match_mapping_type, 'string');
     t.deepEqual(template.mapping, {
       type: 'string',
-      analyzer: 'peliasOneEdgeGram',
+      analyzer: 'peliasIndexOneEdgeGram',
       fielddata: {
         format: 'fst',
         loading: 'eager_global_ordinals'

--- a/test/document.js
+++ b/test/document.js
@@ -123,7 +123,7 @@ module.exports.tests.dynamic_templates = function(test, common) {
     t.equal(template.match_mapping_type, 'string');
     t.deepEqual(template.mapping, {
       type: 'string',
-      analyzer: 'peliasTwoEdgeGram',
+      analyzer: 'peliasIndexTwoEdgeGram',
       fielddata: {
         format: 'fst',
         loading: 'eager_global_ordinals'

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -46,6 +46,7 @@
             "removeAllZeroNumericPrefix",
             "kstem",
             "peliasTwoEdgeGramFilter",
+            "direction_synonym_contraction_keep_original",
             "unique",
             "notnull"
           ]
@@ -742,7 +743,11 @@
             "tpke => turnpike",
             "vly => valley",
             "vlg => village",
-            "wy => way"
+            "wy => way",
+            "n => north",
+            "s => south",
+            "e => east",
+            "w => west"
           ]
         },
         "direction_synonym": {
@@ -756,6 +761,15 @@
             "south => s",
             "east => e",
             "west => w"
+          ]
+        },
+        "direction_synonym_contraction_keep_original": {
+          "type": "synonym",
+          "synonyms": [
+            "north => north,n",
+            "south => south,s",
+            "east => east,e",
+            "west => west,w"
           ]
         },
         "remove_ordinals": {

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -63,7 +63,6 @@
             "ampersand",
             "removeAllZeroNumericPrefix",
             "kstem",
-            "peliasOneEdgeGramFilter",
             "unique",
             "notnull"
           ]

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -16,17 +16,15 @@
             "notnull"
           ]
         },
-        "peliasOneEdgeGram": {
+        "peliasIndexOneEdgeGram" : {
           "type": "custom",
-          "tokenizer": "whitespace",
-          "char_filter": [
-            "punctuation"
-          ],
+          "tokenizer" : "whitespace",
+          "char_filter" : ["punctuation"],
           "filter": [
             "lowercase",
             "asciifolding",
             "trim",
-            "address_suffix_expansion",
+            "full_token_address_suffix_expansion",
             "ampersand",
             "removeAllZeroNumericPrefix",
             "kstem",
@@ -35,21 +33,52 @@
             "notnull"
           ]
         },
-        "peliasTwoEdgeGram": {
+        "peliasIndexTwoEdgeGram" : {
           "type": "custom",
-          "tokenizer": "whitespace",
-          "char_filter": [
-            "punctuation"
-          ],
+          "tokenizer" : "whitespace",
+          "char_filter" : ["punctuation"],
           "filter": [
             "lowercase",
             "asciifolding",
             "trim",
-            "address_suffix_expansion",
+            "full_token_address_suffix_expansion",
             "ampersand",
             "removeAllZeroNumericPrefix",
             "kstem",
             "peliasTwoEdgeGramFilter",
+            "unique",
+            "notnull"
+          ]
+        },
+        "peliasQueryPartialToken" : {
+          "type": "custom",
+          "tokenizer" : "whitespace",
+          "char_filter" : ["punctuation"],
+          "filter": [
+            "lowercase",
+            "asciifolding",
+            "trim",
+            "partial_token_address_suffix_expansion",
+            "ampersand",
+            "removeAllZeroNumericPrefix",
+            "kstem",
+            "peliasOneEdgeGramFilter",
+            "unique",
+            "notnull"
+          ]
+        },
+        "peliasQueryFullToken" : {
+          "type": "custom",
+          "tokenizer" : "whitespace",
+          "char_filter" : ["punctuation"],
+          "filter": [
+            "lowercase",
+            "asciifolding",
+            "trim",
+            "full_token_address_suffix_expansion",
+            "ampersand",
+            "removeAllZeroNumericPrefix",
+            "kstem",
             "unique",
             "notnull"
           ]
@@ -514,7 +543,108 @@
             "way => wy"
           ]
         },
-        "address_suffix_expansion": {
+        "partial_token_address_suffix_expansion": {
+          "type": "synonym",
+          "synonyms": [
+            "aly => alley",
+            "anx => annex",
+            "byu => bayou",
+            "bch => beach",
+            "bnd => bend",
+            "blf => bluff",
+            "blfs => bluffs",
+            "btm => bottom",
+            "blvd => boulevard",
+            "brg => bridge",
+            "brk => brook",
+            "cyn => canyon",
+            "cp => cape",
+            "cswy => causeway",
+            "ctr => center",
+            "chnnl => channel",
+            "clf => cliff",
+            "clb => club",
+            "cmn => common",
+            "cmns => commons",
+            "crse => course",
+            "cv => cove",
+            "crk => creek",
+            "crst => crest",
+            "xing => crossing",
+            "xrd => crossroad",
+            "xrds => crossroads",
+            "dl => dale",
+            "dm => dam",
+            "expy => expressway",
+            "fls => falls",
+            "fry => ferry",
+            "fld => field",
+            "flds => fields",
+            "flt => flat",
+            "flts => flats",
+            "frd => ford",
+            "frst => forest",
+            "frg => forge",
+            "frk => fork",
+            "frks => forks",
+            "fwy => freeway",
+            "gdn => garden",
+            "gdns => gardens",
+            "gtwy => gateway",
+            "gln => glenn",
+            "grn => green",
+            "grv => grove",
+            "hbr => harbor",
+            "hvn => haven",
+            "hts => heights",
+            "hwy => highway",
+            "hl => hill",
+            "hls => hills",
+            "holw => hollow",
+            "jct => junction",
+            "ky => key",
+            "kys => keys",
+            "knl => knoll",
+            "knls => knolls",
+            "lndg => landing",
+            "ln => lane",
+            "lgt => light",
+            "lgts => lights",
+            "lck => lock",
+            "lcks => locks",
+            "mnr => manor",
+            "mdw => meadow",
+            "mdws => meadows",
+            "ml => mill",
+            "mls => mills",
+            "mnt => mountain",
+            "mtwy => motorway",
+            "nck => neck",
+            "pkwy => parkway",
+            "psge => pasage",
+            "pne => pine",
+            "pnes => pines",
+            "plz => plaza",
+            "rnch => ranch",
+            "rdg => ridge",
+            "rdgs => ridges",
+            "rd => road",
+            "rte => route",
+            "shr => shore",
+            "shrs => shores",
+            "skwy => skyway",
+            "spg => spring",
+            "spgs => springs",
+            "ste => suite",
+            "trfy => trafficway",
+            "tunl => tunnel",
+            "tpke => turnpike",
+            "vly => valley",
+            "vlg => village",
+            "wy => way"
+          ]
+        },
+        "full_token_address_suffix_expansion": {
           "type": "synonym",
           "synonyms": [
             "aly => alley",
@@ -1592,7 +1722,7 @@
             "match_mapping_type": "string",
             "mapping": {
               "type": "string",
-              "analyzer": "peliasTwoEdgeGram",
+              "analyzer": "peliasIndexTwoEdgeGram",
               "fielddata": {
                 "format": "fst",
                 "loading": "eager_global_ordinals"
@@ -1633,7 +1763,7 @@
             "match_mapping_type": "string",
             "mapping": {
               "type": "string",
-              "analyzer": "peliasOneEdgeGram",
+              "analyzer": "peliasIndexOneEdgeGram",
               "fielddata": {
                 "format": "fst",
                 "loading": "eager_global_ordinals"
@@ -1651,7 +1781,7 @@
             "match_mapping_type": "string",
             "mapping": {
               "type": "string",
-              "analyzer": "peliasOneEdgeGram",
+              "analyzer": "peliasIndexOneEdgeGram",
               "fielddata": {
                 "format": "fst",
                 "loading": "eager_global_ordinals"
@@ -1669,7 +1799,7 @@
             "match_mapping_type": "string",
             "mapping": {
               "type": "string",
-              "analyzer": "peliasOneEdgeGram",
+              "analyzer": "peliasIndexOneEdgeGram",
               "fielddata": {
                 "format": "fst",
                 "loading": "eager_global_ordinals"
@@ -1687,7 +1817,7 @@
             "match_mapping_type": "string",
             "mapping": {
               "type": "string",
-              "analyzer": "peliasOneEdgeGram",
+              "analyzer": "peliasIndexOneEdgeGram",
               "fielddata": {
                 "format": "fst",
                 "loading": "eager_global_ordinals"
@@ -1705,7 +1835,7 @@
             "match_mapping_type": "string",
             "mapping": {
               "type": "string",
-              "analyzer": "peliasOneEdgeGram",
+              "analyzer": "peliasIndexOneEdgeGram",
               "fielddata": {
                 "format": "fst",
                 "loading": "eager_global_ordinals"
@@ -1723,7 +1853,7 @@
             "match_mapping_type": "string",
             "mapping": {
               "type": "string",
-              "analyzer": "peliasOneEdgeGram",
+              "analyzer": "peliasIndexOneEdgeGram",
               "fielddata": {
                 "format": "fst",
                 "loading": "eager_global_ordinals"

--- a/test/settings.js
+++ b/test/settings.js
@@ -44,24 +44,24 @@ module.exports.tests.peliasAdminAnalyzer = function(test, common) {
   });
 };
 
-module.exports.tests.peliasOneEdgeGramAnalyzer = function(test, common) {
-  test('has peliasOneEdgeGram analyzer', function(t) {
+module.exports.tests.peliasIndexOneEdgeGramAnalyzer = function(test, common) {
+  test('has peliasIndexOneEdgeGram analyzer', function(t) {
     var s = settings();
-    t.equal(typeof s.analysis.analyzer.peliasOneEdgeGram, 'object', 'there is a peliasOneEdgeGram analyzer');
-    var analyzer = s.analysis.analyzer.peliasOneEdgeGram;
+    t.equal(typeof s.analysis.analyzer.peliasIndexOneEdgeGram, 'object', 'there is a peliasIndexOneEdgeGram analyzer');
+    var analyzer = s.analysis.analyzer.peliasIndexOneEdgeGram;
     t.equal(analyzer.type, 'custom', 'custom analyzer');
     t.equal(typeof analyzer.tokenizer, 'string', 'tokenizer specified');
     t.deepEqual(analyzer.char_filter, ["punctuation"], 'punctuation filter specified');
     t.true(Array.isArray(analyzer.filter), 'filters specified');
     t.end();
   });
-  test('peliasOneEdgeGram token filters', function(t) {
-    var analyzer = settings().analysis.analyzer.peliasOneEdgeGram;
+  test('peliasIndexOneEdgeGram token filters', function(t) {
+    var analyzer = settings().analysis.analyzer.peliasIndexOneEdgeGram;
     t.deepEqual( analyzer.filter, [
       "lowercase",
       "asciifolding",
       "trim",
-      "address_suffix_expansion",
+      "full_token_address_suffix_expansion",
       "ampersand",
       "removeAllZeroNumericPrefix",
       "kstem",
@@ -73,24 +73,24 @@ module.exports.tests.peliasOneEdgeGramAnalyzer = function(test, common) {
   });
 };
 
-module.exports.tests.peliasTwoEdgeGramAnalyzer = function(test, common) {
-  test('has peliasTwoEdgeGram analyzer', function(t) {
+module.exports.tests.peliasIndexTwoEdgeGramAnalyzer = function(test, common) {
+  test('has peliasIndexTwoEdgeGram analyzer', function(t) {
     var s = settings();
-    t.equal(typeof s.analysis.analyzer.peliasTwoEdgeGram, 'object', 'there is a peliasTwoEdgeGram analyzer');
-    var analyzer = s.analysis.analyzer.peliasTwoEdgeGram;
+    t.equal(typeof s.analysis.analyzer.peliasIndexTwoEdgeGram, 'object', 'there is a peliasIndexTwoEdgeGram analyzer');
+    var analyzer = s.analysis.analyzer.peliasIndexTwoEdgeGram;
     t.equal(analyzer.type, 'custom', 'custom analyzer');
     t.equal(typeof analyzer.tokenizer, 'string', 'tokenizer specified');
     t.deepEqual(analyzer.char_filter, ["punctuation"], 'punctuation filter specified');
     t.true(Array.isArray(analyzer.filter), 'filters specified');
     t.end();
   });
-  test('peliasTwoEdgeGram token filters', function(t) {
-    var analyzer = settings().analysis.analyzer.peliasTwoEdgeGram;
+  test('peliasIndexTwoEdgeGram token filters', function(t) {
+    var analyzer = settings().analysis.analyzer.peliasIndexTwoEdgeGram;
     t.deepEqual( analyzer.filter, [
       "lowercase",
       "asciifolding",
       "trim",
-      "address_suffix_expansion",
+      "full_token_address_suffix_expansion",
       "ampersand",
       "removeAllZeroNumericPrefix",
       "kstem",
@@ -256,9 +256,9 @@ module.exports.tests.notnullFilter = function(test, common) {
 
 // this filter creates edgeNGrams with the minimum size of 1
 module.exports.tests.peliasOneEdgeGramFilter = function(test, common) {
-  test('has peliasOneEdgeGram filter', function(t) {
+  test('has peliasIndexOneEdgeGram filter', function(t) {
     var s = settings();
-    t.equal(typeof s.analysis.filter.peliasOneEdgeGramFilter, 'object', 'there is a peliasOneEdgeGram filter');
+    t.equal(typeof s.analysis.filter.peliasOneEdgeGramFilter, 'object', 'there is a peliasIndexOneEdgeGram filter');
     var filter = s.analysis.filter.peliasOneEdgeGramFilter;
     t.equal(filter.type, 'edgeNGram');
     t.equal(filter.min_gram, 1);
@@ -269,9 +269,9 @@ module.exports.tests.peliasOneEdgeGramFilter = function(test, common) {
 
 // this filter creates edgeNGrams with the minimum size of 2
 module.exports.tests.peliasTwoEdgeGramFilter = function(test, common) {
-  test('has peliasTwoEdgeGram filter', function(t) {
+  test('has peliasIndexTwoEdgeGram filter', function(t) {
     var s = settings();
-    t.equal(typeof s.analysis.filter.peliasTwoEdgeGramFilter, 'object', 'there is a peliasTwoEdgeGram filter');
+    t.equal(typeof s.analysis.filter.peliasTwoEdgeGramFilter, 'object', 'there is a peliasIndexTwoEdgeGram filter');
     var filter = s.analysis.filter.peliasTwoEdgeGramFilter;
     t.equal(filter.type, 'edgeNGram');
     t.equal(filter.min_gram, 2);

--- a/test/settings.js
+++ b/test/settings.js
@@ -95,6 +95,7 @@ module.exports.tests.peliasIndexTwoEdgeGramAnalyzer = function(test, common) {
       "removeAllZeroNumericPrefix",
       "kstem",
       "peliasTwoEdgeGramFilter",
+      "direction_synonym_contraction_keep_original",
       "unique",
       "notnull"
     ]);


### PR DESCRIPTION
This PR refactors the analyzers used by the `/v1/autocomplete` endpoint, with the goals of:

- removing all interdependencies with the `/v1/search` endpoint making subsequent refactoring easier.
- providing a more robust method of handling synonym substitution:
 - by considering the differences between 'index time' analysis and 'query time' analysis.
 - by handling 'partial tokens' (partially complete words) and 'full tokens' differently.

Currently we use 3 different analyzers in the `/v1/autocomplete` endpoint:

| analyzer |  "trade center"  |
|---|---|
| peliasOneEdgeGram | "t", "tr", "tra", "trad", "trade", "c", "ce", "cen", "cent", "cente", "center" |
| peliasTwoEdgeGram | "tr", "tra", "trad", "trade", "ce", "cen", "cent", "cente", "center" |
| peliasPhrase | "trade", "ctr" |

The `peliasPhrase` analyzer was originally intended to be used with `/v1/search` and you can see above that the way it handles synonyms is mismatched with the way the other 2 analyzers handle the word `center` (for example). *this is the cause of https://github.com/pelias/pelias/issues/211*

## new analyzers:

The new analyzers proposed in this PR are:

| analyzer | tokenizer | partial safe? | "center"  |
|---|:-:|:-:|---|
| peliasIndexOneEdgeGram | 1gram | × | "c", "ce", "cen", "cent", "cente", "center"  |
| peliasIndexTwoEdgeGram | 2gram | × | "ce", "cen", "cent", "cente", "center" |
| peliasQueryPartialToken | word | ✔ | "center" |
| peliasQueryFullToken | keyword | × | "center" |

They produce the same tokens when given the abbreviated/contracted form "ctr":

| analyzer | tokenizer | partial safe? | "ctr"  |
|---|:-:|:-:|---|
| peliasIndexOneEdgeGram | 1gram | × | "c", "ce", "cen", "cent", "cente", "center"  |
| peliasIndexTwoEdgeGram | 2gram | × | "ce", "cen", "cent", "cente", "center" |
| peliasQueryPartialToken | word | ✔ | "center" |
| peliasQueryFullToken | keyword | × | "center" |

#### directionals:

They also handle directional synonyms in a similar way:

| analyzer | tokenizer | partial safe? | "north"  |
|---|:-:|:-:|---|
| peliasIndexOneEdgeGram | 1gram | × | "n", "no", "nor", "nort", "north"  |
| peliasIndexTwoEdgeGram | 2gram | × | "no", "nor", "nort", "north", "n" |
| peliasQueryPartialToken | word | ✔ | "north" |
| peliasQueryFullToken | keyword | × | "north" |

Again, they produce the same tokens when given the abbreviated/contracted form "n":

| analyzer | tokenizer | partial safe? | "n"  |
|---|:-:|:-:|---|
| peliasIndexOneEdgeGram | 1gram | × | "n", "no", "nor", "nort", "north"  |
| peliasIndexTwoEdgeGram | 2gram | × | "no", "nor", "nort", "north", "n" |
| peliasQueryPartialToken | word | ✔ | "n" |
| peliasQueryFullToken | keyword | × | "north" |

*note*: there is a bit of a 'hack' in place for the above `peliasIndexTwoEdgeGram` analysis that is specific to directionals, you can see it adds a single gram 'n' in to a token stream which usually only contains grams of size 2+. This improves address matching and reduces 'jitter'.

## api/query changes:

All usages of existing analyzers in `/v1/autocomplete` must be updated:
- `peliasOneEdgeGram` -> `peliasQueryPartialToken`
- `peliasPhrase` -> `peliasQueryFullToken`

Additionally the **autocomplete** queries should no longer need to use the `phrase.*` index, all queries can safely be performed against the `name.*` index (if not already doing so).

*note*: we can discuss removing the `phrase.*` index completely! this would greatly reduce the cluster disk/ram usage, it might be possible to achieve all the functionality of `/v1/search` using the prefixGram index. *let's discuss this in another issue*.

## dataset importer changes:

nil

## risks / expected acceptance test changes:

There is not much that can go wrong here, the only differences at index time are that:
- `peliasIndexOneEdgeGram` expands directionals whereas `peliasOneEdgeGram` does not.
- `peliasIndexTwoEdgeGram` is the same and includes the 'hack' mentioned above.

The differences at query time are:
- issue 211 is resolved
- expect to see better handling of queries containing a single directional gram such as 'w 26 st'.

I've left some other changes I would like to make for a future PR in order to reduce the amount of changes going in at the same time.

## related:

closes https://github.com/pelias/schema/issues/105
resolves https://github.com/pelias/pelias/issues/211
related https://github.com/pelias/openaddresses/pull/68