### PR TITLE
Es5 compat

### DIFF
--- a/mappings/document.js
+++ b/mappings/document.js
@@ -1,4 +1,4 @@
-module.exports = function(settings) {
+module.exports = function(config) {
 
 var admin = require('./partial/admin');
 var hash = require('./partial/hash');
@@ -102,7 +102,7 @@ return {
     },
 
     // geography
-    center_point: require('./partial/centroid')(settings),
+    center_point: require('./partial/centroid')(config),
     shape: require('./partial/shape'),
     bounding_box: require('./partial/boundingbox'),
 

--- a/mappings/document.js
+++ b/mappings/document.js
@@ -1,9 +1,11 @@
+module.exports = function(settings) {
+
 var admin = require('./partial/admin');
 var hash = require('./partial/hash');
 var multiplier = require('./partial/multiplier');
 var literal = require('./partial/literal');
 
-var schema = {
+return {
   properties: {
 
     // data partitioning
@@ -100,7 +102,7 @@ var schema = {
     },
 
     // geography
-    center_point: require('./partial/centroid'),
+    center_point: require('./partial/centroid')(settings),
     shape: require('./partial/shape'),
     bounding_box: require('./partial/boundingbox'),
 
@@ -144,4 +146,4 @@ var schema = {
   dynamic: 'true'
 };
 
-module.exports = schema;
+};

--- a/mappings/partial/centroid.js
+++ b/mappings/partial/centroid.js
@@ -1,17 +1,24 @@
-module.exports = function(settings) {
+module.exports = function(config) {
+
+var es_version = config && config.esclient && config.esclient.apiVersion;
 
 // @ref: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/mapping-geo-point-type.html
-var schema = {
-  'type': 'geo_point',
+var schema = { 'type': 'geo_point' };
 
+// The enclosed options are required for es versions earlier than 5.x
+// Using `!es_version || ` because right now recommended version is 2.3
+// HACK: I want to use semver but check the following link:
+//       https://github.com/mojombo/semver/issues/237
+// This lexicographical ordering should be fine until major version 10
+if(!es_version || es_version < '5.0') {
   /* `lat_lon` enabled since both the geo distance and bounding box filters can either be executed using in memory checks, or using the indexed lat lon values */
-  'lat_lon': true,
+  schema['lat_lon'] = true;
 
   /* store geohashes (with prefixes) in order to facilitate the geohash_cell filter */
-  'geohash': true,
-  'geohash_prefix': true,
-  'geohash_precision': 18
-};
+  schema['geohash'] = true;
+  schema['geohash_prefix'] = true;
+  schema['geohash_precision'] = 18;
+}
 
 return schema;
 

--- a/mappings/partial/centroid.js
+++ b/mappings/partial/centroid.js
@@ -1,3 +1,5 @@
+module.exports = function(settings) {
+
 // @ref: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/mapping-geo-point-type.html
 var schema = {
   'type': 'geo_point',
@@ -11,4 +13,6 @@ var schema = {
   'geohash_precision': 18
 };
 
-module.exports = schema;
+return schema;
+
+};

--- a/schema.js
+++ b/schema.js
@@ -1,5 +1,6 @@
-var settings = require('./settings')(),
-    doc = require('./mappings/document')(settings);
+var config = require('pelias-config').generate().export(),
+    settings = require('./settings')(config),
+    doc = require('./mappings/document')(config);
 
 var schema = {
   settings: settings,

--- a/schema.js
+++ b/schema.js
@@ -1,7 +1,8 @@
-var doc = require('./mappings/document');
+var settings = require('./settings')(),
+    doc = require('./mappings/document')(settings);
 
 var schema = {
-  settings: require('./settings')(),
+  settings: settings,
   mappings: {
     /**
       the _default_ mapping is applied to all new _type dynamically added after

--- a/settings.js
+++ b/settings.js
@@ -1,13 +1,10 @@
 var Mergeable = require('mergeable');
-var peliasConfig = require('pelias-config');
 var punctuation = require('./punctuation');
 var street_suffix = require('./street_suffix');
 
 var moduleDir = require('path').dirname("../");
 
-function generate(){
-  var config = peliasConfig.generate().export();
-
+function generate(config) {
   // Default settings
   var settings = {
     "analysis": {

--- a/test/compile.js
+++ b/test/compile.js
@@ -1,5 +1,8 @@
-var path = require('path'),
-    schema = require('../'),
+var path = require('path');
+
+process.env.PELIAS_CONFIG = path.resolve( __dirname + '/fixtures/config.json' );
+
+var schema = require('../'),
     fixture = require('./fixtures/expected.json');
 
 module.exports.tests = {};
@@ -58,9 +61,10 @@ module.exports.tests.current_schema = function(test, common) {
     // copy schema
     var schemaCopy = JSON.parse( JSON.stringify( schema ) );
 
-    // use the pelias config fixture instead of the local config
-    process.env.PELIAS_CONFIG = path.resolve( __dirname + '/fixtures/config.json' );
-    schemaCopy.settings = require('../settings')();
+    // use a different pelias config fixture with the same apiVersion
+    process.env.PELIAS_CONFIG = path.resolve( __dirname + '/fixtures/alt_config2.json' );
+    var config = require('pelias-config').generate().export();
+    schemaCopy.settings = require('../settings')(config);
     delete process.env.PELIAS_CONFIG;
 
     // code intentionally commented to allow quick debugging of expected.json

--- a/test/document.js
+++ b/test/document.js
@@ -1,4 +1,4 @@
-var schema = require('../mappings/document');
+var schema = require('../mappings/document')();
 
 module.exports.tests = {};
 

--- a/test/fixtures/alt_config.json
+++ b/test/fixtures/alt_config.json
@@ -1,0 +1,9 @@
+{
+  "elasticsearch": {
+    "settings": {
+      "index": {
+        "number_of_replicas": "999"
+      }
+    }
+  }
+}

--- a/test/fixtures/alt_config2.json
+++ b/test/fixtures/alt_config2.json
@@ -1,0 +1,7 @@
+{
+  "imports": {
+    "whosonfirst": {
+      "datapath": "/path/to/whosonfirst"
+    }
+  }
+}

--- a/test/fixtures/config.json
+++ b/test/fixtures/config.json
@@ -1,9 +1,1 @@
-{
-  "elasticsearch": {
-    "settings": {
-      "index": {
-        "number_of_replicas": "999"
-      }
-    }
-  }
-}
+{}

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -1565,7 +1565,7 @@
       }
     },
     "index": {
-      "number_of_replicas": "999",
+      "number_of_replicas": "0",
       "number_of_shards": "1",
       "refresh_interval": "1m"
     }

--- a/test/partial-centroid.js
+++ b/test/partial-centroid.js
@@ -1,5 +1,7 @@
 
-var schema = require('../mappings/partial/centroid')();
+var schema_cons = require('../mappings/partial/centroid'),
+    schema = schema_cons(),
+    schema5x = schema_cons({esclient:{apiVersion:'5.0'}});
 
 module.exports.tests = {};
 
@@ -35,6 +37,16 @@ module.exports.tests.geohash = function(test, common) {
     t.equal(schema.geohash, true, 'correct value');
     t.equal(schema.geohash_prefix, true, 'correct value');
     t.equal(schema.geohash_precision, 18, 'correct value');
+    t.end();
+  });
+};
+
+module.exports.tests.options_disabled_for_5_x = function(test, common) {
+  test('options disabled for elasticsearch 5.x', function(t) {
+    t.equal(schema5x.lat_lon, undefined, 'correctly unset');
+    t.equal(schema5x.geohash, undefined, 'correctly unset');
+    t.equal(schema5x.geohash_prefix, undefined, 'correctly unset');
+    t.equal(schema5x.geohash_precision, undefined, 'correctly unset');
     t.end();
   });
 };

--- a/test/partial-centroid.js
+++ b/test/partial-centroid.js
@@ -1,5 +1,5 @@
 
-var schema = require('../mappings/partial/centroid');
+var schema = require('../mappings/partial/centroid')();
 
 module.exports.tests = {};
 

--- a/test/settings.js
+++ b/test/settings.js
@@ -1,6 +1,14 @@
-var path = require('path'),
+var path = require('path');
+
+// set the PELIAS_CONFIG env var
+process.env['PELIAS_CONFIG'] = path.resolve( __dirname + '/fixtures/config.json' );
+
+var config = require('pelias-config').generate().export(),
     settings = require('../settings'),
     fs = require('fs');
+
+process.env['PELIAS_CONFIG'] = path.resolve( __dirname + '/fixtures/alt_config.json' );
+var alt_config = require('pelias-config').generate().export();
 
 module.exports.tests = {};
 
@@ -13,7 +21,7 @@ module.exports.tests.interface = function(test, common) {
 
 module.exports.tests.compile = function(test, common) {
   test('valid settings file', function(t) {
-    var s = settings();
+    var s = settings(config);
     t.equal(typeof s, 'object', 'settings generated');
     t.equal(Object.keys(s).length>0, true, 'settings has body');
     t.end();
@@ -23,7 +31,7 @@ module.exports.tests.compile = function(test, common) {
 // analysis should always be set
 module.exports.tests.analysis = function(test, common) {
   test('has analysis settings', function(t) {
-    var s = settings();
+    var s = settings(config);
     t.equal(typeof s.analysis, 'object', 'analysis specified');
     t.end();
   });
@@ -33,7 +41,7 @@ module.exports.tests.analysis = function(test, common) {
 
 module.exports.tests.peliasAdminAnalyzer = function(test, common) {
   test('has pelias admin analyzer', function(t) {
-    var s = settings();
+    var s = settings(config);
     t.equal(typeof s.analysis.analyzer.peliasAdmin, 'object', 'there is a pelias admin analyzer');
     var analyzer = s.analysis.analyzer.peliasAdmin;
     t.equal(analyzer.type, 'custom', 'custom analyzer');
@@ -45,7 +53,7 @@ module.exports.tests.peliasAdminAnalyzer = function(test, common) {
 
 module.exports.tests.peliasIndexOneEdgeGramAnalyzer = function(test, common) {
   test('has peliasIndexOneEdgeGram analyzer', function(t) {
-    var s = settings();
+    var s = settings(config);
     t.equal(typeof s.analysis.analyzer.peliasIndexOneEdgeGram, 'object', 'there is a peliasIndexOneEdgeGram analyzer');
     var analyzer = s.analysis.analyzer.peliasIndexOneEdgeGram;
     t.equal(analyzer.type, 'custom', 'custom analyzer');
@@ -55,7 +63,7 @@ module.exports.tests.peliasIndexOneEdgeGramAnalyzer = function(test, common) {
     t.end();
   });
   test('peliasIndexOneEdgeGram token filters', function(t) {
-    var analyzer = settings().analysis.analyzer.peliasIndexOneEdgeGram;
+    var analyzer = settings(config).analysis.analyzer.peliasIndexOneEdgeGram;
     t.deepEqual( analyzer.filter, [
       "lowercase",
       "icu_folding",
@@ -80,7 +88,7 @@ module.exports.tests.peliasIndexOneEdgeGramAnalyzer = function(test, common) {
 
 module.exports.tests.peliasIndexTwoEdgeGramAnalyzer = function(test, common) {
   test('has peliasIndexTwoEdgeGram analyzer', function(t) {
-    var s = settings();
+    var s = settings(config);
     t.equal(typeof s.analysis.analyzer.peliasIndexTwoEdgeGram, 'object', 'there is a peliasIndexTwoEdgeGram analyzer');
     var analyzer = s.analysis.analyzer.peliasIndexTwoEdgeGram;
     t.equal(analyzer.type, 'custom', 'custom analyzer');
@@ -90,7 +98,7 @@ module.exports.tests.peliasIndexTwoEdgeGramAnalyzer = function(test, common) {
     t.end();
   });
   test('peliasIndexTwoEdgeGram token filters', function(t) {
-    var analyzer = settings().analysis.analyzer.peliasIndexTwoEdgeGram;
+    var analyzer = settings(config).analysis.analyzer.peliasIndexTwoEdgeGram;
     t.deepEqual( analyzer.filter, [
       "lowercase",
       "icu_folding",
@@ -112,7 +120,7 @@ module.exports.tests.peliasIndexTwoEdgeGramAnalyzer = function(test, common) {
 
 module.exports.tests.peliasPhraseAnalyzer = function(test, common) {
   test('has peliasPhrase analyzer', function(t) {
-    var s = settings();
+    var s = settings(config);
     t.equal(typeof s.analysis.analyzer.peliasPhrase, 'object', 'there is a peliasPhrase analyzer');
     var analyzer = s.analysis.analyzer.peliasPhrase;
     t.equal(analyzer.type, 'custom', 'custom analyzer');
@@ -122,7 +130,7 @@ module.exports.tests.peliasPhraseAnalyzer = function(test, common) {
     t.end();
   });
   test('peliasPhrase token filters', function(t) {
-    var analyzer = settings().analysis.analyzer.peliasPhrase;
+    var analyzer = settings(config).analysis.analyzer.peliasPhrase;
     t.deepEqual( analyzer.filter, [
       "lowercase",
       "icu_folding",
@@ -139,7 +147,7 @@ module.exports.tests.peliasPhraseAnalyzer = function(test, common) {
 
 module.exports.tests.peliasZipAnalyzer = function(test, common) {
   test('has peliasZip analyzer', function(t) {
-    var s = settings();
+    var s = settings(config);
     t.equal(typeof s.analysis.analyzer.peliasZip, 'object', 'there is a peliasZip analyzer');
     var analyzer = s.analysis.analyzer.peliasZip;
     t.equal(analyzer.type, 'custom', 'custom analyzer');
@@ -149,7 +157,7 @@ module.exports.tests.peliasZipAnalyzer = function(test, common) {
     t.end();
   });
   test('peliasZip token filters', function(t) {
-    var analyzer = settings().analysis.analyzer.peliasZip;
+    var analyzer = settings(config).analysis.analyzer.peliasZip;
     t.deepEqual( analyzer.filter, [
       "lowercase",
       "trim"
@@ -160,7 +168,7 @@ module.exports.tests.peliasZipAnalyzer = function(test, common) {
 
 module.exports.tests.peliasHousenumberAnalyzer = function(test, common) {
   test('has peliasHousenumber analyzer', function(t) {
-    var s = settings();
+    var s = settings(config);
     t.equal(typeof s.analysis.analyzer.peliasHousenumber, 'object', 'there is a peliasHousenumber analyzer');
     var analyzer = s.analysis.analyzer.peliasHousenumber;
     t.equal(analyzer.type, 'custom', 'custom analyzer');
@@ -173,7 +181,7 @@ module.exports.tests.peliasHousenumberAnalyzer = function(test, common) {
 
 module.exports.tests.peliasStreetAnalyzer = function(test, common) {
   test('has peliasStreet analyzer', function(t) {
-    var s = settings();
+    var s = settings(config);
     t.equal(typeof s.analysis.analyzer.peliasStreet, 'object', 'there is a peliasStreet analyzer');
     var analyzer = s.analysis.analyzer.peliasStreet;
     t.equal(analyzer.type, 'custom', 'custom analyzer');
@@ -183,7 +191,7 @@ module.exports.tests.peliasStreetAnalyzer = function(test, common) {
     t.end();
   });
   test('peliasStreet token filters', function(t) {
-    var analyzer = settings().analysis.analyzer.peliasStreet;
+    var analyzer = settings(config).analysis.analyzer.peliasStreet;
     t.equal( analyzer.filter.length, 133, 'lots of filters' );
     t.end();
   });
@@ -195,7 +203,7 @@ module.exports.tests.allTokenFiltersPresent = function(test, common) {
     'lowercase', 'icu_folding', 'trim', 'word_delimiter', 'unique'
   ];
   test('all token filters present', function(t) {
-    var s = settings();
+    var s = settings(config);
     for( var analyzerName in s.analysis.analyzer ){
       var analyzer = s.analysis.analyzer[analyzerName];
       if( Array.isArray( analyzer.filter ) ){
@@ -216,7 +224,7 @@ module.exports.tests.allTokenFiltersPresent = function(test, common) {
 module.exports.tests.allCharacterFiltersPresent = function(test, common) {
   var ES_INBUILT_FILTERS = [];
   test('all character filters present', function(t) {
-    var s = settings();
+    var s = settings(config);
     for( var analyzerName in s.analysis.analyzer ){
       var analyzer = s.analysis.analyzer[analyzerName];
       if( Array.isArray( analyzer.char_filter ) ){
@@ -239,7 +247,7 @@ module.exports.tests.allCharacterFiltersPresent = function(test, common) {
 // we convert and->& rather than &->and to save memory/disk
 module.exports.tests.ampersandFilter = function(test, common) {
   test('has ampersand filter', function(t) {
-    var s = settings();
+    var s = settings(config);
     t.equal(typeof s.analysis.filter.ampersand, 'object', 'there is a ampersand filter');
     var filter = s.analysis.filter.ampersand;
     t.equal(filter.type, 'synonym');
@@ -252,7 +260,7 @@ module.exports.tests.ampersandFilter = function(test, common) {
 // filters do weird things, so just to be sure, we explicitly get rid of them
 module.exports.tests.notnullFilter = function(test, common) {
   test('has notnull filter', function(t) {
-    var s = settings();
+    var s = settings(config);
     t.equal(typeof s.analysis.filter.notnull, 'object', 'there is a notnull filter');
     var filter = s.analysis.filter.notnull;
     t.equal(filter.type, 'length');
@@ -264,7 +272,7 @@ module.exports.tests.notnullFilter = function(test, common) {
 // this filter creates edgeNGrams with the minimum size of 1
 module.exports.tests.peliasOneEdgeGramFilter = function(test, common) {
   test('has peliasIndexOneEdgeGram filter', function(t) {
-    var s = settings();
+    var s = settings(config);
     t.equal(typeof s.analysis.filter.peliasOneEdgeGramFilter, 'object', 'there is a peliasIndexOneEdgeGram filter');
     var filter = s.analysis.filter.peliasOneEdgeGramFilter;
     t.equal(filter.type, 'edgeNGram');
@@ -277,7 +285,7 @@ module.exports.tests.peliasOneEdgeGramFilter = function(test, common) {
 // this filter creates edgeNGrams with the minimum size of 2
 module.exports.tests.peliasTwoEdgeGramFilter = function(test, common) {
   test('has peliasIndexTwoEdgeGram filter', function(t) {
-    var s = settings();
+    var s = settings(config);
     t.equal(typeof s.analysis.filter.peliasTwoEdgeGramFilter, 'object', 'there is a peliasIndexTwoEdgeGram filter');
     var filter = s.analysis.filter.peliasTwoEdgeGramFilter;
     t.equal(filter.type, 'edgeNGram');
@@ -290,7 +298,7 @@ module.exports.tests.peliasTwoEdgeGramFilter = function(test, common) {
 // this filter removed leading 0 characters. eg. 0001 -> 1
 module.exports.tests.removeAllZeroNumericPrefixFilter = function(test, common) {
   test('has removeAllZeroNumericPrefix filter', function(t) {
-    var s = settings();
+    var s = settings(config);
     t.equal(typeof s.analysis.filter.removeAllZeroNumericPrefix, 'object', 'there is a removeAllZeroNumericPrefix filter');
     var filter = s.analysis.filter.removeAllZeroNumericPrefix;
     t.equal(filter.type, 'pattern_replace');
@@ -305,7 +313,7 @@ module.exports.tests.removeAllZeroNumericPrefixFilter = function(test, common) {
 // note: it is not intended to be used with shingles, but useful for ngrams
 module.exports.tests.addressStopFilter = function(test, common) {
   test('has address_stop filter', function(t) {
-    var s = settings();
+    var s = settings(config);
     t.equal(typeof s.analysis.filter.address_stop, 'object', 'there is an address_stop filter');
     var filter = s.analysis.filter.address_stop;
     t.equal(filter.type, 'stop');
@@ -341,7 +349,7 @@ module.exports.tests.addressStopFilter = function(test, common) {
 // eg. road=>rd and street=>st
 module.exports.tests.streetSynonymFilter = function(test, common) {
   test('has street_synonym filter', function(t) {
-    var s = settings();
+    var s = settings(config);
     t.equal(typeof s.analysis.filter.street_synonym, 'object', 'there is an street_synonym filter');
     var filter = s.analysis.filter.street_synonym;
     t.equal(filter.type, 'synonym');
@@ -355,7 +363,7 @@ module.exports.tests.streetSynonymFilter = function(test, common) {
 // eg. north=>n and south=>s
 module.exports.tests.directionSynonymFilter = function(test, common) {
   test('has direction_synonym filter', function(t) {
-    var s = settings();
+    var s = settings(config);
     t.equal(typeof s.analysis.filter.direction_synonym, 'object', 'there is an direction_synonym filter');
     var filter = s.analysis.filter.direction_synonym;
     t.equal(filter.type, 'synonym');
@@ -369,7 +377,7 @@ module.exports.tests.directionSynonymFilter = function(test, common) {
 // eg. 26th => 26, 1st => 1
 module.exports.tests.removeOrdinalsFilter = function(test, common) {
   test('has remove_ordinals filter', function(t) {
-    var s = settings();
+    var s = settings(config);
     t.equal(typeof s.analysis.filter.remove_ordinals, 'object', 'there is an remove_ordinals filter');
     var filter = s.analysis.filter.remove_ordinals;
     t.equal(filter.type, 'pattern_replace');
@@ -385,7 +393,7 @@ module.exports.tests.removeOrdinalsFilter = function(test, common) {
 // character which would otherwise be stripped by the standard tokenizer
 module.exports.tests.punctuationCharFilter = function(test, common) {
   test('has punctuation char_filter', function(t) {
-    var s = settings();
+    var s = settings(config);
     t.equal(typeof s.analysis.char_filter.punctuation, 'object', 'there is a punctuation char_filter');
     var char_filter = s.analysis.char_filter.punctuation;
     t.equal(char_filter.type, 'mapping');
@@ -398,7 +406,7 @@ module.exports.tests.punctuationCharFilter = function(test, common) {
 // remove non alphanumeric characters
 module.exports.tests.alphanumericCharFilter = function(test, common) {
   test('has alphanumeric char_filter', function(t) {
-    var s = settings();
+    var s = settings(config);
     t.equal(typeof s.analysis.char_filter.alphanumeric, 'object', 'there is a alphanumeric char_filter');
     var char_filter = s.analysis.char_filter.alphanumeric;
     t.equal(char_filter.type, 'pattern_replace');
@@ -411,7 +419,7 @@ module.exports.tests.alphanumericCharFilter = function(test, common) {
 // replace non-numeric chars with a space
 module.exports.tests.numericCharFilter = function(test, common) {
   test('has numeric char_filter', function(t) {
-    var s = settings();
+    var s = settings(config);
     t.equal(typeof s.analysis.char_filter.numeric, 'object', 'there is a numeric char_filter');
     var char_filter = s.analysis.char_filter.numeric;
     t.equal(char_filter.type, 'pattern_replace');
@@ -426,7 +434,7 @@ module.exports.tests.numericCharFilter = function(test, common) {
 // index should always be set
 module.exports.tests.index = function(test, common) {
   test('has index settings', function(t) {
-    var s = settings();
+    var s = settings(config);
     t.equal(typeof s.index, 'object', 'index specified');
     t.equal(s.index.number_of_replicas, "0", 'replicas will increase index time');
     t.equal(s.index.number_of_shards, "1", 'sharding is only required in a distributed env');
@@ -438,13 +446,10 @@ module.exports.tests.index = function(test, common) {
 module.exports.tests.overrides = function(test, common) {
   test('override defaults', function(t) {
 
-    var s = settings();
+    var s = settings(config);
     t.equal(s.index['number_of_replicas'], '0', 'unchanged');
 
-    // set the PELIAS_CONFIG env var
-    process.env['PELIAS_CONFIG'] = path.resolve( __dirname + '/fixtures/config.json' );
-
-    s = settings();
+    s = settings(alt_config);
     t.equal(s.index['number_of_replicas'], '999', 'changed');
     t.end();
 


### PR DESCRIPTION
The tests here will fail unless https://github.com/pelias/config/pull/45 is accepted because the fixture sets an expectation for the index_concurrency field, but that is moot for 5.x compat.