### PR TITLE
Rearrange logic in output_mapping

### DIFF
--- a/scripts/output_mapping.js
+++ b/scripts/output_mapping.js
@@ -6,15 +6,16 @@ var schema = require('../schema');
 var _index = ( process.argv.length > 3 ) ? process.argv[3] : config.schema.indexName;
 var _type = ( process.argv.length > 2 ) ? process.argv[2] : null; // get type from cli args
 
-if( !_type ){
+// print out mapping for just one type
+if ( _type ) {
+  var mapping = schema.mappings[_type];
+  if( !mapping ){
+    console.error( 'could not find a mapping in the schema file for', _index+'/'+_type );
+    process.exit(1);
+  }
+  console.log( JSON.stringify( mapping, null, 2 ) );
+//print out the entire schema mapping
+} else {
   console.log( JSON.stringify( schema, null, 2 ) );
-  process.exit(0);
 }
 
-var mapping = schema.mappings[_type];
-if( !mapping ){
-  console.error( 'could not find a mapping in the schema file for', _index+'/'+_type );
-  process.exit(1);
-}
-
-console.log( JSON.stringify( mapping, null, 2 ) );


### PR DESCRIPTION
`process.exit` can truncate long output in certain node versions, see
these tickets:

https://github.com/nodejs/node/issues/3669
https://github.com/nodejs/node/pull/3170
https://github.com/nodejs/node/issues/2972#issuecomment-146078649

fixes #161