### PR TITLE
run integration tests in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ jdk:
 install:
   - mkdir /tmp/elasticsearch
   - wget -O - https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/${ES_VERSION}/elasticsearch-${ES_VERSION}.tar.gz | tar xz --directory=/tmp/elasticsearch --strip-components=1
+  - /tmp/elasticsearch/bin/plugin install analysis-icu
   - /tmp/elasticsearch/bin/elasticsearch --daemonize --path.data /tmp
   - npm i
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,17 +17,31 @@ matrix:
 env:
   global:
     - CXX=g++-4.8
-script: "npm run travis"
+  matrix:
+    - ES_VERSION=2.3.4
+jdk:
+  - oraclejdk8
+install:
+  - mkdir /tmp/elasticsearch
+  - wget -O - https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/${ES_VERSION}/elasticsearch-${ES_VERSION}.tar.gz | tar xz --directory=/tmp/elasticsearch --strip-components=1
+  - /tmp/elasticsearch/bin/elasticsearch --daemonize --path.data /tmp
+  - npm i
+script:
+  - npm run travis
 addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
     packages:
       - g++-4.8
+      - oracle-java8-installer
 before_install:
   - npm i -g npm@^2.0.0
 before_script:
   - npm prune
+  - sleep 10
+  - curl http://127.0.0.1:9200/
+  - node scripts/create_index.js -y
 after_success:
   - 'curl -Lo travis_after_all.py https://git.io/travis_after_all'
   - python travis_after_all.py


### PR DESCRIPTION
tests all pass against elasticsearch version `2.3.4`, see [example](https://travis-ci.org/pelias/schema/builds/149168878).

I managed to get it all working without using `sudo` and the builds come in at ~2mins

We should be able to speed up the builds more in the future when the following issues have been addressed:
- https://github.com/travis-ci/apt-source-whitelist/issues/293
- https://github.com/travis-ci/apt-source-whitelist/pull/262

see also: https://github.com/travis-ci/travis-ci/issues/4542
based off: https://gist.github.com/mkorkmaz/254cd7c46a6fbcf79804158b4a6fb013

closes https://github.com/pelias/schema/issues/139