### PR TITLE
fix(settings.js): fix relative path to folder with synonyms

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -8,19 +8,17 @@ var punctuation = require('./punctuation');
 var synonymFile = require('./synonyms/parser');
 
 // load synonyms from disk
-var synonyms = fs.readdirSync('./synonyms')
+var synonyms = fs.readdirSync(path.join(__dirname, 'synonyms'))
                  .sort()
                  .filter( f => f.match(/\.txt$/) )
                  .reduce(( acc, cur ) => {
                    acc[cur.replace('.txt','')] = synonymFile(
-                     path.join( './synonyms', cur )
+                     path.join(__dirname, 'synonyms', cur)
                    );
                    return acc;
                  }, {});
 
 require('./configValidation').validate(peliasConfig.generate());
-
-var moduleDir = require('path').dirname("../");
 
 function generate(){
   var config = peliasConfig.generate().export();


### PR DESCRIPTION
Hi there,
thanks for adding extremely useful thing such a separate files for elasticsearch synonyms.

I've noticed that currently it could be problematic to work with this module if run scripts from outside of module folder. This PR adds simply __dirname to path to this folder and in the end it will be absolute path which looks much more safety.