### PR TITLE
refactor schema to use icu plugin

### DIFF
--- a/integration/analyzer_peliasAdmin.js
+++ b/integration/analyzer_peliasAdmin.js
@@ -99,6 +99,38 @@ module.exports.tests.tokenizer = function(test, common){
   });
 };
 
+// @see: https://github.com/pelias/api/issues/600
+module.exports.tests.unicode = function(test, common){
+  test( 'normalization', function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+    var assertAnalysis = analyze.bind( null, suite, t, 'peliasAdmin' );
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
+
+    var latin_large_letter_e_with_acute = String.fromCodePoint(0x00C9);
+    var latin_small_letter_e_with_acute = String.fromCodePoint(0x00E9);
+    var combining_acute_accent = String.fromCodePoint(0x0301);
+    var latin_large_letter_e = String.fromCodePoint(0x0045);
+    var latin_small_letter_e = String.fromCodePoint(0x0065);
+
+    // Chambéry (both forms appear the same)
+    var composed = "Chamb" + latin_small_letter_e_with_acute + "ry";
+    var decomposed = "Chamb" + combining_acute_accent + latin_small_letter_e + "ry"
+
+    assertAnalysis( 'composed', composed, ['chambery'] );
+    assertAnalysis( 'decomposed', decomposed, ['chambery'] );
+
+    // Één (both forms appear the same)
+    var composed = latin_large_letter_e_with_acute + latin_small_letter_e_with_acute + "n";
+    var decomposed = combining_acute_accent + latin_large_letter_e + combining_acute_accent + latin_small_letter_e + "n"
+
+    assertAnalysis( 'composed', composed, ['een'] );
+    assertAnalysis( 'decomposed', decomposed, ['een'] );
+
+    suite.run( t.end );
+  });
+};
+
 module.exports.all = function (tape, common) {
 
   function test(name, testFunction) {

--- a/integration/analyzer_peliasIndexOneEdgeGram.js
+++ b/integration/analyzer_peliasIndexOneEdgeGram.js
@@ -150,6 +150,38 @@ module.exports.tests.address = function(test, common){
   });
 };
 
+// @see: https://github.com/pelias/api/issues/600
+module.exports.tests.unicode = function(test, common){
+  test( 'normalization', function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+    var assertAnalysis = analyze.bind( null, suite, t, 'peliasIndexOneEdgeGram' );
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
+
+    var latin_large_letter_e_with_acute = String.fromCodePoint(0x00C9);
+    var latin_small_letter_e_with_acute = String.fromCodePoint(0x00E9);
+    var combining_acute_accent = String.fromCodePoint(0x0301);
+    var latin_large_letter_e = String.fromCodePoint(0x0045);
+    var latin_small_letter_e = String.fromCodePoint(0x0065);
+
+    // Chambéry (both forms appear the same)
+    var composed = "Chamb" + latin_small_letter_e_with_acute + "ry";
+    var decomposed = "Chamb" + combining_acute_accent + latin_small_letter_e + "ry"
+
+    assertAnalysis( 'composed', composed, ['c', 'ch', 'cha', 'cham', 'chamb', 'chambe', 'chamber', 'chambery'] );
+    assertAnalysis( 'decomposed', decomposed, ['c', 'ch', 'cha', 'cham', 'chamb', 'chambe', 'chamber', 'chambery'] );
+
+    // Één (both forms appear the same)
+    var composed = latin_large_letter_e_with_acute + latin_small_letter_e_with_acute + "n";
+    var decomposed = combining_acute_accent + latin_large_letter_e + combining_acute_accent + latin_small_letter_e + "n"
+
+    assertAnalysis( 'composed', composed, ['e','ee','een'] );
+    assertAnalysis( 'decomposed', decomposed, ['e','ee','een'] );
+
+    suite.run( t.end );
+  });
+};
+
 module.exports.all = function (tape, common) {
 
   function test(name, testFunction) {

--- a/integration/analyzer_peliasIndexTwoEdgeGram.js
+++ b/integration/analyzer_peliasIndexTwoEdgeGram.js
@@ -177,6 +177,38 @@ module.exports.tests.numerals = function(test, common){
   });
 };
 
