### PR TITLE
Elasticsearch2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ env:
    - CXX=g++-4.8
  matrix:
    - TEST_SUITE=test
-   - TEST_SUITE=integration
 script: "npm run $TEST_SUITE"
 addons:
  apt:

--- a/integration/analyzer_peliasIndexOneEdgeGram.js
+++ b/integration/analyzer_peliasIndexOneEdgeGram.js
@@ -33,6 +33,7 @@ module.exports.tests.analyze = function(test, common){
 
     assertAnalysis( 'peliasIndexOneEdgeGramFilter', '1 a ab abc abcdefghij', ['1','a','ab','abc','abcd','abcde','abcdef','abcdefg','abcdefgh','abcdefghi','abcdefghij'] );
     assertAnalysis( 'removeAllZeroNumericPrefix', '00001', ['1'] );
+
     assertAnalysis( 'unique', '1 1 1', ['1'] );
     assertAnalysis( 'notnull', ' / / ', [] );
 
@@ -119,7 +120,30 @@ module.exports.tests.functional = function(test, common){
     ]);
 
     assertAnalysis( 'address', '101 mapzen place', [
-      '1', '10', '101', 'm', 'ma', 'map', 'mapz', 'mapze', 'mapzen', 'p', 'pl', 'pla', 'plac', 'place'
+      '101', 'm', 'ma', 'map', 'mapz', 'mapze', 'mapzen', 'p', 'pl', 'pla', 'plac', 'place'
+    ]);
+
+    suite.run( t.end );
+  });
+};
+
+module.exports.tests.address = function(test, common){
+  test( 'address', function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+    var assertAnalysis = analyze.bind( null, suite, t, 'peliasIndexOneEdgeGram' );
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
+
+    assertAnalysis( 'address', '101 mapzen place', [
+      '101', 'm', 'ma', 'map', 'mapz', 'mapze', 'mapzen', 'p', 'pl', 'pla', 'plac', 'place'
+    ]);
+
+    assertAnalysis( 'address', '30 w 26 st', [
+      '30', 'w', 'we', 'wes', 'west', '26', 's', 'st'
+    ]);
+
+    assertAnalysis( 'address', '4B 921 83 st', [
+      '4b', '921', '83', 's', 'st'
     ]);
 
     suite.run( t.end );

--- a/integration/analyzer_peliasQueryFullToken.js
+++ b/integration/analyzer_peliasQueryFullToken.js
@@ -176,6 +176,29 @@ module.exports.tests.slop = function(test, common){
   });
 };
 
+module.exports.tests.address = function(test, common){
+  test( 'address', function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+    var assertAnalysis = analyze.bind( null, suite, t, 'peliasQueryFullToken' );
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
+
+    assertAnalysis( 'address', '101 mapzen place', [
+      '101', 'mapzen', 'place'
+    ]);
+
+    assertAnalysis( 'address', '30 w 26 st', [
+      '30', 'west', '26', 'st'
+    ]);
+
+    assertAnalysis( 'address', '4B 921 83 st', [
+      '4b', '921', '83', 'st'
+    ]);
+
+    suite.run( t.end );
+  });
+};
+
 module.exports.all = function (tape, common) {
 
   function test(name, testFunction) {

--- a/integration/analyzer_peliasQueryPartialToken.js
+++ b/integration/analyzer_peliasQueryPartialToken.js
@@ -99,6 +99,29 @@ module.exports.tests.functional = function(test, common){
   });
 };
 
