### PR TITLE
Remove remaining legacy schema

### DIFF
--- a/integration/dynamic_templates.js
+++ b/integration/dynamic_templates.js
@@ -9,14 +9,12 @@ module.exports.tests = {};
 
 // 'admin' mappings have a different 'name' dynamic_template to the other types
 module.exports.tests.dynamic_templates_name = function(test, common){
-  test( 'admin->name (legacy)', nameAssertion( 'admin0', 'peliasOneEdgeGram' ) );
   test( 'admin->name', nameAssertion( 'country', 'peliasOneEdgeGram' ) );
   test( 'document->name', nameAssertion( 'myType', 'peliasTwoEdgeGram' ) );
 };
 
 // all types share the same phrase mapping
 module.exports.tests.dynamic_templates_phrase = function(test, common){
-  test( 'admin->phrase (legacy)', phraseAssertion( 'admin0', 'peliasPhrase' ) );
   test( 'admin->phrase', phraseAssertion( 'country', 'peliasPhrase' ) );
   test( 'document->phrase', phraseAssertion( 'myType', 'peliasPhrase' ) );
 };

--- a/mappings/document.js
+++ b/mappings/document.js
@@ -45,15 +45,6 @@ var schema = {
       }
     },
 
-    // quattroshapes (legacy) hierarchy
-    admin0: admin,
-    admin1: admin,
-    admin1_abbr: admin,
-    admin2: admin,
-    local_admin: admin,
-    locality: admin,
-    neighborhood: admin,
-
     // hierarchy
     parent: {
       type: 'object',

--- a/schema.js
+++ b/schema.js
@@ -46,15 +46,7 @@ var schema = {
     county: oneGramMapping,
     localadmin: oneGramMapping,
     locality: oneGramMapping,
-    borough: oneGramMapping,
-
-    /**
-      legacy _type for quattroshapes.
-      @todo: remove these once quattroshapes has been decomissioned.
-    **/
-    admin0: oneGramMapping,
-    admin1: oneGramMapping,
-    admin2: oneGramMapping
+    borough: oneGramMapping
   }
 };
 

--- a/test/compile.js
+++ b/test/compile.js
@@ -31,15 +31,6 @@ module.exports.tests.indeces = function(test, common) {
     t.equal(schema.mappings.county.dynamic_templates[0].nameGram.mapping.analyzer, 'peliasOneEdgeGram');
     t.end();
   });
-  test('explicitly specify some admin indeces and their analyzer (legacy)', function(t) {
-    t.equal(typeof schema.mappings.admin0, 'object', 'mappings present');
-    t.equal(schema.mappings.admin0.dynamic_templates[0].nameGram.mapping.analyzer, 'peliasOneEdgeGram');
-    t.equal(typeof schema.mappings.admin1, 'object', 'mappings present');
-    t.equal(schema.mappings.admin1.dynamic_templates[0].nameGram.mapping.analyzer, 'peliasOneEdgeGram');
-    t.equal(typeof schema.mappings.admin2, 'object', 'mappings present');
-    t.equal(schema.mappings.admin2.dynamic_templates[0].nameGram.mapping.analyzer, 'peliasOneEdgeGram');
-    t.end();
-  });
 };
 
 // some 'admin' types allow single edgeNGrams and so have a different dynamic_template
