### PR TITLE
Remove space appending to directionals

### DIFF
--- a/integration/analyzer_peliasStreet.js
+++ b/integration/analyzer_peliasStreet.js
@@ -22,6 +22,7 @@ module.exports.tests.analyze = function(test, common){
     assertAnalysis( 'keyword_street_suffix', 'foo Crescent', ['foo cres'] );
     assertAnalysis( 'keyword_compass', 'north foo', ['n foo'] );
     assertAnalysis( 'keyword_compass', 'SouthWest foo', ['sw foo'] );
+    assertAnalysis( 'keyword_compass', 'foo SouthWest', ['foo sw'] );
     assertAnalysis( 'remove_ordinals', '1st 2nd 3rd 4th 5th', ['1 2 3 4 5'] );
     assertAnalysis( 'remove_ordinals', 'Ast th 101st', ['ast th 101'] );
 

--- a/settings.js
+++ b/settings.js
@@ -318,8 +318,8 @@ function generate(){
     var split = synonym.split(' ');
     settings.analysis.filter[ "keyword_compass_" + split[0] ] = {
       "type": "pattern_replace",
-      "pattern": split[0] + " ",
-      "replacement": split[2] + " "
+      "pattern": split[0],
+      "replacement": split[2]
     }
   });
 

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -1455,43 +1455,43 @@
         },
         "keyword_compass_southwest": {
           "type": "pattern_replace",
-          "pattern": "southwest ",
-          "replacement": "sw "
+          "pattern": "southwest",
+          "replacement": "sw"
         },
         "keyword_compass_southeast": {
           "type": "pattern_replace",
-          "pattern": "southeast ",
-          "replacement": "se "
+          "pattern": "southeast",
+          "replacement": "se"
         },
         "keyword_compass_northwest": {
           "type": "pattern_replace",
-          "pattern": "northwest ",
-          "replacement": "nw "
+          "pattern": "northwest",
+          "replacement": "nw"
         },
         "keyword_compass_northeast": {
           "type": "pattern_replace",
-          "pattern": "northeast ",
-          "replacement": "ne "
+          "pattern": "northeast",
+          "replacement": "ne"
         },
         "keyword_compass_north": {
           "type": "pattern_replace",
-          "pattern": "north ",
-          "replacement": "n "
+          "pattern": "north",
+          "replacement": "n"
         },
         "keyword_compass_south": {
           "type": "pattern_replace",
-          "pattern": "south ",
-          "replacement": "s "
+          "pattern": "south",
+          "replacement": "s"
         },
         "keyword_compass_east": {
           "type": "pattern_replace",
-          "pattern": "east ",
-          "replacement": "e "
+          "pattern": "east",
+          "replacement": "e"
         },
         "keyword_compass_west": {
           "type": "pattern_replace",
-          "pattern": "west ",
-          "replacement": "w "
+          "pattern": "west",
+          "replacement": "w"
         }
       },
       "char_filter": {


### PR DESCRIPTION
The reason that `186 Tuskegee St SE Atlanta GA` test was failing is because directionals were being contracted with a space appended which is incorrect behavior since postdirectionals are a thing.  