+module.exports.tests.address = function(test, common){
+  test( 'address', function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+    var assertAnalysis = analyze.bind( null, suite, t, 'peliasQueryPartialToken' );
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
+
+    assertAnalysis( 'address', '101 mapzen place', [
+      '101', 'mapzen', 'place'
+    ]);
+
+    assertAnalysis( 'address', '30 w 26 st', [
+      '30', 'w', '26', 'st'
+    ]);
+
+    assertAnalysis( 'address', '4B 921 83 st', [
+      '4b', '921', '83', 'st'
+    ]);
+
+    suite.run( t.end );
+  });
+};
+
 module.exports.all = function (tape, common) {
 
   function test(name, testFunction) {

--- a/integration/dynamic_templates.js
+++ b/integration/dynamic_templates.js
@@ -10,7 +10,7 @@ module.exports.tests = {};
 // 'admin' mappings have a different 'name' dynamic_template to the other types
 module.exports.tests.dynamic_templates_name = function(test, common){
   test( 'admin->name', nameAssertion( 'country', 'peliasIndexOneEdgeGram' ) );
-  test( 'document->name', nameAssertion( 'myType', 'peliasIndexTwoEdgeGram' ) );
+  test( 'document->name', nameAssertion( 'myType', 'peliasIndexOneEdgeGram' ) );
 };
 
 // all types share the same phrase mapping

--- a/integration/validate.js
+++ b/integration/validate.js
@@ -10,12 +10,12 @@ module.exports.tests = {};
 
 module.exports.tests.validate = function(test, common){
   test( 'schema', function(t){
-    
+
     var suite = new elastictest.Suite( null, { schema: schema } );
 
     suite.assert( function( done ){
-      suite.client.info({}, function( err, res ){
-        t.equal( res.status, 200 );
+      suite.client.info({}, function( err, res, status ){
+        t.equal( status, 200 );
         done();
       });
     });

--- a/mappings/document.js
+++ b/mappings/document.js
@@ -24,23 +24,19 @@ var schema = {
       properties: {
         name: {
           type: 'string',
-          index_analyzer: 'keyword',
-          search_analyzer: 'keyword'
+          analyzer: 'keyword',
         },
         number: {
           type: 'string',
-          index_analyzer: 'peliasHousenumber',
-          search_analyzer: 'peliasHousenumber'
+          analyzer: 'peliasHousenumber',
         },
         street: {
           type: 'string',
-          index_analyzer: 'peliasStreet',
-          search_analyzer: 'peliasStreet'
+          analyzer: 'peliasStreet',
         },
         zip: {
           type: 'string',
-          index_analyzer: 'peliasZip',
-          search_analyzer: 'peliasZip'
+          analyzer: 'peliasZip',
         }
       }
     },
@@ -115,9 +111,8 @@ var schema = {
       match_mapping_type: 'string',
       mapping: {
         type: 'string',
-        analyzer: 'peliasIndexTwoEdgeGram',
+        analyzer: 'peliasIndexOneEdgeGram',
         fielddata : {
-          format : 'fst',
           loading: 'eager_global_ordinals'
         }
       }

--- a/mappings/partial/centroid.js
+++ b/mappings/partial/centroid.js
@@ -9,12 +9,7 @@ var schema = {
   /* store geohashes (with prefixes) in order to facilitate the geohash_cell filter */
   'geohash': true,
   'geohash_prefix': true,
-  'geohash_precision': 18,
-
-  /* eager loading should be enabled to prevent cold starts */
-  'fielddata' : {
-    'loading': 'eager_global_ordinals'
-  }
+  'geohash_precision': 18
 };
 
 module.exports = schema;

--- a/mappings/partial/literal.json
+++ b/mappings/partial/literal.json
@@ -1,6 +1,5 @@
 {
   "type": "string",
-  "index_analyzer": "keyword",
-  "search_analyzer": "keyword",
+  "analyzer": "keyword",
   "store": "yes"
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "colors": "^1.1.2",
     "mergeable": "latest",
-    "pelias-config": "git://github.com/pelias/config.git#elasticsearch2"
+    "pelias-config": "~2.0.0"
   },
   "devDependencies": {
     "difflet": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "colors": "^1.1.2",
     "mergeable": "latest",
-    "pelias-config": "latest"
+    "pelias-config": "git://github.com/pelias/config.git#elasticsearch2"
   },
   "devDependencies": {
     "difflet": "^1.0.1",

--- a/schema.js
+++ b/schema.js
@@ -1,22 +1,5 @@
 var doc = require('./mappings/document');
 
-var oneGramMapping = {
-  dynamic_templates: [{
-    nameGram: {
-      path_match: 'name.*',
-      match_mapping_type: 'string',
-      mapping: {
-        type: 'string',
-        analyzer: 'peliasIndexOneEdgeGram',
-        fielddata : {
-          format : 'fst',
-          loading: 'eager_global_ordinals'
-        }
-      }
-    }
-  }]
-};
-
 var schema = {
   settings: require('./settings')(),
   mappings: {
@@ -28,25 +11,22 @@ var schema = {
 
     /**
       these `_type`s are created when the index is created, while all other `_type`
-      are dynamically created as required at run time, this served two purposes:
+      are dynamically created as required at run time due to:
 
-      1) creating at least one _type will avoid errors when searching against
-         an empty database. Having at least one _type means that 0 documents are
-         returned instead of a error from elasticsearch.
+      creating at least one _type will avoid errors when searching against
+      an empty database. Having at least one _type means that 0 documents are
+      returned instead of a error from elasticsearch.
 
-      2) allows us to define their analysis differently from the other `_type`s.
-         in this case, we will elect to use the $oneGramMapping so that these
-         _type can be searched with a single character. doing so on *all* _type
-         would result in much larger indeces and decreased search performance.
+      querying against non-existant _types will result in errors.
     **/
-    country: oneGramMapping,
-    macroregion: oneGramMapping,
-    region: oneGramMapping,
-    macrocounty: oneGramMapping,
-    county: oneGramMapping,
-    localadmin: oneGramMapping,
-    locality: oneGramMapping,
-    borough: oneGramMapping
+    country: doc,
+    macroregion: doc,
+    region: doc,
+    macrocounty: doc,
+    county: doc,
+    localadmin: doc,
+    locality: doc,
+    borough: doc
   }
 };
 

--- a/scripts/info.js
+++ b/scripts/info.js
@@ -1,0 +1,3 @@
+
+var client = require('pelias-esclient')();
+client.info( {}, console.log.bind(console) );

--- a/settings.js
+++ b/settings.js
@@ -133,6 +133,21 @@ function generate(){
           "tokenizer":"standard",
           "char_filter" : ["numeric"]
         },
+        "goldbergianPeliasHousenumber": {
+          "type": "custom",
+          "tokenizer": "standard",
+          "filter": [
+            "surround_single_letters_with_!s",
+            "house_number_word_delimiter",
+            "remove_single_letters",
+            "surround_numbers_with_!s",
+            "peliasOneEdgeGramFilter",
+            "eliminate_tokens_starting_with_!",
+            "remove_encapsulating_!s",
+            "unique",
+            "notnull"
+          ]
+        },
         "peliasStreet": {
           "type": "custom",
           "tokenizer":"peliasStreetTokenizer",
@@ -213,7 +228,45 @@ function generate(){
           "type" : "pattern_replace",
           "pattern": " +",
           "replacement": " "
+        },
+        // START OF COMPLICATED FILTERS TO ANALYZE HOUSE NUMBERS
+        "surround_single_letters_with_!s":{
+          "description": "wraps single characters with !'s'",
+          "type": "pattern_replace",
+          "pattern": "^([a-z0-9])$",
+          "replacement": "!$1!"
+        },
+        "house_number_word_delimiter": {
+          "description": "splits on letter-to-number transition and vice versa",
+          "type": "word_delimiter",
+          "split_on_numerics": "true",
+          "preserve_original": "true"
+        },
+        "remove_single_letters": {
+          "description": "removes single characters created from house_number_word_delimiter",
+          "type": "length",
+          "min": 2
+        },
+        "surround_numbers_with_!s": {
+          "description": "surrounds numbers with !'s'",
+          "type": "pattern_replace",
+          "pattern": "^([0-9]+[a-z]?)$",
+          "replacement": "!$1!"
+        },
+        "eliminate_tokens_starting_with_!": {
+          "description": "removed tokens starting but not ending with !'s'",
+          "type": "pattern_replace",
+          "pattern": "^!(.*[^!])?$",
+          "replacement": ""
+        },
+        "remove_encapsulating_!s": {
+          "description": "extract the stuff between the !'s'",
+          "type": "pattern_replace",
+          "pattern": "^!(.*)!$",
+          "replacement": "$1"
         }
+        // END OF COMPLICATED FILTERS TO ANALYZE HOUSE NUMBERS
+
         // more generated below
       },
       "char_filter": {

--- a/settings.js
+++ b/settings.js
@@ -137,16 +137,27 @@ function generate(){
           "type": "custom",
           "tokenizer": "standard",
           "filter": [
-            "surround_single_letters_with_!s",
+            "surround_single_characters_with_!s",
             "house_number_word_delimiter",
-            "remove_single_letters",
-            "surround_numbers_with_!s",
+            "remove_single_characters",
+            "surround_house_numbers_with_!s",
             "peliasOneEdgeGramFilter",
             "eliminate_tokens_starting_with_!",
             "remove_encapsulating_!s",
-            "unique",
-            "notnull"
+            "notnull",
+            "unique"
           ]
+          // eg: 14a w main st
+          // surround_single_characters_with_!s  -> [14a, !w!, main, st]
+          // house_number_word_delimiter         -> [14, 14a, a, !w!, main, st]
+          // remove_single_characters            -> [14, 14a, !w!, main, st]
+          // surround_house_numbers_with_!s      -> [!14!, !14a!, !w!, main, st]
+          // peliasOneEdgeGramFilter             -> [!, !1, !14, !14!, !, !1, !14, !14a, !14a!, !, !w, !w!, m, ma, mai, main, s, st]
+          // eliminate_tokens_starting_with_!    -> ["", "", "", !14!, "", "", "", "", !14a!, "", "", w, m, ma, mai, main, s, st]
+          // remove_encapsulating_!s             -> ["", "", "", 14, "", "", "", "", 14a, "", "", w, m, ma, mai, main, s, st]
+          // notnull                             -> [14, 14a, w, m, ma, mai, main, s, st]
+          // unique                              -> [14, 14a, w, m, ma, mai, main, s, st]
+
         },
         "peliasStreet": {
           "type": "custom",
@@ -230,37 +241,37 @@ function generate(){
           "replacement": " "
         },
         // START OF COMPLICATED FILTERS TO ANALYZE HOUSE NUMBERS
-        "surround_single_letters_with_!s":{
-          "description": "wraps single characters with !'s'",
+        "surround_single_characters_with_!s":{
+          "description": "wraps single characters with !s, needed to protect valid single characters and not those extracted from house numbers (14a creates an 'a' token)",
           "type": "pattern_replace",
           "pattern": "^([a-z0-9])$",
           "replacement": "!$1!"
         },
         "house_number_word_delimiter": {
-          "description": "splits on letter-to-number transition and vice versa",
+          "description": "splits on letter-to-number transition and vice versa, splits 14a -> [14, 14a, a]",
           "type": "word_delimiter",
           "split_on_numerics": "true",
           "preserve_original": "true"
         },
-        "remove_single_letters": {
-          "description": "removes single characters created from house_number_word_delimiter",
+        "remove_single_characters": {
+          "description": "removes single characters created from house_number_word_delimiter, removes the letter portion of a house number",
           "type": "length",
           "min": 2
         },
-        "surround_numbers_with_!s": {
-          "description": "surrounds numbers with !'s'",
+        "surround_house_numbers_with_!s": {
+          "description": "surrounds house numbers with !'s', needed to protect whole house numbers from elimination step after prefix n-gramming",
           "type": "pattern_replace",
           "pattern": "^([0-9]+[a-z]?)$",
           "replacement": "!$1!"
         },
         "eliminate_tokens_starting_with_!": {
-          "description": "removed tokens starting but not ending with !'s'",
+          "description": "remove tokens starting but not ending with !'s', saves whole house numbers wrapped in !s",
           "type": "pattern_replace",
           "pattern": "^!(.*[^!])?$",
           "replacement": ""
         },
         "remove_encapsulating_!s": {
-          "description": "extract the stuff between the !'s'",
+          "description": "extract the stuff between the !'s', extract 14 from !14! since we're done the prefix n-gramming step",
           "type": "pattern_replace",
           "pattern": "^!(.*)!$",
           "replacement": "$1"

--- a/test/compile.js
+++ b/test/compile.js
@@ -19,7 +19,7 @@ module.exports.tests.compile = function(test, common) {
 module.exports.tests.indeces = function(test, common) {
   test('contains "_default_" index definition', function(t) {
     t.equal(typeof schema.mappings._default_, 'object', 'mappings present');
-    t.equal(schema.mappings._default_.dynamic_templates[0].nameGram.mapping.analyzer, 'peliasIndexTwoEdgeGram');
+    t.equal(schema.mappings._default_.dynamic_templates[0].nameGram.mapping.analyzer, 'peliasIndexOneEdgeGram');
     t.end();
   });
   test('explicitly specify some admin indeces and their analyzer', function(t) {
@@ -44,7 +44,6 @@ module.exports.tests.dynamic_templates = function(test, common) {
       type: 'string',
       analyzer: 'peliasIndexOneEdgeGram',
       fielddata: {
-        format: 'fst',
         loading: 'eager_global_ordinals'
       }
     });
@@ -66,7 +65,7 @@ module.exports.tests.current_schema = function(test, common) {
     delete process.env.PELIAS_CONFIG;
 
     // code intentionally commented to allow quick debugging of expected.json
-    // common.diff(fixture, schemaCopy);
+    // common.diff(schemaCopy, fixture);
 
     t.deepEqual(schemaCopy, fixture);
     t.end();

--- a/test/document.js
+++ b/test/document.js
@@ -46,24 +46,21 @@ module.exports.tests.address_analysis = function(test, common) {
   // at time of writing this field was not used by any API queries.
   test('name', function(t) {
     t.equal(prop.name.type, 'string');
-    t.equal(prop.name.index_analyzer, 'keyword');
-    t.equal(prop.name.search_analyzer, 'keyword');
+    t.equal(prop.name.analyzer, 'keyword');
     t.end();
   });
 
   // $number analysis is discussed in: https://github.com/pelias/schema/pull/77
   test('number', function(t) {
     t.equal(prop.number.type, 'string');
-    t.equal(prop.number.index_analyzer, 'peliasHousenumber');
-    t.equal(prop.number.search_analyzer, 'peliasHousenumber');
+    t.equal(prop.number.analyzer, 'peliasHousenumber');
     t.end();
   });
 
   // $street analysis is discussed in: https://github.com/pelias/schema/pull/77
   test('street', function(t) {
     t.equal(prop.street.type, 'string');
-    t.equal(prop.street.index_analyzer, 'peliasStreet');
-    t.equal(prop.street.search_analyzer, 'peliasStreet');
+    t.equal(prop.street.analyzer, 'peliasStreet');
     t.end();
   });
 
@@ -72,8 +69,7 @@ module.exports.tests.address_analysis = function(test, common) {
   // generic term such as $postalcode as it is not specific to the USA.
   test('zip', function(t) {
     t.equal(prop.zip.type, 'string');
-    t.equal(prop.zip.index_analyzer, 'peliasZip');
-    t.equal(prop.zip.search_analyzer, 'peliasZip');
+    t.equal(prop.zip.analyzer, 'peliasZip');
     t.end();
   });
 };
@@ -99,8 +95,8 @@ module.exports.tests.parent_analysis = function(test, common) {
       t.equal(prop[field+'_a'].type, 'string');
       t.equal(prop[field+'_a'].analyzer, 'peliasAdmin');
       t.equal(prop[field+'_id'].type, 'string');
-      t.equal(prop[field+'_id'].index_analyzer, 'keyword');
-      t.equal(prop[field+'_id'].search_analyzer, 'keyword');
+      t.equal(prop[field+'_id'].analyzer, 'keyword');
+
       t.end();
     });
   });
@@ -123,9 +119,8 @@ module.exports.tests.dynamic_templates = function(test, common) {
     t.equal(template.match_mapping_type, 'string');
     t.deepEqual(template.mapping, {
       type: 'string',
-      analyzer: 'peliasIndexTwoEdgeGram',
+      analyzer: 'peliasIndexOneEdgeGram',
       fielddata: {
-        format: 'fst',
         loading: 'eager_global_ordinals'
       }
     });

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -130,6 +130,21 @@
             "numeric"
           ]
         },
+        "goldbergianPeliasHousenumber": {
+          "type": "custom",
+          "tokenizer": "standard",
+          "filter": [
+            "surround_single_letters_with_!s",
+            "house_number_word_delimiter",
+            "remove_single_letters",
+            "surround_numbers_with_!s",
+            "peliasOneEdgeGramFilter",
+            "eliminate_tokens_starting_with_!",
+            "remove_encapsulating_!s",
+            "unique",
+            "notnull"
+          ]
+        },
         "peliasStreet": {
           "type": "custom",
           "tokenizer": "peliasStreetTokenizer",
@@ -796,6 +811,41 @@
           "type": "pattern_replace",
           "pattern": " +",
           "replacement": " "
+        },
+        "surround_single_letters_with_!s":{
+          "description": "wraps single characters with !'s'",
+          "type": "pattern_replace",
+          "pattern": "^([a-z0-9])$",
+          "replacement": "!$1!"
+        },
+        "house_number_word_delimiter": {
+          "description": "splits on letter-to-number transition and vice versa",
+          "type": "word_delimiter",
+          "split_on_numerics": "true",
+          "preserve_original": "true"
+        },
+        "remove_single_letters": {
+          "description": "removes single characters created from house_number_word_delimiter",
+          "type": "length",
+          "min": 2
+        },
+        "surround_numbers_with_!s": {
+          "description": "surrounds numbers with !'s'",
+          "type": "pattern_replace",
+          "pattern": "^([0-9]+[a-z]?)$",
+          "replacement": "!$1!"
+        },
+        "eliminate_tokens_starting_with_!": {
+          "description": "removed tokens starting but not ending with !'s'",
+          "type": "pattern_replace",
+          "pattern": "^!(.*[^!])?$",
+          "replacement": ""
+        },
+        "remove_encapsulating_!s": {
+          "description": "extract the stuff between the !'s'",
+          "type": "pattern_replace",
+          "pattern": "^!(.*)!$",
+          "replacement": "$1"
         },
         "keyword_street_suffix_alley": {
           "type": "pattern_replace",

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -26,10 +26,12 @@
             "notnull"
           ]
         },
-        "peliasIndexOneEdgeGram" : {
+        "peliasIndexOneEdgeGram": {
           "type": "custom",
-          "tokenizer" : "peliasNameTokenizer",
-          "char_filter" : ["punctuation"],
+          "tokenizer": "peliasNameTokenizer",
+          "char_filter": [
+            "punctuation"
+          ],
           "filter": [
             "lowercase",
             "asciifolding",
@@ -38,15 +40,23 @@
             "ampersand",
             "remove_ordinals",
             "removeAllZeroNumericPrefix",
+            "surround_single_characters_with_word_markers",
+            "house_number_word_delimiter",
+            "remove_single_characters",
+            "surround_house_numbers_with_word_markers",
             "peliasOneEdgeGramFilter",
+            "eliminate_tokens_starting_with_word_marker",
+            "remove_encapsulating_word_markers",
             "unique",
             "notnull"
           ]
         },
-        "peliasIndexTwoEdgeGram" : {
+        "peliasIndexTwoEdgeGram": {
           "type": "custom",
-          "tokenizer" : "peliasNameTokenizer",
-          "char_filter" : ["punctuation"],
+          "tokenizer": "peliasNameTokenizer",
+          "char_filter": [
+            "punctuation"
+          ],
           "filter": [
             "lowercase",
             "asciifolding",
@@ -63,10 +73,12 @@
             "notnull"
           ]
         },
-        "peliasQueryPartialToken" : {
+        "peliasQueryPartialToken": {
           "type": "custom",
-          "tokenizer" : "peliasNameTokenizer",
-          "char_filter" : ["punctuation"],
+          "tokenizer": "peliasNameTokenizer",
+          "char_filter": [
+            "punctuation"
+          ],
           "filter": [
             "lowercase",
             "asciifolding",
@@ -79,10 +91,12 @@
             "notnull"
           ]
         },
-        "peliasQueryFullToken" : {
+        "peliasQueryFullToken": {
           "type": "custom",
-          "tokenizer" : "peliasNameTokenizer",
-          "char_filter" : ["punctuation"],
+          "tokenizer": "peliasNameTokenizer",
+          "char_filter": [
+            "punctuation"
+          ],
           "filter": [
             "lowercase",
             "asciifolding",
@@ -128,21 +142,6 @@
           "tokenizer": "standard",
           "char_filter": [
             "numeric"
-          ]
-        },
-        "goldbergianPeliasHousenumber": {
-          "type": "custom",
-          "tokenizer": "standard",
-          "filter": [
-            "surround_single_letters_with_!s",
-            "house_number_word_delimiter",
-            "remove_single_letters",
-            "surround_numbers_with_!s",
-            "peliasOneEdgeGramFilter",
-            "eliminate_tokens_starting_with_!",
-            "remove_encapsulating_!s",
-            "unique",
-            "notnull"
           ]
         },
         "peliasStreet": {
@@ -309,10 +308,10 @@
           "min_gram": 2,
           "max_gram": 18
         },
-        "prefixZeroToSingleDigitNumbers" : {
-          "type" : "pattern_replace",
-          "pattern" : "^([0-9])$",
-          "replacement" : "0$1"
+        "prefixZeroToSingleDigitNumbers": {
+          "type": "pattern_replace",
+          "pattern": "^([0-9])$",
+          "replacement": "0$1"
         },
         "removeAllZeroNumericPrefix": {
           "type": "pattern_replace",
@@ -812,39 +811,39 @@
           "pattern": " +",
           "replacement": " "
         },
-        "surround_single_letters_with_!s":{
-          "description": "wraps single characters with !'s'",
+        "surround_single_characters_with_word_markers": {
+          "description": "wraps single characters with markers, needed to protect valid single characters and not those extracted from house numbers (14a creates an 'a' token)",
           "type": "pattern_replace",
-          "pattern": "^([a-z0-9])$",
-          "replacement": "!$1!"
+          "pattern": "^(.{1})$",
+          "replacement": "\u0002$1\u0003"
         },
         "house_number_word_delimiter": {
-          "description": "splits on letter-to-number transition and vice versa",
+          "description": "splits on letter-to-number transition and vice versa, splits 14a -> [14, 14a, a]",
           "type": "word_delimiter",
           "split_on_numerics": "true",
           "preserve_original": "true"
         },
-        "remove_single_letters": {
-          "description": "removes single characters created from house_number_word_delimiter",
+        "remove_single_characters": {
+          "description": "removes single characters created from house_number_word_delimiter, removes the letter portion of a house number",
           "type": "length",
           "min": 2
         },
-        "surround_numbers_with_!s": {
-          "description": "surrounds numbers with !'s'",
+        "surround_house_numbers_with_word_markers": {
+          "description": "surrounds house numbers with markers, needed to protect whole house numbers from elimination step after prefix n-gramming",
           "type": "pattern_replace",
           "pattern": "^([0-9]+[a-z]?)$",
-          "replacement": "!$1!"
+          "replacement": "\u0002$1\u0003"
         },
-        "eliminate_tokens_starting_with_!": {
-          "description": "removed tokens starting but not ending with !'s'",
+        "eliminate_tokens_starting_with_word_marker": {
+          "description": "remove tokens starting but not ending with markers, saves whole house numbers wrapped in markers",
           "type": "pattern_replace",
-          "pattern": "^!(.*[^!])?$",
+          "pattern": "^\u0002(.*[^\u0003])?$",
           "replacement": ""
         },
-        "remove_encapsulating_!s": {
-          "description": "extract the stuff between the !'s'",
+        "remove_encapsulating_word_markers": {
+          "description": "extract the stuff between the markers, extract 14 from \u000214\u0003 since we're done the prefix n-gramming step",
           "type": "pattern_replace",
-          "pattern": "^!(.*)!$",
+          "pattern": "^\u0002(.*)\u0003$",
           "replacement": "$1"
         },
         "keyword_street_suffix_alley": {
@@ -2349,269 +2348,6 @@
       },
       "dynamic": "true"
     },
-    "borough": {
-      "properties": {
-        "source": {
-          "type": "string",
-          "analyzer": "keyword",
-          "store": "yes"
-        },
-        "layer": {
-          "type": "string",
-          "analyzer": "keyword",
-          "store": "yes"
-        },
-        "alpha3": {
-          "type": "string",
-          "analyzer": "peliasAdmin",
-          "store": "yes"
-        },
-        "name": {
-          "type": "object",
-          "dynamic": true
-        },
-        "phrase": {
-          "type": "object",
-          "dynamic": true
-        },
-        "address_parts": {
-          "type": "object",
-          "dynamic": true,
-          "properties": {
-            "name": {
-              "type": "string",
-              "analyzer": "keyword"
-            },
-            "number": {
-              "type": "string",
-              "analyzer": "peliasHousenumber"
-            },
-            "street": {
-              "type": "string",
-              "analyzer": "peliasStreet"
-            },
-            "zip": {
-              "type": "string",
-              "analyzer": "peliasZip"
-            }
-          }
-        },
-        "parent": {
-          "type": "object",
-          "dynamic": true,
-          "properties": {
-            "country": {
-              "type": "string",
-              "analyzer": "peliasAdmin",
-              "store": "yes"
-            },
-            "country_a": {
-              "type": "string",
-              "analyzer": "peliasAdmin",
-              "store": "yes"
-            },
-            "country_id": {
-              "type": "string",
-              "analyzer": "keyword",
-              "store": "yes"
-            },
-            "macroregion": {
-              "type": "string",
-              "analyzer": "peliasAdmin",
-              "store": "yes"
-            },
-            "macroregion_a": {
-              "type": "string",
-              "analyzer": "peliasAdmin",
-              "store": "yes"
-            },
-            "macroregion_id": {
-              "type": "string",
-              "analyzer": "keyword",
-              "store": "yes"
-            },
-            "region": {
-              "type": "string",
-              "analyzer": "peliasAdmin",
-              "store": "yes"
-            },
-            "region_a": {
-              "type": "string",
-              "analyzer": "peliasAdmin",
-              "store": "yes"
-            },
-            "region_id": {
-              "type": "string",
-              "analyzer": "keyword",
-              "store": "yes"
-            },
-            "macrocounty": {
-              "type": "string",
-              "analyzer": "peliasAdmin",
-              "store": "yes"
-            },
-            "macrocounty_a": {
-              "type": "string",
-              "analyzer": "peliasAdmin",
-              "store": "yes"
-            },
-            "macrocounty_id": {
-              "type": "string",
-              "analyzer": "keyword",
-              "store": "yes"
-            },
-            "county": {
-              "type": "string",
-              "analyzer": "peliasAdmin",
-              "store": "yes"
-            },
-            "county_a": {
-              "type": "string",
-              "analyzer": "peliasAdmin",
-              "store": "yes"
-            },
-            "county_id": {
-              "type": "string",
-              "analyzer": "keyword",
-              "store": "yes"
-            },
-            "locality": {
-              "type": "string",
-              "analyzer": "peliasAdmin",
-              "store": "yes"
-            },
-            "locality_a": {
-              "type": "string",
-              "analyzer": "peliasAdmin",
-              "store": "yes"
-            },
-            "locality_id": {
-              "type": "string",
-              "analyzer": "keyword",
-              "store": "yes"
-            },
-            "borough": {
-              "type": "string",
-              "analyzer": "peliasAdmin",
-              "store": "yes"
-            },
-            "borough_a": {
-              "type": "string",
-              "analyzer": "peliasAdmin",
-              "store": "yes"
-            },
-            "borough_id": {
-              "type": "string",
-              "analyzer": "keyword",
-              "store": "yes"
-            },
-            "localadmin": {
-              "type": "string",
-              "analyzer": "peliasAdmin",
-              "store": "yes"
-            },
-            "localadmin_a": {
-              "type": "string",
-              "analyzer": "peliasAdmin",
-              "store": "yes"
-            },
-            "localadmin_id": {
-              "type": "string",
-              "analyzer": "keyword",
-              "store": "yes"
-            },
-            "neighbourhood": {
-              "type": "string",
-              "analyzer": "peliasAdmin",
-              "store": "yes"
-            },
-            "neighbourhood_a": {
-              "type": "string",
-              "analyzer": "peliasAdmin",
-              "store": "yes"
-            },
-            "neighbourhood_id": {
-              "type": "string",
-              "analyzer": "keyword",
-              "store": "yes"
-            }
-          }
-        },
-        "center_point": {
-          "type": "geo_point",
-          "lat_lon": true,
-          "geohash": true,
-          "geohash_prefix": true,
-          "geohash_precision": 18
-        },
-        "shape": {
-          "type": "geo_shape",
-          "tree": "quadtree",
-          "tree_levels": "20"
-        },
-        "bounding_box": {
-          "type": "string",
-          "index": "no",
-          "store": "yes"
-        },
-        "source_id": {
-          "type": "string",
-          "analyzer": "keyword",
-          "store": "yes"
-        },
-        "category": {
-          "type": "string",
-          "analyzer": "keyword",
-          "store": "yes"
-        },
-        "population": {
-          "type": "long",
-          "null_value": 0
-        },
-        "popularity": {
-          "type": "long",
-          "null_value": 0
-        }
-      },
-      "dynamic_templates": [
-        {
-          "nameGram": {
-            "path_match": "name.*",
-            "match_mapping_type": "string",
-            "mapping": {
-              "type": "string",
-              "analyzer": "peliasIndexOneEdgeGram",
-              "fielddata": {
-                "loading": "eager_global_ordinals"
-              }
-            }
-          }
-        },
-        {
-          "phrase": {
-            "path_match": "phrase.*",
-            "match_mapping_type": "string",
-            "mapping": {
-              "type": "string",
-              "analyzer": "peliasPhrase",
-              "fielddata": {
-                "loading": "eager_global_ordinals"
-              }
-            }
-          }
-        }
-      ],
-      "_source": {
-        "excludes": [
-          "shape",
-          "phrase"
-        ]
-      },
-      "_all": {
-        "enabled": false
-      },
-      "dynamic": "true"
-    },
     "region": {
       "properties": {
         "source": {
@@ -3665,6 +3401,269 @@
       "dynamic": "true"
     },
     "locality": {
+      "properties": {
+        "source": {
+          "type": "string",
+          "analyzer": "keyword",
+          "store": "yes"
+        },
+        "layer": {
+          "type": "string",
+          "analyzer": "keyword",
+          "store": "yes"
+        },
+        "alpha3": {
+          "type": "string",
+          "analyzer": "peliasAdmin",
+          "store": "yes"
+        },
+        "name": {
+          "type": "object",
+          "dynamic": true
+        },
+        "phrase": {
+          "type": "object",
+          "dynamic": true
+        },
+        "address_parts": {
+          "type": "object",
+          "dynamic": true,
+          "properties": {
+            "name": {
+              "type": "string",
+              "analyzer": "keyword"
+            },
+            "number": {
+              "type": "string",
+              "analyzer": "peliasHousenumber"
+            },
+            "street": {
+              "type": "string",
+              "analyzer": "peliasStreet"
+            },
+            "zip": {
+              "type": "string",
+              "analyzer": "peliasZip"
+            }
+          }
+        },
+        "parent": {
+          "type": "object",
+          "dynamic": true,
+          "properties": {
+            "country": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "country_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "country_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "macroregion": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "macroregion_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "macroregion_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "region": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "region_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "region_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "macrocounty": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "macrocounty_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "macrocounty_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "county": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "county_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "county_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "locality": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "locality_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "locality_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "borough": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "borough_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "borough_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "localadmin": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "localadmin_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "localadmin_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "neighbourhood": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "neighbourhood_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "neighbourhood_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            }
+          }
+        },
+        "center_point": {
+          "type": "geo_point",
+          "lat_lon": true,
+          "geohash": true,
+          "geohash_prefix": true,
+          "geohash_precision": 18
+        },
+        "shape": {
+          "type": "geo_shape",
+          "tree": "quadtree",
+          "tree_levels": "20"
+        },
+        "bounding_box": {
+          "type": "string",
+          "index": "no",
+          "store": "yes"
+        },
+        "source_id": {
+          "type": "string",
+          "analyzer": "keyword",
+          "store": "yes"
+        },
+        "category": {
+          "type": "string",
+          "analyzer": "keyword",
+          "store": "yes"
+        },
+        "population": {
+          "type": "long",
+          "null_value": 0
+        },
+        "popularity": {
+          "type": "long",
+          "null_value": 0
+        }
+      },
+      "dynamic_templates": [
+        {
+          "nameGram": {
+            "path_match": "name.*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "string",
+              "analyzer": "peliasIndexOneEdgeGram",
+              "fielddata": {
+                "loading": "eager_global_ordinals"
+              }
+            }
+          }
+        },
+        {
+          "phrase": {
+            "path_match": "phrase.*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "string",
+              "analyzer": "peliasPhrase",
+              "fielddata": {
+                "loading": "eager_global_ordinals"
+              }
+            }
+          }
+        }
+      ],
+      "_source": {
+        "excludes": [
+          "shape",
+          "phrase"
+        ]
+      },
+      "_all": {
+        "enabled": false
+      },
+      "dynamic": "true"
+    },
+    "borough": {
       "properties": {
         "source": {
           "type": "string",

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -1514,14 +1514,12 @@
       "properties": {
         "source": {
           "type": "string",
-          "index_analyzer": "keyword",
-          "search_analyzer": "keyword",
+          "analyzer": "keyword",
           "store": "yes"
         },
         "layer": {
           "type": "string",
-          "index_analyzer": "keyword",
-          "search_analyzer": "keyword",
+          "analyzer": "keyword",
           "store": "yes"
         },
         "alpha3": {
@@ -1543,23 +1541,19 @@
           "properties": {
             "name": {
               "type": "string",
-              "index_analyzer": "keyword",
-              "search_analyzer": "keyword"
+              "analyzer": "keyword"
             },
             "number": {
               "type": "string",
-              "index_analyzer": "peliasHousenumber",
-              "search_analyzer": "peliasHousenumber"
+              "analyzer": "peliasHousenumber"
             },
             "street": {
               "type": "string",
-              "index_analyzer": "peliasStreet",
-              "search_analyzer": "peliasStreet"
+              "analyzer": "peliasStreet"
             },
             "zip": {
               "type": "string",
-              "index_analyzer": "peliasZip",
-              "search_analyzer": "peliasZip"
+              "analyzer": "peliasZip"
             }
           }
         },
@@ -1579,8 +1573,7 @@
             },
             "country_id": {
               "type": "string",
-              "index_analyzer": "keyword",
-              "search_analyzer": "keyword",
+              "analyzer": "keyword",
               "store": "yes"
             },
             "macroregion": {
@@ -1595,8 +1588,7 @@
             },
             "macroregion_id": {
               "type": "string",
-              "index_analyzer": "keyword",
-              "search_analyzer": "keyword",
+              "analyzer": "keyword",
               "store": "yes"
             },
             "region": {
@@ -1611,8 +1603,7 @@
             },
             "region_id": {
               "type": "string",
-              "index_analyzer": "keyword",
-              "search_analyzer": "keyword",
+              "analyzer": "keyword",
               "store": "yes"
             },
             "macrocounty": {
@@ -1627,8 +1618,7 @@
             },
             "macrocounty_id": {
               "type": "string",
-              "index_analyzer": "keyword",
-              "search_analyzer": "keyword",
+              "analyzer": "keyword",
               "store": "yes"
             },
             "county": {
@@ -1643,8 +1633,7 @@
             },
             "county_id": {
               "type": "string",
-              "index_analyzer": "keyword",
-              "search_analyzer": "keyword",
+              "analyzer": "keyword",
               "store": "yes"
             },
             "locality": {
@@ -1659,8 +1648,7 @@
             },
             "locality_id": {
               "type": "string",
-              "index_analyzer": "keyword",
-              "search_analyzer": "keyword",
+              "analyzer": "keyword",
               "store": "yes"
             },
             "borough": {
@@ -1675,8 +1663,7 @@
             },
             "borough_id": {
               "type": "string",
-              "index_analyzer": "keyword",
-              "search_analyzer": "keyword",
+              "analyzer": "keyword",
               "store": "yes"
             },
             "localadmin": {
@@ -1691,8 +1678,7 @@
             },
             "localadmin_id": {
               "type": "string",
-              "index_analyzer": "keyword",
-              "search_analyzer": "keyword",
+              "analyzer": "keyword",
               "store": "yes"
             },
             "neighbourhood": {
@@ -1707,8 +1693,7 @@
             },
             "neighbourhood_id": {
               "type": "string",
-              "index_analyzer": "keyword",
-              "search_analyzer": "keyword",
+              "analyzer": "keyword",
               "store": "yes"
             }
           }
@@ -1718,10 +1703,7 @@
           "lat_lon": true,
           "geohash": true,
           "geohash_prefix": true,
-          "geohash_precision": 18,
-          "fielddata": {
-            "loading": "eager_global_ordinals"
-          }
+          "geohash_precision": 18
         },
         "shape": {
           "type": "geo_shape",
@@ -1735,14 +1717,12 @@
         },
         "source_id": {
           "type": "string",
-          "index_analyzer": "keyword",
-          "search_analyzer": "keyword",
+          "analyzer": "keyword",
           "store": "yes"
         },
         "category": {
           "type": "string",
-          "index_analyzer": "keyword",
-          "search_analyzer": "keyword",
+          "analyzer": "keyword",
           "store": "yes"
         },
         "population": {
@@ -1761,9 +1741,8 @@
             "match_mapping_type": "string",
             "mapping": {
               "type": "string",
-              "analyzer": "peliasIndexTwoEdgeGram",
+              "analyzer": "peliasIndexOneEdgeGram",
               "fielddata": {
-                "format": "fst",
                 "loading": "eager_global_ordinals"
               }
             }
@@ -1795,6 +1774,229 @@
       "dynamic": "true"
     },
     "country": {
+      "properties": {
+        "source": {
+          "type": "string",
+          "analyzer": "keyword",
+          "store": "yes"
+        },
+        "layer": {
+          "type": "string",
+          "analyzer": "keyword",
+          "store": "yes"
+        },
+        "alpha3": {
+          "type": "string",
+          "analyzer": "peliasAdmin",
+          "store": "yes"
+        },
+        "name": {
+          "type": "object",
+          "dynamic": true
+        },
+        "phrase": {
+          "type": "object",
+          "dynamic": true
+        },
+        "address_parts": {
+          "type": "object",
+          "dynamic": true,
+          "properties": {
+            "name": {
+              "type": "string",
+              "analyzer": "keyword"
+            },
+            "number": {
+              "type": "string",
+              "analyzer": "peliasHousenumber"
+            },
+            "street": {
+              "type": "string",
+              "analyzer": "peliasStreet"
+            },
+            "zip": {
+              "type": "string",
+              "analyzer": "peliasZip"
+            }
+          }
+        },
+        "parent": {
+          "type": "object",
+          "dynamic": true,
+          "properties": {
+            "country": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "country_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "country_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "macroregion": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "macroregion_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "macroregion_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "region": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "region_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "region_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "macrocounty": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "macrocounty_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "macrocounty_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "county": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "county_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "county_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "locality": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "locality_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "locality_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "borough": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "borough_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "borough_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "localadmin": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "localadmin_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "localadmin_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "neighbourhood": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "neighbourhood_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "neighbourhood_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            }
+          }
+        },
+        "center_point": {
+          "type": "geo_point",
+          "lat_lon": true,
+          "geohash": true,
+          "geohash_prefix": true,
+          "geohash_precision": 18
+        },
+        "shape": {
+          "type": "geo_shape",
+          "tree": "quadtree",
+          "tree_levels": "20"
+        },
+        "bounding_box": {
+          "type": "string",
+          "index": "no",
+          "store": "yes"
+        },
+        "source_id": {
+          "type": "string",
+          "analyzer": "keyword",
+          "store": "yes"
+        },
+        "category": {
+          "type": "string",
+          "analyzer": "keyword",
+          "store": "yes"
+        },
+        "population": {
+          "type": "long",
+          "null_value": 0
+        },
+        "popularity": {
+          "type": "long",
+          "null_value": 0
+        }
+      },
       "dynamic_templates": [
         {
           "nameGram": {
@@ -1804,15 +2006,260 @@
               "type": "string",
               "analyzer": "peliasIndexOneEdgeGram",
               "fielddata": {
-                "format": "fst",
+                "loading": "eager_global_ordinals"
+              }
+            }
+          }
+        },
+        {
+          "phrase": {
+            "path_match": "phrase.*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "string",
+              "analyzer": "peliasPhrase",
+              "fielddata": {
                 "loading": "eager_global_ordinals"
               }
             }
           }
         }
-      ]
+      ],
+      "_source": {
+        "excludes": [
+          "shape",
+          "phrase"
+        ]
+      },
+      "_all": {
+        "enabled": false
+      },
+      "dynamic": "true"
     },
     "macroregion": {
+      "properties": {
+        "source": {
+          "type": "string",
+          "analyzer": "keyword",
+          "store": "yes"
+        },
+        "layer": {
+          "type": "string",
+          "analyzer": "keyword",
+          "store": "yes"
+        },
+        "alpha3": {
+          "type": "string",
+          "analyzer": "peliasAdmin",
+          "store": "yes"
+        },
+        "name": {
+          "type": "object",
+          "dynamic": true
+        },
+        "phrase": {
+          "type": "object",
+          "dynamic": true
+        },
+        "address_parts": {
+          "type": "object",
+          "dynamic": true,
+          "properties": {
+            "name": {
+              "type": "string",
+              "analyzer": "keyword"
+            },
+            "number": {
+              "type": "string",
+              "analyzer": "peliasHousenumber"
+            },
+            "street": {
+              "type": "string",
+              "analyzer": "peliasStreet"
+            },
+            "zip": {
+              "type": "string",
+              "analyzer": "peliasZip"
+            }
+          }
+        },
+        "parent": {
+          "type": "object",
+          "dynamic": true,
+          "properties": {
+            "country": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "country_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "country_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "macroregion": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "macroregion_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "macroregion_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "region": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "region_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "region_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "macrocounty": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "macrocounty_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "macrocounty_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "county": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "county_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "county_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "locality": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "locality_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "locality_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "borough": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "borough_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "borough_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "localadmin": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "localadmin_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "localadmin_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "neighbourhood": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "neighbourhood_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "neighbourhood_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            }
+          }
+        },
+        "center_point": {
+          "type": "geo_point",
+          "lat_lon": true,
+          "geohash": true,
+          "geohash_prefix": true,
+          "geohash_precision": 18
+        },
+        "shape": {
+          "type": "geo_shape",
+          "tree": "quadtree",
+          "tree_levels": "20"
+        },
+        "bounding_box": {
+          "type": "string",
+          "index": "no",
+          "store": "yes"
+        },
+        "source_id": {
+          "type": "string",
+          "analyzer": "keyword",
+          "store": "yes"
+        },
+        "category": {
+          "type": "string",
+          "analyzer": "keyword",
+          "store": "yes"
+        },
+        "population": {
+          "type": "long",
+          "null_value": 0
+        },
+        "popularity": {
+          "type": "long",
+          "null_value": 0
+        }
+      },
       "dynamic_templates": [
         {
           "nameGram": {
@@ -1822,15 +2269,260 @@
               "type": "string",
               "analyzer": "peliasIndexOneEdgeGram",
               "fielddata": {
-                "format": "fst",
+                "loading": "eager_global_ordinals"
+              }
+            }
+          }
+        },
+        {
+          "phrase": {
+            "path_match": "phrase.*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "string",
+              "analyzer": "peliasPhrase",
+              "fielddata": {
                 "loading": "eager_global_ordinals"
               }
             }
           }
         }
-      ]
+      ],
+      "_source": {
+        "excludes": [
+          "shape",
+          "phrase"
+        ]
+      },
+      "_all": {
+        "enabled": false
+      },
+      "dynamic": "true"
     },
     "borough": {
+      "properties": {
+        "source": {
+          "type": "string",
+          "analyzer": "keyword",
+          "store": "yes"
+        },
+        "layer": {
+          "type": "string",
+          "analyzer": "keyword",
+          "store": "yes"
+        },
+        "alpha3": {
+          "type": "string",
+          "analyzer": "peliasAdmin",
+          "store": "yes"
+        },
+        "name": {
+          "type": "object",
+          "dynamic": true
+        },
+        "phrase": {
+          "type": "object",
+          "dynamic": true
+        },
+        "address_parts": {
+          "type": "object",
+          "dynamic": true,
+          "properties": {
+            "name": {
+              "type": "string",
+              "analyzer": "keyword"
+            },
+            "number": {
+              "type": "string",
+              "analyzer": "peliasHousenumber"
+            },
+            "street": {
+              "type": "string",
+              "analyzer": "peliasStreet"
+            },
+            "zip": {
+              "type": "string",
+              "analyzer": "peliasZip"
+            }
+          }
+        },
+        "parent": {
+          "type": "object",
+          "dynamic": true,
+          "properties": {
+            "country": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "country_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "country_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "macroregion": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "macroregion_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "macroregion_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "region": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "region_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "region_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "macrocounty": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "macrocounty_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "macrocounty_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "county": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "county_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "county_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "locality": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "locality_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "locality_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "borough": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "borough_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "borough_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "localadmin": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "localadmin_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "localadmin_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "neighbourhood": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "neighbourhood_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "neighbourhood_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            }
+          }
+        },
+        "center_point": {
+          "type": "geo_point",
+          "lat_lon": true,
+          "geohash": true,
+          "geohash_prefix": true,
+          "geohash_precision": 18
+        },
+        "shape": {
+          "type": "geo_shape",
+          "tree": "quadtree",
+          "tree_levels": "20"
+        },
+        "bounding_box": {
+          "type": "string",
+          "index": "no",
+          "store": "yes"
+        },
+        "source_id": {
+          "type": "string",
+          "analyzer": "keyword",
+          "store": "yes"
+        },
+        "category": {
+          "type": "string",
+          "analyzer": "keyword",
+          "store": "yes"
+        },
+        "population": {
+          "type": "long",
+          "null_value": 0
+        },
+        "popularity": {
+          "type": "long",
+          "null_value": 0
+        }
+      },
       "dynamic_templates": [
         {
           "nameGram": {
@@ -1840,15 +2532,260 @@
               "type": "string",
               "analyzer": "peliasIndexOneEdgeGram",
               "fielddata": {
-                "format": "fst",
+                "loading": "eager_global_ordinals"
+              }
+            }
+          }
+        },
+        {
+          "phrase": {
+            "path_match": "phrase.*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "string",
+              "analyzer": "peliasPhrase",
+              "fielddata": {
                 "loading": "eager_global_ordinals"
               }
             }
           }
         }
-      ]
+      ],
+      "_source": {
+        "excludes": [
+          "shape",
+          "phrase"
+        ]
+      },
+      "_all": {
+        "enabled": false
+      },
+      "dynamic": "true"
     },
     "region": {
+      "properties": {
+        "source": {
+          "type": "string",
+          "analyzer": "keyword",
+          "store": "yes"
+        },
+        "layer": {
+          "type": "string",
+          "analyzer": "keyword",
+          "store": "yes"
+        },
+        "alpha3": {
+          "type": "string",
+          "analyzer": "peliasAdmin",
+          "store": "yes"
+        },
+        "name": {
+          "type": "object",
+          "dynamic": true
+        },
+        "phrase": {
+          "type": "object",
+          "dynamic": true
+        },
+        "address_parts": {
+          "type": "object",
+          "dynamic": true,
+          "properties": {
+            "name": {
+              "type": "string",
+              "analyzer": "keyword"
+            },
+            "number": {
+              "type": "string",
+              "analyzer": "peliasHousenumber"
+            },
+            "street": {
+              "type": "string",
+              "analyzer": "peliasStreet"
+            },
+            "zip": {
+              "type": "string",
+              "analyzer": "peliasZip"
+            }
+          }
+        },
+        "parent": {
+          "type": "object",
+          "dynamic": true,
+          "properties": {
+            "country": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "country_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "country_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "macroregion": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "macroregion_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "macroregion_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "region": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "region_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "region_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "macrocounty": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "macrocounty_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "macrocounty_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "county": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "county_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "county_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "locality": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "locality_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "locality_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "borough": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "borough_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "borough_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "localadmin": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "localadmin_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "localadmin_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "neighbourhood": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "neighbourhood_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "neighbourhood_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            }
+          }
+        },
+        "center_point": {
+          "type": "geo_point",
+          "lat_lon": true,
+          "geohash": true,
+          "geohash_prefix": true,
+          "geohash_precision": 18
+        },
+        "shape": {
+          "type": "geo_shape",
+          "tree": "quadtree",
+          "tree_levels": "20"
+        },
+        "bounding_box": {
+          "type": "string",
+          "index": "no",
+          "store": "yes"
+        },
+        "source_id": {
+          "type": "string",
+          "analyzer": "keyword",
+          "store": "yes"
+        },
+        "category": {
+          "type": "string",
+          "analyzer": "keyword",
+          "store": "yes"
+        },
+        "population": {
+          "type": "long",
+          "null_value": 0
+        },
+        "popularity": {
+          "type": "long",
+          "null_value": 0
+        }
+      },
       "dynamic_templates": [
         {
           "nameGram": {
@@ -1858,15 +2795,260 @@
               "type": "string",
               "analyzer": "peliasIndexOneEdgeGram",
               "fielddata": {
-                "format": "fst",
+                "loading": "eager_global_ordinals"
+              }
+            }
+          }
+        },
+        {
+          "phrase": {
+            "path_match": "phrase.*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "string",
+              "analyzer": "peliasPhrase",
+              "fielddata": {
                 "loading": "eager_global_ordinals"
               }
             }
           }
         }
-      ]
+      ],
+      "_source": {
+        "excludes": [
+          "shape",
+          "phrase"
+        ]
+      },
+      "_all": {
+        "enabled": false
+      },
+      "dynamic": "true"
     },
     "macrocounty": {
+      "properties": {
+        "source": {
+          "type": "string",
+          "analyzer": "keyword",
+          "store": "yes"
+        },
+        "layer": {
+          "type": "string",
+          "analyzer": "keyword",
+          "store": "yes"
+        },
+        "alpha3": {
+          "type": "string",
+          "analyzer": "peliasAdmin",
+          "store": "yes"
+        },
+        "name": {
+          "type": "object",
+          "dynamic": true
+        },
+        "phrase": {
+          "type": "object",
+          "dynamic": true
+        },
+        "address_parts": {
+          "type": "object",
+          "dynamic": true,
+          "properties": {
+            "name": {
+              "type": "string",
+              "analyzer": "keyword"
+            },
+            "number": {
+              "type": "string",
+              "analyzer": "peliasHousenumber"
+            },
+            "street": {
+              "type": "string",
+              "analyzer": "peliasStreet"
+            },
+            "zip": {
+              "type": "string",
+              "analyzer": "peliasZip"
+            }
+          }
+        },
+        "parent": {
+          "type": "object",
+          "dynamic": true,
+          "properties": {
+            "country": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "country_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "country_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "macroregion": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "macroregion_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "macroregion_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "region": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "region_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "region_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "macrocounty": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "macrocounty_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "macrocounty_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "county": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "county_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "county_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "locality": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "locality_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "locality_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "borough": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "borough_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "borough_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "localadmin": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "localadmin_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "localadmin_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "neighbourhood": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "neighbourhood_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "neighbourhood_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            }
+          }
+        },
+        "center_point": {
+          "type": "geo_point",
+          "lat_lon": true,
+          "geohash": true,
+          "geohash_prefix": true,
+          "geohash_precision": 18
+        },
+        "shape": {
+          "type": "geo_shape",
+          "tree": "quadtree",
+          "tree_levels": "20"
+        },
+        "bounding_box": {
+          "type": "string",
+          "index": "no",
+          "store": "yes"
+        },
+        "source_id": {
+          "type": "string",
+          "analyzer": "keyword",
+          "store": "yes"
+        },
+        "category": {
+          "type": "string",
+          "analyzer": "keyword",
+          "store": "yes"
+        },
+        "population": {
+          "type": "long",
+          "null_value": 0
+        },
+        "popularity": {
+          "type": "long",
+          "null_value": 0
+        }
+      },
       "dynamic_templates": [
         {
           "nameGram": {
@@ -1876,15 +3058,260 @@
               "type": "string",
               "analyzer": "peliasIndexOneEdgeGram",
               "fielddata": {
-                "format": "fst",
+                "loading": "eager_global_ordinals"
+              }
+            }
+          }
+        },
+        {
+          "phrase": {
+            "path_match": "phrase.*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "string",
+              "analyzer": "peliasPhrase",
+              "fielddata": {
                 "loading": "eager_global_ordinals"
               }
             }
           }
         }
-      ]
+      ],
+      "_source": {
+        "excludes": [
+          "shape",
+          "phrase"
+        ]
+      },
+      "_all": {
+        "enabled": false
+      },
+      "dynamic": "true"
     },
     "county": {
+      "properties": {
+        "source": {
+          "type": "string",
+          "analyzer": "keyword",
+          "store": "yes"
+        },
+        "layer": {
+          "type": "string",
+          "analyzer": "keyword",
+          "store": "yes"
+        },
+        "alpha3": {
+          "type": "string",
+          "analyzer": "peliasAdmin",
+          "store": "yes"
+        },
+        "name": {
+          "type": "object",
+          "dynamic": true
+        },
+        "phrase": {
+          "type": "object",
+          "dynamic": true
+        },
+        "address_parts": {
+          "type": "object",
+          "dynamic": true,
+          "properties": {
+            "name": {
+              "type": "string",
+              "analyzer": "keyword"
+            },
+            "number": {
+              "type": "string",
+              "analyzer": "peliasHousenumber"
+            },
+            "street": {
+              "type": "string",
+              "analyzer": "peliasStreet"
+            },
+            "zip": {
+              "type": "string",
+              "analyzer": "peliasZip"
+            }
+          }
+        },
+        "parent": {
+          "type": "object",
+          "dynamic": true,
+          "properties": {
+            "country": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "country_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "country_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "macroregion": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "macroregion_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "macroregion_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "region": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "region_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "region_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "macrocounty": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "macrocounty_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "macrocounty_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "county": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "county_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "county_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "locality": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "locality_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "locality_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "borough": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "borough_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "borough_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "localadmin": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "localadmin_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "localadmin_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "neighbourhood": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "neighbourhood_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "neighbourhood_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            }
+          }
+        },
+        "center_point": {
+          "type": "geo_point",
+          "lat_lon": true,
+          "geohash": true,
+          "geohash_prefix": true,
+          "geohash_precision": 18
+        },
+        "shape": {
+          "type": "geo_shape",
+          "tree": "quadtree",
+          "tree_levels": "20"
+        },
+        "bounding_box": {
+          "type": "string",
+          "index": "no",
+          "store": "yes"
+        },
+        "source_id": {
+          "type": "string",
+          "analyzer": "keyword",
+          "store": "yes"
+        },
+        "category": {
+          "type": "string",
+          "analyzer": "keyword",
+          "store": "yes"
+        },
+        "population": {
+          "type": "long",
+          "null_value": 0
+        },
+        "popularity": {
+          "type": "long",
+          "null_value": 0
+        }
+      },
       "dynamic_templates": [
         {
           "nameGram": {
@@ -1894,15 +3321,260 @@
               "type": "string",
               "analyzer": "peliasIndexOneEdgeGram",
               "fielddata": {
-                "format": "fst",
+                "loading": "eager_global_ordinals"
+              }
+            }
+          }
+        },
+        {
+          "phrase": {
+            "path_match": "phrase.*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "string",
+              "analyzer": "peliasPhrase",
+              "fielddata": {
                 "loading": "eager_global_ordinals"
               }
             }
           }
         }
-      ]
+      ],
+      "_source": {
+        "excludes": [
+          "shape",
+          "phrase"
+        ]
+      },
+      "_all": {
+        "enabled": false
+      },
+      "dynamic": "true"
     },
     "localadmin": {
+      "properties": {
+        "source": {
+          "type": "string",
+          "analyzer": "keyword",
+          "store": "yes"
+        },
+        "layer": {
+          "type": "string",
+          "analyzer": "keyword",
+          "store": "yes"
+        },
+        "alpha3": {
+          "type": "string",
+          "analyzer": "peliasAdmin",
+          "store": "yes"
+        },
+        "name": {
+          "type": "object",
+          "dynamic": true
+        },
+        "phrase": {
+          "type": "object",
+          "dynamic": true
+        },
+        "address_parts": {
+          "type": "object",
+          "dynamic": true,
+          "properties": {
+            "name": {
+              "type": "string",
+              "analyzer": "keyword"
+            },
+            "number": {
+              "type": "string",
+              "analyzer": "peliasHousenumber"
+            },
+            "street": {
+              "type": "string",
+              "analyzer": "peliasStreet"
+            },
+            "zip": {
+              "type": "string",
+              "analyzer": "peliasZip"
+            }
+          }
+        },
+        "parent": {
+          "type": "object",
+          "dynamic": true,
+          "properties": {
+            "country": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "country_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "country_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "macroregion": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "macroregion_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "macroregion_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "region": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "region_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "region_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "macrocounty": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "macrocounty_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "macrocounty_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "county": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "county_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "county_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "locality": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "locality_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "locality_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "borough": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "borough_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "borough_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "localadmin": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "localadmin_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "localadmin_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "neighbourhood": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "neighbourhood_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "neighbourhood_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            }
+          }
+        },
+        "center_point": {
+          "type": "geo_point",
+          "lat_lon": true,
+          "geohash": true,
+          "geohash_prefix": true,
+          "geohash_precision": 18
+        },
+        "shape": {
+          "type": "geo_shape",
+          "tree": "quadtree",
+          "tree_levels": "20"
+        },
+        "bounding_box": {
+          "type": "string",
+          "index": "no",
+          "store": "yes"
+        },
+        "source_id": {
+          "type": "string",
+          "analyzer": "keyword",
+          "store": "yes"
+        },
+        "category": {
+          "type": "string",
+          "analyzer": "keyword",
+          "store": "yes"
+        },
+        "population": {
+          "type": "long",
+          "null_value": 0
+        },
+        "popularity": {
+          "type": "long",
+          "null_value": 0
+        }
+      },
       "dynamic_templates": [
         {
           "nameGram": {
@@ -1912,15 +3584,260 @@
               "type": "string",
               "analyzer": "peliasIndexOneEdgeGram",
               "fielddata": {
-                "format": "fst",
+                "loading": "eager_global_ordinals"
+              }
+            }
+          }
+        },
+        {
+          "phrase": {
+            "path_match": "phrase.*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "string",
+              "analyzer": "peliasPhrase",
+              "fielddata": {
                 "loading": "eager_global_ordinals"
               }
             }
           }
         }
-      ]
+      ],
+      "_source": {
+        "excludes": [
+          "shape",
+          "phrase"
+        ]
+      },
+      "_all": {
+        "enabled": false
+      },
+      "dynamic": "true"
     },
     "locality": {
+      "properties": {
+        "source": {
+          "type": "string",
+          "analyzer": "keyword",
+          "store": "yes"
+        },
+        "layer": {
+          "type": "string",
+          "analyzer": "keyword",
+          "store": "yes"
+        },
+        "alpha3": {
+          "type": "string",
+          "analyzer": "peliasAdmin",
+          "store": "yes"
+        },
+        "name": {
+          "type": "object",
+          "dynamic": true
+        },
+        "phrase": {
+          "type": "object",
+          "dynamic": true
+        },
+        "address_parts": {
+          "type": "object",
+          "dynamic": true,
+          "properties": {
+            "name": {
+              "type": "string",
+              "analyzer": "keyword"
+            },
+            "number": {
+              "type": "string",
+              "analyzer": "peliasHousenumber"
+            },
+            "street": {
+              "type": "string",
+              "analyzer": "peliasStreet"
+            },
+            "zip": {
+              "type": "string",
+              "analyzer": "peliasZip"
+            }
+          }
+        },
+        "parent": {
+          "type": "object",
+          "dynamic": true,
+          "properties": {
+            "country": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "country_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "country_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "macroregion": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "macroregion_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "macroregion_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "region": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "region_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "region_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "macrocounty": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "macrocounty_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "macrocounty_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "county": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "county_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "county_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "locality": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "locality_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "locality_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "borough": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "borough_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "borough_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "localadmin": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "localadmin_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "localadmin_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "neighbourhood": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "neighbourhood_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "neighbourhood_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            }
+          }
+        },
+        "center_point": {
+          "type": "geo_point",
+          "lat_lon": true,
+          "geohash": true,
+          "geohash_prefix": true,
+          "geohash_precision": 18
+        },
+        "shape": {
+          "type": "geo_shape",
+          "tree": "quadtree",
+          "tree_levels": "20"
+        },
+        "bounding_box": {
+          "type": "string",
+          "index": "no",
+          "store": "yes"
+        },
+        "source_id": {
+          "type": "string",
+          "analyzer": "keyword",
+          "store": "yes"
+        },
+        "category": {
+          "type": "string",
+          "analyzer": "keyword",
+          "store": "yes"
+        },
+        "population": {
+          "type": "long",
+          "null_value": 0
+        },
+        "popularity": {
+          "type": "long",
+          "null_value": 0
+        }
+      },
       "dynamic_templates": [
         {
           "nameGram": {
@@ -1930,13 +3847,35 @@
               "type": "string",
               "analyzer": "peliasIndexOneEdgeGram",
               "fielddata": {
-                "format": "fst",
+                "loading": "eager_global_ordinals"
+              }
+            }
+          }
+        },
+        {
+          "phrase": {
+            "path_match": "phrase.*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "string",
+              "analyzer": "peliasPhrase",
+              "fielddata": {
                 "loading": "eager_global_ordinals"
               }
             }
           }
         }