+// @see: https://github.com/pelias/api/issues/600
+module.exports.tests.unicode = function(test, common){
+  test( 'normalization', function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+    var assertAnalysis = analyze.bind( null, suite, t, 'peliasIndexTwoEdgeGram' );
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
+
+    var latin_large_letter_e_with_acute = String.fromCodePoint(0x00C9);
+    var latin_small_letter_e_with_acute = String.fromCodePoint(0x00E9);
+    var combining_acute_accent = String.fromCodePoint(0x0301);
+    var latin_large_letter_e = String.fromCodePoint(0x0045);
+    var latin_small_letter_e = String.fromCodePoint(0x0065);
+
+    // Chambéry (both forms appear the same)
+    var composed = "Chamb" + latin_small_letter_e_with_acute + "ry";
+    var decomposed = "Chamb" + combining_acute_accent + latin_small_letter_e + "ry"
+
+    assertAnalysis( 'composed', composed, ['ch', 'cha', 'cham', 'chamb', 'chambe', 'chamber', 'chambery'] );
+    assertAnalysis( 'decomposed', decomposed, ['ch', 'cha', 'cham', 'chamb', 'chambe', 'chamber', 'chambery'] );
+
+    // Één (both forms appear the same)
+    var composed = latin_large_letter_e_with_acute + latin_small_letter_e_with_acute + "n";
+    var decomposed = combining_acute_accent + latin_large_letter_e + combining_acute_accent + latin_small_letter_e + "n"
+
+    assertAnalysis( 'composed', composed, ['ee','een'] );
+    assertAnalysis( 'decomposed', decomposed, ['ee','een'] );
+
+    suite.run( t.end );
+  });
+};
+
 module.exports.all = function (tape, common) {
 
   function test(name, testFunction) {

--- a/integration/analyzer_peliasPhrase.js
+++ b/integration/analyzer_peliasPhrase.js
@@ -277,6 +277,38 @@ module.exports.tests.slop = function(test, common){
   });
 };
 
+// @see: https://github.com/pelias/api/issues/600
+module.exports.tests.unicode = function(test, common){
+  test( 'normalization', function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+    var assertAnalysis = analyze.bind( null, suite, t, 'peliasPhrase' );
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
+
+    var latin_large_letter_e_with_acute = String.fromCodePoint(0x00C9);
+    var latin_small_letter_e_with_acute = String.fromCodePoint(0x00E9);
+    var combining_acute_accent = String.fromCodePoint(0x0301);
+    var latin_large_letter_e = String.fromCodePoint(0x0045);
+    var latin_small_letter_e = String.fromCodePoint(0x0065);
+
+    // Chambéry (both forms appear the same)
+    var composed = "Chamb" + latin_small_letter_e_with_acute + "ry";
+    var decomposed = "Chamb" + combining_acute_accent + latin_small_letter_e + "ry"
+
+    assertAnalysis( 'composed', composed, ['chambery'] );
+    assertAnalysis( 'decomposed', decomposed, ['chambery'] );
+
+    // Één (both forms appear the same)
+    var composed = latin_large_letter_e_with_acute + latin_small_letter_e_with_acute + "n";
+    var decomposed = combining_acute_accent + latin_large_letter_e + combining_acute_accent + latin_small_letter_e + "n"
+
+    assertAnalysis( 'composed', composed, ['een'] );
+    assertAnalysis( 'decomposed', decomposed, ['een'] );
+
+    suite.run( t.end );
+  });
+};
+
 module.exports.all = function (tape, common) {
 
   function test(name, testFunction) {

--- a/integration/analyzer_peliasQueryFullToken.js
+++ b/integration/analyzer_peliasQueryFullToken.js
@@ -199,6 +199,38 @@ module.exports.tests.address = function(test, common){
   });
 };
 
