### PR TITLE
Update travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,30 @@
 sudo: false
 language: node_js
-services:
- - elasticsearch
+cache:
+  directories:
+    - node_modules
+notifications:
+  email: false
 node_js:
-  - 0.10
   - 0.12
-  - 4.4
-  - 5.8
+  - 4
+  - 5
+  - 6
 matrix:
+    fast_finish: true
     allow_failures:
-        - node_js: 4.4
-        - node_js: 5.8
+        - node_js: 6
 env:
- global:
-   - CXX=g++-4.8
- matrix:
-   - TEST_SUITE=test
-script: "npm run $TEST_SUITE"
+  global:
+    - CXX=g++-4.8
+script: "npm run travis"
 addons:
- apt:
-   sources:
-     - ubuntu-toolchain-r-test
-   packages:
-     - g++-4.8
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
+before_install:
+  - npm i -g npm@^2.0.0
+before_script:
+  - npm prune

--- a/README.md
+++ b/README.md
@@ -86,6 +86,6 @@ $ npm run integration
 
 ### Continuous Integration
 
-Travis tests every release against node version `0.10`
+Travis tests every release against Node.js version `0.12`, `4`, `5`, and `6`.
 
 [![Build Status](https://travis-ci.org/pelias/schema.png?branch=master)](https://travis-ci.org/pelias/schema)

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "create_index": "node scripts/create_index",
     "drop_index": "node scripts/drop_index",
     "reset_type": "node scripts/reset_type",
-    "update_settings": "node scripts/update_settings"
+    "update_settings": "node scripts/update_settings",
+    "travis": "npm run test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
These are the perf improvements and other cool new things we learned about from semantic release. It also changes the versions we test against to 0.12,  4, 5, and 6 (6 is allowed to fail for now).