### PR TITLE
Skip plugin checks on hosted Elasticsearch

### DIFF
--- a/scripts/check_plugins.js
+++ b/scripts/check_plugins.js
@@ -28,6 +28,13 @@ client.nodes.info( null, function( err, res ){
   for( var uid in res.nodes ){
 
     var node = res.nodes[uid];
+
+    // Amazon's hosted Elasticsearch does not have the plugins property
+    // but has the plugins we need
+    if (!node.plugins) {
+      continue;
+    }
+
     console.log( util.format( "\033[1;37mnode '%s' [%s]\033[0m", node.name, uid ) );
 
     // per node failures


### PR DESCRIPTION
The AWS Elasticsearch service does not expose the list of installed plugins, so our plugin checking code breaks.

Fortunately, for now, it has the plugin we need already installed.

Note that in our testing, Pelias performs significantly worse on the hosted Elasticsearch compared to regular EC2 instances.
See https://github.com/pelias/pelias/issues/402#issuecomment-255854624 for more details

Fixes https://github.com/pelias/schema/issues/213