@@ -47,25 +38,6 @@ module.exports.tests.dynamic_templates = function(test, common) {
   test('dynamic_templates: nameGram', function(t) {
     t.equal(typeof schema.mappings.country.dynamic_templates[0].nameGram, 'object', 'nameGram template specified');
     var template = schema.mappings.country.dynamic_templates[0].nameGram;
-    t.equal(template.path_match, 'name.*');
-    t.equal(template.match_mapping_type, 'string');
-    t.deepEqual(template.mapping, {
-      type: 'string',
-      analyzer: 'peliasOneEdgeGram',
-      fielddata: {
-        format: 'fst',
-        loading: 'eager_global_ordinals'
-      }
-    });
-    t.end();
-  });
-};
-
-// as above for the legacy quattroshapes _types
-module.exports.tests.dynamic_templates_legacy = function(test, common) {
-  test('dynamic_templates: nameGram (legacy)', function(t) {
-    t.equal(typeof schema.mappings.admin0.dynamic_templates[0].nameGram, 'object', 'nameGram template specified');
-    var template = schema.mappings.admin0.dynamic_templates[0].nameGram;
     t.equal(template.path_match, 'name.*');
     t.equal(template.match_mapping_type, 'string');
     t.deepEqual(template.mapping, {

--- a/test/document.js
+++ b/test/document.js
@@ -21,7 +21,7 @@ module.exports.tests.properties = function(test, common) {
 
 // should contain the correct field definitions
 module.exports.tests.fields = function(test, common) {
-  var fields = ['source', 'layer', 'alpha3', 'name', 'phrase', 'address_parts', 'admin0', 'admin1', 'admin1_abbr', 'admin2', 'local_admin', 'locality', 'neighborhood', 'parent', 'center_point', 'shape', 'bounding_box', 'source_id', 'category', 'population', 'popularity'];
+  var fields = ['source', 'layer', 'alpha3', 'name', 'phrase', 'address_parts', 'parent', 'center_point', 'shape', 'bounding_box', 'source_id', 'category', 'population', 'popularity'];
   test('fields specified', function(t) {
     t.deepEqual(Object.keys(schema.properties), fields);
     t.end();

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -1407,41 +1407,6 @@
             }
           }
         },
-        "admin0": {
-          "type": "string",
-          "analyzer": "peliasAdmin",
-          "store": "yes"
-        },
-        "admin1": {
-          "type": "string",
-          "analyzer": "peliasAdmin",
-          "store": "yes"
-        },
-        "admin1_abbr": {
-          "type": "string",
-          "analyzer": "peliasAdmin",
-          "store": "yes"
-        },
-        "admin2": {
-          "type": "string",
-          "analyzer": "peliasAdmin",
-          "store": "yes"
-        },
-        "local_admin": {
-          "type": "string",
-          "analyzer": "peliasAdmin",
-          "store": "yes"
-        },
-        "locality": {
-          "type": "string",
-          "analyzer": "peliasAdmin",
-          "store": "yes"
-        },
-        "neighborhood": {
-          "type": "string",
-          "analyzer": "peliasAdmin",
-          "store": "yes"
-        },
         "parent": {
           "type": "object",
           "dynamic": true,
@@ -1800,60 +1765,6 @@
       ]
     },
     "locality": {
-      "dynamic_templates": [
-        {
-          "nameGram": {
-            "path_match": "name.*",
-            "match_mapping_type": "string",
-            "mapping": {
-              "type": "string",
-              "analyzer": "peliasOneEdgeGram",
-              "fielddata": {
-                "format": "fst",
-                "loading": "eager_global_ordinals"
-              }
-            }
-          }
-        }
-      ]
-    },
-    "admin0": {
-      "dynamic_templates": [
-        {
-          "nameGram": {
-            "path_match": "name.*",
-            "match_mapping_type": "string",
-            "mapping": {
-              "type": "string",
-              "analyzer": "peliasOneEdgeGram",
-              "fielddata": {
-                "format": "fst",
-                "loading": "eager_global_ordinals"
-              }
-            }
-          }
-        }
-      ]
-    },
-    "admin1": {
-      "dynamic_templates": [
-        {
-          "nameGram": {
-            "path_match": "name.*",
-            "match_mapping_type": "string",
-            "mapping": {
-              "type": "string",
-              "analyzer": "peliasOneEdgeGram",
-              "fielddata": {
-                "format": "fst",
-                "loading": "eager_global_ordinals"
-              }
-            }
-          }
-        }
-      ]
-    },
-    "admin2": {
       "dynamic_templates": [
         {
           "nameGram": {


### PR DESCRIPTION
This is no longer used now that we're 100% on the new schema.

Edit: we should remove the usage of this from wof-admin-lookup and pelias/model first.

Connected to pelias/model#32
Connected to pelias/wof-admin-lookup#38