### PR TITLE
Dockerfile tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,12 @@ FROM pelias/baseimage
 ENV WORKDIR /code/pelias/schema
 WORKDIR ${WORKDIR}
 
+# copy package.json first to prevent npm install being rerun when only code changes
+COPY ./package.json ${WORK}
+RUN npm install
+
 # add code from local checkout to image
 ADD . ${WORKDIR}
-
-# install npm dependencies
-RUN npm install
 
 # run tests
 RUN npm test

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,3 @@ RUN npm install
 
 # add code from local checkout to image
 ADD . ${WORKDIR}
-
-# run tests
-RUN npm test


### PR DESCRIPTION
Speed up repeated builds of code-only changes by copying package.json and running npm install separately first.

Additionally, disable unit test running as part of the build process. There are many cases where we might want to build docker images that don't have passing unit tests.