### PR TITLE
Faster travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ matrix:
 env:
   global:
     - BUILD_LEADER_ID=2
-    - CXX=g++-4.8
   matrix:
     - ES_VERSION=2.3.4
 jdk:
@@ -25,10 +24,7 @@ script:
   - npm run travis
 addons:
   apt:
-    sources:
-      - ubuntu-toolchain-r-test
     packages:
-      - g++-4.8
       - oracle-java8-installer
 before_install:
   - npm i -g npm@^3.0.0


### PR DESCRIPTION
Now that TravisCI [defaults to Ubuntu 14](https://blog.travis-ci.com/2017-08-31-trusty-as-default-status), we no longer need to install a newer version of GCC in our Travis builds.

This installation process can take up to 2 minutes (and our builds are usually under 4 minutes), meaning this change makes Travis run twice as fast!!

Connects pelias/pelias#575