### PR TITLE
Add continent and empire to parent field mappings

### DIFF
--- a/mappings/document.js
+++ b/mappings/document.js
@@ -51,6 +51,10 @@ var schema = {
       type: 'object',
       dynamic: true,
       properties: {
+        // https://github.com/whosonfirst/whosonfirst-placetypes#continent
+        continent: admin,
+        continent_a: admin,
+        continent_id: literal,
 
         // https://github.com/whosonfirst/whosonfirst-placetypes#country
         country: admin,

--- a/mappings/document.js
+++ b/mappings/document.js
@@ -56,6 +56,11 @@ var schema = {
         continent_a: admin,
         continent_id: literal,
 
+        // https://github.com/whosonfirst/whosonfirst-placetypes#empire
+        empire: admin,
+        empire_a: admin,
+        empire_id: literal,
+
         // https://github.com/whosonfirst/whosonfirst-placetypes#country
         country: admin,
         country_a: admin,

--- a/test/document.js
+++ b/test/document.js
@@ -85,6 +85,7 @@ module.exports.tests.address_analysis = function(test, common) {
 // should contain the correct parent field definitions
 module.exports.tests.parent_fields = function(test, common) {
   var fields = [
+    'continent',      'continent_a',      'continent_id',
     'country',        'country_a',        'country_id',
     'dependency',     'dependency_a',     'dependency_id',
     'macroregion',    'macroregion_a',    'macroregion_id',

--- a/test/document.js
+++ b/test/document.js
@@ -86,6 +86,7 @@ module.exports.tests.address_analysis = function(test, common) {
 module.exports.tests.parent_fields = function(test, common) {
   var fields = [
     'continent',      'continent_a',      'continent_id',
+    'empire',         'empire_a',         'empire_id',
     'country',        'country_a',        'country_id',
     'dependency',     'dependency_a',     'dependency_id',
     'macroregion',    'macroregion_a',    'macroregion_id',

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -1507,6 +1507,21 @@
               "analyzer": "keyword",
               "store": "yes"
             },
+            "empire": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "empire_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "empire_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
             "country": {
               "type": "string",
               "analyzer": "peliasAdmin",
@@ -1815,6 +1830,21 @@
               "store": "yes"
             },
             "continent_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "empire": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "empire_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "empire_id": {
               "type": "string",
               "analyzer": "keyword",
               "store": "yes"
@@ -2131,6 +2161,21 @@
               "analyzer": "keyword",
               "store": "yes"
             },
+            "empire": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "empire_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "empire_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
             "country": {
               "type": "string",
               "analyzer": "peliasAdmin",
@@ -2439,6 +2484,21 @@
               "store": "yes"
             },
             "continent_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "empire": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "empire_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "empire_id": {
               "type": "string",
               "analyzer": "keyword",
               "store": "yes"
@@ -2755,6 +2815,21 @@
               "analyzer": "keyword",
               "store": "yes"
             },
+            "empire": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "empire_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "empire_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
             "country": {
               "type": "string",
               "analyzer": "peliasAdmin",
@@ -3063,6 +3138,21 @@
               "store": "yes"
             },
             "continent_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "empire": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "empire_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "empire_id": {
               "type": "string",
               "analyzer": "keyword",
               "store": "yes"
@@ -3379,6 +3469,21 @@
               "analyzer": "keyword",
               "store": "yes"
             },
+            "empire": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "empire_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "empire_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
             "country": {
               "type": "string",
               "analyzer": "peliasAdmin",
@@ -3687,6 +3792,21 @@
               "store": "yes"
             },
             "continent_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "empire": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "empire_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "empire_id": {
               "type": "string",
               "analyzer": "keyword",
               "store": "yes"
@@ -4003,6 +4123,21 @@
               "analyzer": "keyword",
               "store": "yes"
             },
+            "empire": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "empire_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "empire_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
             "country": {
               "type": "string",
               "analyzer": "peliasAdmin",
@@ -4311,6 +4446,21 @@
               "store": "yes"
             },
             "continent_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "empire": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "empire_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "empire_id": {
               "type": "string",
               "analyzer": "keyword",
               "store": "yes"
@@ -4627,6 +4777,21 @@
               "analyzer": "keyword",
               "store": "yes"
             },
+            "empire": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "empire_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "empire_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
             "country": {
               "type": "string",
               "analyzer": "peliasAdmin",
@@ -4935,6 +5100,21 @@
               "store": "yes"
             },
             "continent_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "empire": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "empire_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "empire_id": {
               "type": "string",
               "analyzer": "keyword",
               "store": "yes"
@@ -5251,6 +5431,21 @@
               "analyzer": "keyword",
               "store": "yes"
             },
+            "empire": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "empire_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "empire_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
             "country": {
               "type": "string",
               "analyzer": "peliasAdmin",
@@ -5563,6 +5758,21 @@
               "analyzer": "keyword",
               "store": "yes"
             },
+            "empire": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "empire_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "empire_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
             "country": {
               "type": "string",
               "analyzer": "peliasAdmin",
@@ -5871,6 +6081,21 @@
               "store": "yes"
             },
             "continent_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
+            "empire": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "empire_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "empire_id": {
               "type": "string",
               "analyzer": "keyword",
               "store": "yes"

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -1492,6 +1492,21 @@
           "type": "object",
           "dynamic": true,
           "properties": {
+            "continent": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "continent_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "continent_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
             "country": {
               "type": "string",
               "analyzer": "peliasAdmin",
@@ -1789,6 +1804,21 @@
           "type": "object",
           "dynamic": true,
           "properties": {
+            "continent": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "continent_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "continent_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
             "country": {
               "type": "string",
               "analyzer": "peliasAdmin",
@@ -2086,6 +2116,21 @@
           "type": "object",
           "dynamic": true,
           "properties": {
+            "continent": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "continent_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "continent_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
             "country": {
               "type": "string",
               "analyzer": "peliasAdmin",
@@ -2383,6 +2428,21 @@
           "type": "object",
           "dynamic": true,
           "properties": {
+            "continent": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "continent_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "continent_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
             "country": {
               "type": "string",
               "analyzer": "peliasAdmin",
@@ -2680,6 +2740,21 @@
           "type": "object",
           "dynamic": true,
           "properties": {
+            "continent": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "continent_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "continent_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
             "country": {
               "type": "string",
               "analyzer": "peliasAdmin",
@@ -2977,6 +3052,21 @@
           "type": "object",
           "dynamic": true,
           "properties": {
+            "continent": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "continent_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "continent_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
             "country": {
               "type": "string",
               "analyzer": "peliasAdmin",
@@ -3274,6 +3364,21 @@
           "type": "object",
           "dynamic": true,
           "properties": {
+            "continent": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "continent_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "continent_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
             "country": {
               "type": "string",
               "analyzer": "peliasAdmin",
@@ -3571,6 +3676,21 @@
           "type": "object",
           "dynamic": true,
           "properties": {
+            "continent": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "continent_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "continent_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
             "country": {
               "type": "string",
               "analyzer": "peliasAdmin",
@@ -3868,6 +3988,21 @@
           "type": "object",
           "dynamic": true,
           "properties": {
+            "continent": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "continent_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "continent_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
             "country": {
               "type": "string",
               "analyzer": "peliasAdmin",
@@ -4165,6 +4300,21 @@
           "type": "object",
           "dynamic": true,
           "properties": {
+            "continent": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "continent_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "continent_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
             "country": {
               "type": "string",
               "analyzer": "peliasAdmin",
@@ -4462,6 +4612,21 @@
           "type": "object",
           "dynamic": true,
           "properties": {
+            "continent": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "continent_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "continent_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
             "country": {
               "type": "string",
               "analyzer": "peliasAdmin",
@@ -4759,6 +4924,21 @@
           "type": "object",
           "dynamic": true,
           "properties": {
+            "continent": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "continent_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "continent_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
             "country": {
               "type": "string",
               "analyzer": "peliasAdmin",
@@ -5056,6 +5236,21 @@
           "type": "object",
           "dynamic": true,
           "properties": {
+            "continent": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "continent_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "continent_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
             "country": {
               "type": "string",
               "analyzer": "peliasAdmin",
@@ -5353,6 +5548,21 @@
           "type": "object",
           "dynamic": true,
           "properties": {
+            "continent": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "continent_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "continent_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
             "country": {
               "type": "string",
               "analyzer": "peliasAdmin",
@@ -5650,6 +5860,21 @@
           "type": "object",
           "dynamic": true,
           "properties": {
+            "continent": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "continent_a": {
+              "type": "string",
+              "analyzer": "peliasAdmin",
+              "store": "yes"
+            },
+            "continent_id": {
+              "type": "string",
+              "analyzer": "keyword",
+              "store": "yes"
+            },
             "country": {
               "type": "string",
               "analyzer": "peliasAdmin",


### PR DESCRIPTION
We added continents to pelias/model in https://github.com/pelias/model/pull/48, so our importers now ask Elasticsearch to create records with fields for continents.

At the moment, looking at https://github.com/pelias/pelias/issues/473 and associated issues, it doesn't appear we ever add any data to the continent fields. Whether or not we want to do that is worth discussing.

However, without adding continents to the Elasticsearch mapping, Elasticsearch will add all of these continent fields as string mappings:

```
julian@manhattan ~/repos/pelias/schema $ curl -s localhost:9200/pelias | jq . | grep continent -C 3
                "store": true,
                "analyzer": "keyword"
              },
              "continent": {
                "type": "string"
              },
              "continent_id": {
                "type": "string"
              },

```

This isn't ideal, even if no continents are ever added to the index.

`empire` support was similarly added at some point along the way.