### PR TITLE
Use strict mapping

### DIFF
--- a/integration/admin_matching.js
+++ b/integration/admin_matching.js
@@ -17,26 +17,28 @@ module.exports.tests.functional = function(test, common){
     suite.action( function( done ){
       suite.client.index({
         index: suite.props.index, type: 'test',
-        id: '1', body: { admin: {
-          country: 'Test Country',
-          country_a: 'TestCountry',
-          country_id: '100',
-          region: 'Test Region',
-          region_a: 'TestRegion',
-          region_id: '200',
-          county: 'Test County',
-          county_a: 'TestCounty',
-          county_id: '300',
-          locality: 'Test Locality',
-          locality_a: 'TestLocality',
-          locality_id: '400',
-          localadmin: 'Test LocalAdmin',
-          localadmin_a: 'TestLocalAdmin',
-          localadmin_id: '500',
-          neighbourhood: 'Test Neighbourhood',
-          neighbourhood_a: 'TestNeighbourhood',
-          neighbourhood_id: '600',
-        }}
+        id: '1', body: {
+          parent: {
+            country: 'Test Country',
+            country_a: 'TestCountry',
+            country_id: '100',
+            region: 'Test Region',
+            region_a: 'TestRegion',
+            region_id: '200',
+            county: 'Test County',
+            county_a: 'TestCounty',
+            county_id: '300',
+            locality: 'Test Locality',
+            locality_a: 'TestLocality',
+            locality_id: '400',
+            localadmin: 'Test LocalAdmin',
+            localadmin_a: 'TestLocalAdmin',
+            localadmin_id: '500',
+            neighbourhood: 'Test Neighbourhood',
+            neighbourhood_a: 'TestNeighbourhood',
+            neighbourhood_id: '600',
+          }
+        }
       }, done );
     });
 
@@ -45,7 +47,7 @@ module.exports.tests.functional = function(test, common){
       suite.client.search({
         index: suite.props.index,
         type: 'test',
-        body: { query: { match: { 'admin.country': 'Test Country' } } }
+        body: { query: { match: { 'parent.country': 'Test Country' } } }
       }, function( err, res ){
         t.equal( err, undefined );
         t.equal( res.hits.total, 1, 'document found' );
@@ -58,7 +60,7 @@ module.exports.tests.functional = function(test, common){
       suite.client.search({
         index: suite.props.index,
         type: 'test',
-        body: { query: { match: { 'admin.country_a': 'TestCountry' } } }
+        body: { query: { match: { 'parent.country_a': 'TestCountry' } } }
       }, function( err, res ){
         t.equal( err, undefined );
         t.equal( res.hits.total, 1, 'document found' );
@@ -71,7 +73,7 @@ module.exports.tests.functional = function(test, common){
       suite.client.search({
         index: suite.props.index,
         type: 'test',
-        body: { query: { match: { 'admin.country_id': '100' } } }
+        body: { query: { match: { 'parent.country_id': '100' } } }
       }, function( err, res ){
         t.equal( err, undefined );
         t.equal( res.hits.total, 1, 'document found' );

--- a/mappings/document.js
+++ b/mappings/document.js
@@ -22,7 +22,7 @@ var schema = {
     // address data
     address_parts: {
       type: 'object',
-      dynamic: true,
+      dynamic: 'strict',
       properties: {
         name: {
           type: 'string',
@@ -50,7 +50,7 @@ var schema = {
     // hierarchy
     parent: {
       type: 'object',
-      dynamic: true,
+      dynamic: 'strict',
       properties: {
         // https://github.com/whosonfirst/whosonfirst-placetypes#continent
         continent: admin,
@@ -161,7 +161,7 @@ var schema = {
   _all: {
     enabled: false
   },
-  dynamic: 'true'
+  dynamic: 'strict'
 };
 
 module.exports = schema;

--- a/test/document.js
+++ b/test/document.js
@@ -176,9 +176,10 @@ module.exports.tests.all_disabled = function(test, common) {
 
 // dynamic should be true in order for dynamic_templates to function properly
 // @see: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/mapping-dynamic-mapping.html
+// strict ensures extra fields cannot be added: https://www.elastic.co/guide/en/elasticsearch/guide/current/dynamic-mapping.html
 module.exports.tests.dynamic_disabled = function(test, common) {
-  test('dynamic true', function(t) {
-    t.equal(schema.dynamic, 'true', 'dynamic true');
+  test('dynamic strict', function(t) {
+    t.equal(schema.dynamic, 'strict', 'dynamic true');
     t.end();
   });
 };

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -1457,7 +1457,7 @@
         },
         "address_parts": {
           "type": "object",
-          "dynamic": true,
+          "dynamic": "strict",
           "properties": {
             "name": {
               "type": "string",
@@ -1483,7 +1483,7 @@
         },
         "parent": {
           "type": "object",
-          "dynamic": true,
+          "dynamic": "strict",
           "properties": {
             "continent": {
               "type": "string",
@@ -1724,7 +1724,7 @@
       "_all": {
         "enabled": false
       },
-      "dynamic": "true"
+      "dynamic": "strict"
     },
     "venue": {
       "properties": {
@@ -1746,7 +1746,7 @@
         },
         "address_parts": {
           "type": "object",
-          "dynamic": true,
+          "dynamic": "strict",
           "properties": {
             "name": {
               "type": "string",
@@ -1772,7 +1772,7 @@
         },
         "parent": {
           "type": "object",
-          "dynamic": true,
+          "dynamic": "strict",
           "properties": {
             "continent": {
               "type": "string",
@@ -2013,7 +2013,7 @@
       "_all": {
         "enabled": false
       },
-      "dynamic": "true"
+      "dynamic": "strict"
     },
     "address": {
       "properties": {
@@ -2035,7 +2035,7 @@
         },
         "address_parts": {
           "type": "object",
-          "dynamic": true,
+          "dynamic": "strict",
           "properties": {
             "name": {
               "type": "string",
@@ -2061,7 +2061,7 @@
         },
         "parent": {
           "type": "object",
-          "dynamic": true,
+          "dynamic": "strict",
           "properties": {
             "continent": {
               "type": "string",
@@ -2302,7 +2302,7 @@
       "_all": {
         "enabled": false
       },
-      "dynamic": "true"
+      "dynamic": "strict"
     },
     "street": {
       "properties": {
@@ -2324,7 +2324,7 @@
         },
         "address_parts": {
           "type": "object",
-          "dynamic": true,
+          "dynamic": "strict",
           "properties": {
             "name": {
               "type": "string",
@@ -2350,7 +2350,7 @@
         },
         "parent": {
           "type": "object",
-          "dynamic": true,
+          "dynamic": "strict",
           "properties": {
             "continent": {
               "type": "string",
@@ -2591,7 +2591,7 @@
       "_all": {
         "enabled": false
       },
-      "dynamic": "true"
+      "dynamic": "strict"
     },
     "neighbourhood": {
       "properties": {
@@ -2613,7 +2613,7 @@
         },
         "address_parts": {
           "type": "object",
-          "dynamic": true,
+          "dynamic": "strict",
           "properties": {
             "name": {
               "type": "string",
@@ -2639,7 +2639,7 @@
         },
         "parent": {
           "type": "object",
-          "dynamic": true,
+          "dynamic": "strict",
           "properties": {
             "continent": {
               "type": "string",
@@ -2880,7 +2880,7 @@
       "_all": {
         "enabled": false
       },
-      "dynamic": "true"
+      "dynamic": "strict"
     },
     "borough": {
       "properties": {
@@ -2902,7 +2902,7 @@
         },
         "address_parts": {
           "type": "object",
-          "dynamic": true,
+          "dynamic": "strict",
           "properties": {
             "name": {
               "type": "string",
@@ -2928,7 +2928,7 @@
         },
         "parent": {
           "type": "object",
-          "dynamic": true,
+          "dynamic": "strict",
           "properties": {
             "continent": {
               "type": "string",
@@ -3169,7 +3169,7 @@
       "_all": {
         "enabled": false
       },
-      "dynamic": "true"
+      "dynamic": "strict"
     },
     "postalcode": {
       "properties": {
@@ -3191,7 +3191,7 @@
         },
         "address_parts": {
           "type": "object",
-          "dynamic": true,
+          "dynamic": "strict",
           "properties": {
             "name": {
               "type": "string",
@@ -3217,7 +3217,7 @@
         },
         "parent": {
           "type": "object",
-          "dynamic": true,
+          "dynamic": "strict",
           "properties": {
             "continent": {
               "type": "string",
@@ -3458,7 +3458,7 @@
       "_all": {
         "enabled": false
       },
-      "dynamic": "true"
+      "dynamic": "strict"
     },
     "locality": {
       "properties": {
@@ -3480,7 +3480,7 @@
         },
         "address_parts": {
           "type": "object",
-          "dynamic": true,
+          "dynamic": "strict",
           "properties": {
             "name": {
               "type": "string",
@@ -3506,7 +3506,7 @@
         },
         "parent": {
           "type": "object",
-          "dynamic": true,
+          "dynamic": "strict",
           "properties": {
             "continent": {
               "type": "string",
@@ -3747,7 +3747,7 @@
       "_all": {
         "enabled": false
       },
-      "dynamic": "true"
+      "dynamic": "strict"
     },
     "localadmin": {
       "properties": {
@@ -3769,7 +3769,7 @@
         },
         "address_parts": {
           "type": "object",
-          "dynamic": true,
+          "dynamic": "strict",
           "properties": {
             "name": {
               "type": "string",
@@ -3795,7 +3795,7 @@
         },
         "parent": {
           "type": "object",
-          "dynamic": true,
+          "dynamic": "strict",
           "properties": {
             "continent": {
               "type": "string",
@@ -4036,7 +4036,7 @@
       "_all": {
         "enabled": false
       },
-      "dynamic": "true"
+      "dynamic": "strict"
     },
     "county": {
       "properties": {
@@ -4058,7 +4058,7 @@
         },
         "address_parts": {
           "type": "object",
-          "dynamic": true,
+          "dynamic": "strict",
           "properties": {
             "name": {
               "type": "string",
@@ -4084,7 +4084,7 @@
         },
         "parent": {
           "type": "object",
-          "dynamic": true,
+          "dynamic": "strict",
           "properties": {
             "continent": {
               "type": "string",
@@ -4325,7 +4325,7 @@
       "_all": {
         "enabled": false
       },
-      "dynamic": "true"
+      "dynamic": "strict"
     },
     "macrocounty": {
       "properties": {
@@ -4347,7 +4347,7 @@
         },
         "address_parts": {
           "type": "object",
-          "dynamic": true,
+          "dynamic": "strict",
           "properties": {
             "name": {
               "type": "string",
@@ -4373,7 +4373,7 @@
         },
         "parent": {
           "type": "object",
-          "dynamic": true,
+          "dynamic": "strict",
           "properties": {
             "continent": {
               "type": "string",
@@ -4614,7 +4614,7 @@
       "_all": {
         "enabled": false
       },
-      "dynamic": "true"
+      "dynamic": "strict"
     },
     "region": {
       "properties": {
@@ -4636,7 +4636,7 @@
         },
         "address_parts": {
           "type": "object",
-          "dynamic": true,
+          "dynamic": "strict",
           "properties": {
             "name": {
               "type": "string",
@@ -4662,7 +4662,7 @@
         },
         "parent": {
           "type": "object",
-          "dynamic": true,
+          "dynamic": "strict",
           "properties": {
             "continent": {
               "type": "string",
@@ -4903,7 +4903,7 @@
       "_all": {
         "enabled": false
       },
-      "dynamic": "true"
+      "dynamic": "strict"
     },
     "macroregion": {
       "properties": {
@@ -4925,7 +4925,7 @@
         },
         "address_parts": {
           "type": "object",
-          "dynamic": true,
+          "dynamic": "strict",
           "properties": {
             "name": {
               "type": "string",
@@ -4951,7 +4951,7 @@
         },
         "parent": {
           "type": "object",
-          "dynamic": true,
+          "dynamic": "strict",
           "properties": {
             "continent": {
               "type": "string",
@@ -5192,7 +5192,7 @@
       "_all": {
         "enabled": false
       },
-      "dynamic": "true"
+      "dynamic": "strict"
     },
     "dependency": {
       "properties": {
@@ -5214,7 +5214,7 @@
         },
         "address_parts": {
           "type": "object",
-          "dynamic": true,
+          "dynamic": "strict",
           "properties": {
             "name": {
               "type": "string",
@@ -5240,7 +5240,7 @@
         },
         "parent": {
           "type": "object",
-          "dynamic": true,
+          "dynamic": "strict",
           "properties": {
             "continent": {
               "type": "string",
@@ -5481,7 +5481,7 @@
       "_all": {
         "enabled": false
       },
-      "dynamic": "true"
+      "dynamic": "strict"
     },
     "country": {
       "properties": {
@@ -5503,7 +5503,7 @@
         },
         "address_parts": {
           "type": "object",
-          "dynamic": true,
+          "dynamic": "strict",
           "properties": {
             "name": {
               "type": "string",
@@ -5529,7 +5529,7 @@
         },
         "parent": {
           "type": "object",
-          "dynamic": true,
+          "dynamic": "strict",
           "properties": {
             "continent": {
               "type": "string",
@@ -5770,7 +5770,7 @@
       "_all": {
         "enabled": false
       },
-      "dynamic": "true"
+      "dynamic": "strict"
     }
   }
 }


### PR DESCRIPTION
Strict [dynamic mapping](https://www.elastic.co/guide/en/elasticsearch/guide/current/dynamic-mapping.html) tells Elasticsearch to throw an exception whenever an attempt to index a field not specified in the type mapping is made.

By setting dynamic mapping to true, we missed issues such as [continents being added to the model, but not schema](https://github.com/pelias/schema/pull/281). Using strict mapping should help us catch issues like this in the future.