### PR TITLE
Index one-grams for macroregion, macrocounty, localadmin, locality

### DIFF
--- a/schema.js
+++ b/schema.js
@@ -27,21 +27,25 @@ var schema = {
     _default_: doc,
 
     /**
-      these 3 _type are created when the index is created, while all other _type
+      these `_type`s are created when the index is created, while all other `_type`
       are dynamically created as required at run time, this served two purposes:
 
       1) creating at least one _type will avoid errors when searching against
          an empty database. Having at least one _type means that 0 documents are
          returned instead of a error from elasticsearch.
 
-      2) allows us to define their analysis differently from the other _type.
+      2) allows us to define their analysis differently from the other `_type`s.
          in this case, we will elect to use the $oneGramMapping so that these
          _type can be searched with a single character. doing so on *all* _type
          would result in much larger indeces and decreased search performance.
     **/
     country: oneGramMapping,
+    macroregion: oneGramMapping,
     region: oneGramMapping,
+    macrocounty: oneGramMapping,
     county: oneGramMapping,
+    localadmin: oneGramMapping,
+    locality: oneGramMapping,
 
     /**
       legacy _type for quattroshapes.

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -1643,6 +1643,24 @@
         }
       ]
     },
+    "macroregion": {
+      "dynamic_templates": [
+        {
+          "nameGram": {
+            "path_match": "name.*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "string",
+              "analyzer": "peliasOneEdgeGram",
+              "fielddata": {
+                "format": "fst",
+                "loading": "eager_global_ordinals"
+              }
+            }
+          }
+        }
+      ]
+    },
     "region": {
       "dynamic_templates": [
         {
@@ -1661,7 +1679,61 @@
         }
       ]
     },
+    "macrocounty": {
+      "dynamic_templates": [
+        {
+          "nameGram": {
+            "path_match": "name.*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "string",
+              "analyzer": "peliasOneEdgeGram",
+              "fielddata": {
+                "format": "fst",
+                "loading": "eager_global_ordinals"
+              }
+            }
+          }
+        }
+      ]
+    },
     "county": {
+      "dynamic_templates": [
+        {
+          "nameGram": {
+            "path_match": "name.*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "string",
+              "analyzer": "peliasOneEdgeGram",
+              "fielddata": {
+                "format": "fst",
+                "loading": "eager_global_ordinals"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "localadmin": {
+      "dynamic_templates": [
+        {
+          "nameGram": {
+            "path_match": "name.*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "string",
+              "analyzer": "peliasOneEdgeGram",
+              "fielddata": {
+                "format": "fst",
+                "loading": "eager_global_ordinals"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "locality": {
       "dynamic_templates": [
         {
           "nameGram": {


### PR DESCRIPTION
This will prevent localities and other admin areas from ranking below
counties that have the same name, but lower population.

This hopefully fixes the failing San Francisco acceptance test found in https://github.com/pelias/acceptance-tests/issues/192#issuecomment-199464239