### PR TITLE
Replace pelias-mergeable with lodash.merge

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "colors": "^1.1.2",
     "elasticsearch": "^13.3.1",
     "joi": "^12.0.0",
-    "mergeable": "latest",
+    "lodash.merge": "^4.6.0",
     "pelias-config": "2.13.0"
   },
   "devDependencies": {

--- a/settings.js
+++ b/settings.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Mergeable = require('mergeable');
+var merge = require('lodash.merge');
 var peliasConfig = require('pelias-config');
 var punctuation = require('./punctuation');
 var street_suffix = require('./street_suffix');
@@ -308,9 +308,7 @@ function generate(){
   if( 'object' == typeof config &&
       'object' == typeof config.elasticsearch &&
       'object' == typeof config.elasticsearch.settings ){
-    var defaults = new Mergeable( settings );
-    defaults.deepMerge( config.elasticsearch.settings );
-    return defaults.export();
+    return merge({}, settings, config.elasticsearch.settings);
   }
 
   return settings;


### PR DESCRIPTION
[pelias-mergeable](https://github.com/pelias/mergeable/) is to be deprecated, so replace usage with the functionality provided by `lodash`.

Given we only require a small subset of lodash, add dependency for `lodash.merge` to avoid pulling in an unnecessarily large dependency.

See further the objective in: https://github.com/pelias/mergeable/issues/5