### PR TITLE
Add checks for localhost drop

### DIFF
--- a/scripts/drop_index.js
+++ b/scripts/drop_index.js
@@ -17,10 +17,12 @@ function drop(){
   });
 }
 
+// check all hosts to see if any is not localhost
 function warnIfNotLocal() {
-  if(config.esclient.hosts[0].host !== "localhost") {
+  if (config.esclient.hosts.some((env) => { return env.host !== 'localhost'; } )) {
     console.log(colors.red("WARNING: DROPPING SCHEMA NOT ON LOCALHOST"));
   }
+
 }
 
 function prompt( yes, no ){


### PR DESCRIPTION
Previously, only the first host in `esclient.hosts` was checked for localhost value so if the array contained multiple hosts and the first was not localhost, no warning would be given about dropping a non-localhost index.  For example:

```
{
      "env": "development",
      "protocol": "http",
      "host": "localhost",
      "port": 9200
},
{
      "env": "production",
      "protocol": "http",
      "host": "internal-pelias-production-es2-162482742.us-east-1.elb.amazonaws.com",
      "port": 9200
}
```

No warning would be given even though it would drop the production index.  