### PR TITLE
Replace pelias-esclient with official elasticsearch module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
 node_modules
 npm-debug.log
 .DS_Store
-esclient.log
-
-

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
   },
   "devDependencies": {
     "difflet": "^1.0.1",
+    "elasticsearch": "^11.0.1",
     "elastictest": "^1.2.0",
-    "pelias-esclient": "1.0.0",
     "tap-spec": "^4.1.1",
     "tape": "^4.5.0"
   }

--- a/scripts/create_index.js
+++ b/scripts/create_index.js
@@ -1,6 +1,6 @@
-
-var client = require('pelias-esclient')(),
-    schema = require('../schema');
+var es = require('elasticsearch');
+var client = new es.Client();
+var schema = require('../schema');
 
 client.indices.create( { index: 'pelias', body: schema }, function( err, res ){
   console.log( '[put mapping]', '\t', 'pelias', err || '\t', res );

--- a/scripts/drop_index.js
+++ b/scripts/drop_index.js
@@ -1,8 +1,9 @@
 var colors = require('colors/safe');
 var config = require('pelias-config').generate();
+var es = require('elasticsearch');
+var client = new es.Client();
 var readline = require('readline'),
     rl = readline.createInterface({ input: process.stdin, output: process.stdout }),
-    client = require('pelias-esclient')(),
     schema = require('../schema');
 
 // use -f or --force-yes to skip the prompt

--- a/scripts/info.js
+++ b/scripts/info.js
@@ -1,3 +1,4 @@
+var es = require('elasticsearch');
+var client = new es.Client();
 
-var client = require('pelias-esclient')();
 client.info( {}, console.log.bind(console) );

--- a/scripts/output_mapping.js
+++ b/scripts/output_mapping.js
@@ -1,6 +1,6 @@
-
-var client = require('pelias-esclient')(),
-    schema = require('../schema');
+var es = require('elasticsearch');
+var client = new es.Client();
+var schema = require('../schema');
 
 var _index = ( process.argv.length > 3 ) ? process.argv[3] : 'pelias';
 var _type = ( process.argv.length > 2 ) ? process.argv[2] : null; // get type from cli args

--- a/scripts/reset_type.js
+++ b/scripts/reset_type.js
@@ -1,6 +1,6 @@
-
-var client = require('pelias-esclient')(),
-    schema = require('../schema');
+var es = require('elasticsearch');
+var client = new es.Client();
+var schema = require('../schema');
 
 var _index = ( process.argv.length > 3 ) ? process.argv[3] : 'pelias';
 var _type = ( process.argv.length > 2 ) ? process.argv[2] : null; // get type from cli args

--- a/scripts/update_settings.js
+++ b/scripts/update_settings.js
@@ -1,6 +1,6 @@
-
-var client = require('pelias-esclient')(),
-    schema = require('../schema');
+var es = require('elasticsearch');
+var client = new es.Client();
+var schema = require('../schema');
 
 var _index = 'pelias';
 


### PR DESCRIPTION
Now that the client is [deprecated](https://github.com/pelias-deprecated/esclient) we should stop using it. Fortunately, esclient was mostly a wrapper around the official Elasticsearch client, so this was a straightforward change.

Fixes #144