### PR TITLE
Fixed path to check_plugins.js in create_index.js

### DIFF
--- a/scripts/create_index.js
+++ b/scripts/create_index.js
@@ -7,7 +7,7 @@ var schema = require('../schema');
 
 // check mandatory plugins are installed before continuing
 try {
-  child_process.execSync( 'node ./scripts/check_plugins.js' );
+  child_process.execSync( 'node ' + __dirname + '/check_plugins.js' );
 } catch( e ){
   console.error( "please install mandatory plugins before continuing.\n");
   process.exit(1);


### PR DESCRIPTION
Fixed path to check_plugins.js in create_index.js script to allow run index creation from any working dir only only from schema directory itself.

Fixes https://github.com/pelias/schema/issues/190