+// @see: https://github.com/pelias/api/issues/600
+module.exports.tests.unicode = function(test, common){
+  test( 'normalization', function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+    var assertAnalysis = analyze.bind( null, suite, t, 'peliasQueryFullToken' );
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
+
+    var latin_large_letter_e_with_acute = String.fromCodePoint(0x00C9);
+    var latin_small_letter_e_with_acute = String.fromCodePoint(0x00E9);
+    var combining_acute_accent = String.fromCodePoint(0x0301);
+    var latin_large_letter_e = String.fromCodePoint(0x0045);
+    var latin_small_letter_e = String.fromCodePoint(0x0065);
+
+    // Chambéry (both forms appear the same)
+    var composed = "Chamb" + latin_small_letter_e_with_acute + "ry";
+    var decomposed = "Chamb" + combining_acute_accent + latin_small_letter_e + "ry"
+
+    assertAnalysis( 'composed', composed, ['chambery'] );
+    assertAnalysis( 'decomposed', decomposed, ['chambery'] );
+
+    // Één (both forms appear the same)
+    var composed = latin_large_letter_e_with_acute + latin_small_letter_e_with_acute + "n";
+    var decomposed = combining_acute_accent + latin_large_letter_e + combining_acute_accent + latin_small_letter_e + "n"
+
+    assertAnalysis( 'composed', composed, ['een'] );
+    assertAnalysis( 'decomposed', decomposed, ['een'] );
+
+    suite.run( t.end );
+  });
+};
+
 module.exports.all = function (tape, common) {
 
   function test(name, testFunction) {

--- a/integration/analyzer_peliasQueryPartialToken.js
+++ b/integration/analyzer_peliasQueryPartialToken.js
@@ -122,6 +122,38 @@ module.exports.tests.address = function(test, common){
   });
 };
 
+// @see: https://github.com/pelias/api/issues/600
+module.exports.tests.unicode = function(test, common){
+  test( 'normalization', function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+    var assertAnalysis = analyze.bind( null, suite, t, 'peliasQueryPartialToken' );
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
+
+    var latin_large_letter_e_with_acute = String.fromCodePoint(0x00C9);
+    var latin_small_letter_e_with_acute = String.fromCodePoint(0x00E9);
+    var combining_acute_accent = String.fromCodePoint(0x0301);
+    var latin_large_letter_e = String.fromCodePoint(0x0045);
+    var latin_small_letter_e = String.fromCodePoint(0x0065);
+
+    // Chambéry (both forms appear the same)
+    var composed = "Chamb" + latin_small_letter_e_with_acute + "ry";
+    var decomposed = "Chamb" + combining_acute_accent + latin_small_letter_e + "ry"
+
+    assertAnalysis( 'composed', composed, ['chambery'] );
+    assertAnalysis( 'decomposed', decomposed, ['chambery'] );
+
+    // Één (both forms appear the same)
+    var composed = latin_large_letter_e_with_acute + latin_small_letter_e_with_acute + "n";
+    var decomposed = combining_acute_accent + latin_large_letter_e + combining_acute_accent + latin_small_letter_e + "n"
+
+    assertAnalysis( 'composed', composed, ['een'] );
+    assertAnalysis( 'decomposed', decomposed, ['een'] );
+
+    suite.run( t.end );
+  });
+};
+
 module.exports.all = function (tape, common) {
 
   function test(name, testFunction) {

--- a/integration/analyzer_peliasStreet.js
+++ b/integration/analyzer_peliasStreet.js
@@ -159,6 +159,38 @@ module.exports.tests.tokenizer = function(test, common){
   });
 };
 
