### PR TITLE
Pass config to Elasticsearch

### DIFF
--- a/scripts/create_index.js
+++ b/scripts/create_index.js
@@ -1,5 +1,6 @@
+var config = require('pelias-config').generate().esclient;
 var es = require('elasticsearch');
-var client = new es.Client();
+var client = new es.Client(config);
 var schema = require('../schema');
 
 client.indices.create( { index: 'pelias', body: schema }, function( err, res ){

--- a/scripts/drop_index.js
+++ b/scripts/drop_index.js
@@ -1,7 +1,7 @@
 var colors = require('colors/safe');
 var config = require('pelias-config').generate();
 var es = require('elasticsearch');
-var client = new es.Client();
+var client = new es.Client(config.esclient);
 var readline = require('readline'),
     rl = readline.createInterface({ input: process.stdin, output: process.stdout }),
     schema = require('../schema');

--- a/scripts/info.js
+++ b/scripts/info.js
@@ -1,4 +1,5 @@
+var config = require('pelias-config').generate().esclient;
 var es = require('elasticsearch');
-var client = new es.Client();
+var client = new es.Client(config);
 
 client.info( {}, console.log.bind(console) );

--- a/scripts/output_mapping.js
+++ b/scripts/output_mapping.js
@@ -1,5 +1,6 @@
+var config = require('pelias-config').generate().esclient;
 var es = require('elasticsearch');
-var client = new es.Client();
+var client = new es.Client(config);
 var schema = require('../schema');
 
 var _index = ( process.argv.length > 3 ) ? process.argv[3] : 'pelias';

--- a/scripts/reset_type.js
+++ b/scripts/reset_type.js
@@ -1,5 +1,6 @@
+var config = require('pelias-config').generate().esclient;
 var es = require('elasticsearch');
-var client = new es.Client();
+var client = new es.Client(config);
 var schema = require('../schema');
 
 var _index = ( process.argv.length > 3 ) ? process.argv[3] : 'pelias';

--- a/scripts/update_settings.js
+++ b/scripts/update_settings.js
@@ -1,5 +1,6 @@
+var config = require('pelias-config').generate().esclient;
 var es = require('elasticsearch');
-var client = new es.Client();
+var client = new es.Client(config);
 var schema = require('../schema');
 
 var _index = 'pelias';


### PR DESCRIPTION
One confusing part of `esclient` is that it automatically pulls in `pelias-config`. I know this because I missed the exact same thing when making this change for the API: https://github.com/pelias/api/pull/448