### PR TITLE
Move elasticsearch to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,12 +34,12 @@
   },
   "dependencies": {
     "colors": "^1.1.2",
+    "elasticsearch": "^11.0.1",
     "mergeable": "latest",
     "pelias-config": "2.1.0"
   },
   "devDependencies": {
     "difflet": "^1.0.1",
-    "elasticsearch": "^11.0.1",
     "elastictest": "^1.2.0",
     "tap-spec": "^4.1.1",
     "tape": "^4.5.0",


### PR DESCRIPTION
It's required in production but has been living in devDependencies for a
long time since we were installing both.