+// @see: https://github.com/pelias/api/issues/600
+module.exports.tests.unicode = function(test, common){
+  test( 'normalization', function(t){
+
+    var suite = new elastictest.Suite( null, { schema: schema } );
+    var assertAnalysis = analyze.bind( null, suite, t, 'peliasStreet' );
+    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
+
+    var latin_large_letter_e_with_acute = String.fromCodePoint(0x00C9);
+    var latin_small_letter_e_with_acute = String.fromCodePoint(0x00E9);
+    var combining_acute_accent = String.fromCodePoint(0x0301);
+    var latin_large_letter_e = String.fromCodePoint(0x0045);
+    var latin_small_letter_e = String.fromCodePoint(0x0065);
+
+    // Chambéry (both forms appear the same)
+    var composed = "Chamb" + latin_small_letter_e_with_acute + "ry";
+    var decomposed = "Chamb" + combining_acute_accent + latin_small_letter_e + "ry"
+
+    assertAnalysis( 'composed', composed, ['chambery'] );
+    assertAnalysis( 'decomposed', decomposed, ['chambery'] );
+
+    // Één (both forms appear the same)
+    var composed = latin_large_letter_e_with_acute + latin_small_letter_e_with_acute + "n";
+    var decomposed = combining_acute_accent + latin_large_letter_e + combining_acute_accent + latin_small_letter_e + "n"
+
+    assertAnalysis( 'composed', composed, ['een'] );
+    assertAnalysis( 'decomposed', decomposed, ['een'] );
+
+    suite.run( t.end );
+  });
+};
+
 module.exports.all = function (tape, common) {
 
   function test(name, testFunction) {

--- a/settings.js
+++ b/settings.js
@@ -26,10 +26,10 @@ function generate(){
         "peliasAdmin": {
           "type": "custom",
           "tokenizer": "peliasNameTokenizer",
-          "char_filter" : ["punctuation"],
+          "char_filter" : ["punctuation", "nfkc_normalizer"],
           "filter": [
             "lowercase",
-            "asciifolding",
+            "icu_folding",
             "trim",
             "word_delimiter",
             "notnull"
@@ -38,10 +38,10 @@ function generate(){
         "peliasIndexOneEdgeGram" : {
           "type": "custom",
           "tokenizer" : "peliasNameTokenizer",
-          "char_filter" : ["punctuation"],
+          "char_filter" : ["punctuation", "nfkc_normalizer"],
           "filter": [
             "lowercase",
-            "asciifolding",
+            "icu_folding",
             "trim",
             "full_token_address_suffix_expansion",
             "ampersand",
@@ -61,10 +61,10 @@ function generate(){
         "peliasIndexTwoEdgeGram" : {
           "type": "custom",
           "tokenizer" : "peliasNameTokenizer",
-          "char_filter" : ["punctuation"],
+          "char_filter" : ["punctuation", "nfkc_normalizer"],
           "filter": [
             "lowercase",
-            "asciifolding",
+            "icu_folding",
             "trim",
             "full_token_address_suffix_expansion",
             "ampersand",
@@ -81,10 +81,10 @@ function generate(){
         "peliasQueryPartialToken" : {
           "type": "custom",
           "tokenizer" : "peliasNameTokenizer",
-          "char_filter" : ["punctuation"],
+          "char_filter" : ["punctuation", "nfkc_normalizer"],
           "filter": [
             "lowercase",
-            "asciifolding",
+            "icu_folding",
             "trim",
             "partial_token_address_suffix_expansion",
             "ampersand",
@@ -97,10 +97,10 @@ function generate(){
         "peliasQueryFullToken" : {
           "type": "custom",
           "tokenizer" : "peliasNameTokenizer",
-          "char_filter" : ["punctuation"],
+          "char_filter" : ["punctuation", "nfkc_normalizer"],
           "filter": [
             "lowercase",
-            "asciifolding",
+            "icu_folding",
             "trim",
             "remove_ordinals",
             "full_token_address_suffix_expansion",
@@ -113,10 +113,10 @@ function generate(){
         "peliasPhrase": {
           "type": "custom",
           "tokenizer":"peliasNameTokenizer",
-          "char_filter" : ["punctuation"],
+          "char_filter" : ["punctuation", "nfkc_normalizer"],
           "filter": [
             "lowercase",
-            "asciifolding",
+            "icu_folding",
             "trim",
             "ampersand",
             "street_synonym",
@@ -142,10 +142,10 @@ function generate(){
         "peliasStreet": {
           "type": "custom",
           "tokenizer":"peliasStreetTokenizer",
-          "char_filter" : ["punctuation"],
+          "char_filter" : ["punctuation", "nfkc_normalizer"],
           "filter": [
             "lowercase",
-            "asciifolding",
+            "icu_folding",
             "remove_duplicate_spaces",
           ].concat( street_suffix.synonyms.map( function( synonym ){
             return "keyword_street_suffix_" + synonym.split(' ')[0];
@@ -279,6 +279,11 @@ function generate(){
           "type" : "pattern_replace",
           "pattern": "[^0-9]",
           "replacement": " "
+        },
+        "nfkc_normalizer": {
+          "type": "icu_normalizer",
+          "name": "nfkc",
+          "mode": "compose"
         }
       }
     },

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -16,11 +16,12 @@
           "type": "custom",
           "tokenizer": "peliasNameTokenizer",
           "char_filter": [
-            "punctuation"
+            "punctuation",
+            "nfkc_normalizer"
           ],
           "filter": [
             "lowercase",
-            "asciifolding",
+            "icu_folding",
             "trim",
             "word_delimiter",
             "notnull"
@@ -30,11 +31,12 @@
           "type": "custom",
           "tokenizer": "peliasNameTokenizer",
           "char_filter": [
-            "punctuation"
+            "punctuation",
+            "nfkc_normalizer"
           ],
           "filter": [
             "lowercase",
-            "asciifolding",
+            "icu_folding",
             "trim",
             "full_token_address_suffix_expansion",
             "ampersand",
@@ -55,11 +57,12 @@
           "type": "custom",
           "tokenizer": "peliasNameTokenizer",
           "char_filter": [
-            "punctuation"
+            "punctuation",
+            "nfkc_normalizer"
           ],
           "filter": [
             "lowercase",
-            "asciifolding",
+            "icu_folding",
             "trim",
             "full_token_address_suffix_expansion",
             "ampersand",
@@ -77,11 +80,12 @@
           "type": "custom",
           "tokenizer": "peliasNameTokenizer",
           "char_filter": [
-            "punctuation"
+            "punctuation",
+            "nfkc_normalizer"
           ],
           "filter": [
             "lowercase",
-            "asciifolding",
+            "icu_folding",
             "trim",
             "partial_token_address_suffix_expansion",
             "ampersand",
@@ -95,11 +99,12 @@
           "type": "custom",
           "tokenizer": "peliasNameTokenizer",
           "char_filter": [
-            "punctuation"
+            "punctuation",
+            "nfkc_normalizer"
           ],
           "filter": [
             "lowercase",
-            "asciifolding",
+            "icu_folding",
             "trim",
             "remove_ordinals",
             "full_token_address_suffix_expansion",
@@ -113,11 +118,12 @@
           "type": "custom",
           "tokenizer": "peliasNameTokenizer",
           "char_filter": [
-            "punctuation"
+            "punctuation",
+            "nfkc_normalizer"
           ],
           "filter": [
             "lowercase",
-            "asciifolding",
+            "icu_folding",
             "trim",
             "ampersand",
             "street_synonym",
@@ -148,11 +154,12 @@
           "type": "custom",
           "tokenizer": "peliasStreetTokenizer",
           "char_filter": [
-            "punctuation"
+            "punctuation",
+            "nfkc_normalizer"
           ],
           "filter": [
             "lowercase",
-            "asciifolding",
+            "icu_folding",
             "remove_duplicate_spaces",
             "keyword_street_suffix_alley",
             "keyword_street_suffix_annex",
@@ -1549,6 +1556,11 @@
           "type": "pattern_replace",
           "pattern": "[^0-9]",
           "replacement": " "
+        },
+        "nfkc_normalizer": {
+          "type": "icu_normalizer",
+          "name": "nfkc",
+          "mode": "compose"
         }
       }
     },

--- a/test/settings.js
+++ b/test/settings.js
@@ -51,7 +51,7 @@ module.exports.tests.peliasIndexOneEdgeGramAnalyzer = function(test, common) {
     var analyzer = s.analysis.analyzer.peliasIndexOneEdgeGram;
     t.equal(analyzer.type, 'custom', 'custom analyzer');
     t.equal(typeof analyzer.tokenizer, 'string', 'tokenizer specified');
-    t.deepEqual(analyzer.char_filter, ["punctuation"], 'punctuation filter specified');
+    t.deepEqual(analyzer.char_filter, ["punctuation","nfkc_normalizer"], 'character filters specified');
     t.true(Array.isArray(analyzer.filter), 'filters specified');
     t.end();
   });
@@ -59,7 +59,7 @@ module.exports.tests.peliasIndexOneEdgeGramAnalyzer = function(test, common) {
     var analyzer = settings().analysis.analyzer.peliasIndexOneEdgeGram;
     t.deepEqual( analyzer.filter, [
       "lowercase",
-      "asciifolding",
+      "icu_folding",
       "trim",
       "full_token_address_suffix_expansion",
       "ampersand",
@@ -86,7 +86,7 @@ module.exports.tests.peliasIndexTwoEdgeGramAnalyzer = function(test, common) {
     var analyzer = s.analysis.analyzer.peliasIndexTwoEdgeGram;
     t.equal(analyzer.type, 'custom', 'custom analyzer');
     t.equal(typeof analyzer.tokenizer, 'string', 'tokenizer specified');
-    t.deepEqual(analyzer.char_filter, ["punctuation"], 'punctuation filter specified');
+    t.deepEqual(analyzer.char_filter, ["punctuation","nfkc_normalizer"], 'character filters specified');
     t.true(Array.isArray(analyzer.filter), 'filters specified');
     t.end();
   });
@@ -94,7 +94,7 @@ module.exports.tests.peliasIndexTwoEdgeGramAnalyzer = function(test, common) {
     var analyzer = settings().analysis.analyzer.peliasIndexTwoEdgeGram;
     t.deepEqual( analyzer.filter, [
       "lowercase",
-      "asciifolding",
+      "icu_folding",
       "trim",
       "full_token_address_suffix_expansion",
       "ampersand",
@@ -118,7 +118,7 @@ module.exports.tests.peliasPhraseAnalyzer = function(test, common) {
     var analyzer = s.analysis.analyzer.peliasPhrase;
     t.equal(analyzer.type, 'custom', 'custom analyzer');
     t.equal(typeof analyzer.tokenizer, 'string', 'tokenizer specified');
-    t.deepEqual(analyzer.char_filter, ["punctuation"], 'punctuation filter specified');
+    t.deepEqual(analyzer.char_filter, ["punctuation","nfkc_normalizer"], 'character filters specified');
     t.true(Array.isArray(analyzer.filter), 'filters specified');
     t.end();
   });
@@ -126,7 +126,7 @@ module.exports.tests.peliasPhraseAnalyzer = function(test, common) {
     var analyzer = settings().analysis.analyzer.peliasPhrase;
     t.deepEqual( analyzer.filter, [
       "lowercase",
-      "asciifolding",
+      "icu_folding",
       "trim",
       "ampersand",
       "street_synonym",
@@ -179,7 +179,7 @@ module.exports.tests.peliasStreetAnalyzer = function(test, common) {
     var analyzer = s.analysis.analyzer.peliasStreet;
     t.equal(analyzer.type, 'custom', 'custom analyzer');
     t.equal(typeof analyzer.tokenizer, 'string', 'tokenizer specified');
-    t.deepEqual(analyzer.char_filter, ["punctuation"], 'punctuation filter specified');
+    t.deepEqual(analyzer.char_filter, ["punctuation","nfkc_normalizer"], 'character filters specified');
     t.true(Array.isArray(analyzer.filter), 'filters specified');
     t.end();
   });
@@ -193,7 +193,7 @@ module.exports.tests.peliasStreetAnalyzer = function(test, common) {
 // cycle through all analyzers and ensure the corrsponding token filters are defined
 module.exports.tests.allTokenFiltersPresent = function(test, common) {
   var ES_INBUILT_FILTERS = [
-    'lowercase', 'asciifolding', 'trim', 'word_delimiter', 'unique'
+    'lowercase', 'icu_folding', 'trim', 'word_delimiter', 'unique'
   ];
   test('all token filters present', function(t) {
     var s = settings();


### PR DESCRIPTION
DO NOT MERGE at this time, this PR requires that the `icu plugin` to be installed in elasticsearch in order to work.

Closes https://github.com/pelias/schema/issues/148

More info can be found on the issue above, this PR enables the ICU plugin and uses unicode-aware functions in place of non unicode-aware functions.

In effect this provides support for unicode combining characters and better glyph folding.