-      ]
+      ],
+      "_source": {
+        "excludes": [
+          "shape",
+          "phrase"
+        ]
+      },
+      "_all": {
+        "enabled": false
+      },
+      "dynamic": "true"
     }
   }
 }

--- a/test/partial-centroid.js
+++ b/test/partial-centroid.js
@@ -39,15 +39,6 @@ module.exports.tests.geohash = function(test, common) {
   });
 };
 
-// this should be set to 'eager_global_ordinals' in order
-// to build caches at index time rather than query time
-module.exports.tests.fielddata = function(test, common) {
-  test('fielddata configured', function(t) {
-    t.equal(schema.fielddata.loading, 'eager_global_ordinals', 'correct value');
-    t.end();
-  });
-};
-
 module.exports.all = function (tape, common) {
 
   function test(name, testFunction) {

--- a/test/partial-literal.js
+++ b/test/partial-literal.js
@@ -29,8 +29,7 @@ module.exports.tests.store = function(test, common) {
 // do not perform analysis on categories
 module.exports.tests.analysis = function(test, common) {
   test('index analysis', function(t) {
-    t.equal(schema.index_analyzer, 'keyword', 'should be keyword');
-    t.equal(schema.search_analyzer, 'keyword', 'should be keyword');
+    t.equal(schema.analyzer, 'keyword', 'should be keyword');
     t.end();
   });
 };

--- a/test/settings.js
+++ b/test/settings.js
@@ -65,7 +65,13 @@ module.exports.tests.peliasIndexOneEdgeGramAnalyzer = function(test, common) {
       "ampersand",
       "remove_ordinals",
       "removeAllZeroNumericPrefix",
+      "surround_single_characters_with_word_markers",
+      "house_number_word_delimiter",
+      "remove_single_characters",
+      "surround_house_numbers_with_word_markers",
       "peliasOneEdgeGramFilter",
+      "eliminate_tokens_starting_with_word_marker",
+      "remove_encapsulating_word_markers",
       "unique",
       "notnull"
     ]);


### PR DESCRIPTION
- add `goldbergianPeliasHousenumber` to ensure that numeric values are treated as whole tokens rather than creating prefixes.
- use single gram analyzers for all fields, no longer using 2 gram analysis
- remove settings deprecated in ES2
- remove `dynamic_templates` so now all `_type` have the same config