### PR TITLE
Disable fielddata for name.* and phrase.* fields

### DIFF
--- a/mappings/document.js
+++ b/mappings/document.js
@@ -137,7 +137,7 @@ var schema = {
         type: 'string',
         analyzer: 'peliasIndexOneEdgeGram',
         fielddata : {
-          loading: 'eager_global_ordinals'
+          format: "disabled"
         }
       }
     },
@@ -149,7 +149,7 @@ var schema = {
         type: 'string',
         analyzer: 'peliasPhrase',
         fielddata : {
-          loading: 'eager_global_ordinals'
+          format: "disabled"
         }
       }
     }

--- a/test/compile.js
+++ b/test/compile.js
@@ -43,7 +43,7 @@ module.exports.tests.dynamic_templates = function(test, common) {
       type: 'string',
       analyzer: 'peliasIndexOneEdgeGram',
       fielddata: {
-        loading: 'eager_global_ordinals'
+        format: "disabled"
       }
     });
     t.end();

--- a/test/document.js
+++ b/test/document.js
@@ -154,7 +154,7 @@ module.exports.tests.dynamic_templates = function(test, common) {
       type: 'string',
       analyzer: 'peliasIndexOneEdgeGram',
       fielddata: {
-        loading: 'eager_global_ordinals'
+        format: "disabled"
       }
     });
     t.end();
@@ -168,7 +168,7 @@ module.exports.tests.dynamic_templates = function(test, common) {
       type: 'string',
       analyzer: 'peliasPhrase',
       fielddata: {
-        loading: 'eager_global_ordinals'
+        format: "disabled"
       }
     });
     t.end();

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -1730,7 +1730,7 @@
               "type": "string",
               "analyzer": "peliasIndexOneEdgeGram",
               "fielddata": {
-                "loading": "eager_global_ordinals"
+                "format": "disabled"
               }
             }
           }
@@ -1743,7 +1743,7 @@
               "type": "string",
               "analyzer": "peliasPhrase",
               "fielddata": {
-                "loading": "eager_global_ordinals"
+                "format": "disabled"
               }
             }
           }
@@ -2053,7 +2053,7 @@
               "type": "string",
               "analyzer": "peliasIndexOneEdgeGram",
               "fielddata": {
-                "loading": "eager_global_ordinals"
+                "format": "disabled"
               }
             }
           }
@@ -2066,7 +2066,7 @@
               "type": "string",
               "analyzer": "peliasPhrase",
               "fielddata": {
-                "loading": "eager_global_ordinals"
+                "format": "disabled"
               }
             }
           }
@@ -2376,7 +2376,7 @@
               "type": "string",
               "analyzer": "peliasIndexOneEdgeGram",
               "fielddata": {
-                "loading": "eager_global_ordinals"
+                "format": "disabled"
               }
             }
           }
@@ -2389,7 +2389,7 @@
               "type": "string",
               "analyzer": "peliasPhrase",
               "fielddata": {
-                "loading": "eager_global_ordinals"
+                "format": "disabled"
               }
             }
           }
@@ -2699,7 +2699,7 @@
               "type": "string",
               "analyzer": "peliasIndexOneEdgeGram",
               "fielddata": {
-                "loading": "eager_global_ordinals"
+                "format": "disabled"
               }
             }
           }
@@ -2712,7 +2712,7 @@
               "type": "string",
               "analyzer": "peliasPhrase",
               "fielddata": {
-                "loading": "eager_global_ordinals"
+                "format": "disabled"
               }
             }
           }
@@ -3022,7 +3022,7 @@
               "type": "string",
               "analyzer": "peliasIndexOneEdgeGram",
               "fielddata": {
-                "loading": "eager_global_ordinals"
+                "format": "disabled"
               }
             }
           }
@@ -3035,7 +3035,7 @@
               "type": "string",
               "analyzer": "peliasPhrase",
               "fielddata": {
-                "loading": "eager_global_ordinals"
+                "format": "disabled"
               }
             }
           }
@@ -3345,7 +3345,7 @@
               "type": "string",
               "analyzer": "peliasIndexOneEdgeGram",
               "fielddata": {
-                "loading": "eager_global_ordinals"
+                "format": "disabled"
               }
             }
           }
@@ -3358,7 +3358,7 @@
               "type": "string",
               "analyzer": "peliasPhrase",
               "fielddata": {
-                "loading": "eager_global_ordinals"
+                "format": "disabled"
               }
             }
           }
@@ -3668,7 +3668,7 @@
               "type": "string",
               "analyzer": "peliasIndexOneEdgeGram",
               "fielddata": {
-                "loading": "eager_global_ordinals"
+                "format": "disabled"
               }
             }
           }
@@ -3681,7 +3681,7 @@
               "type": "string",
               "analyzer": "peliasPhrase",
               "fielddata": {
-                "loading": "eager_global_ordinals"
+                "format": "disabled"
               }
             }
           }
@@ -3991,7 +3991,7 @@
               "type": "string",
               "analyzer": "peliasIndexOneEdgeGram",
               "fielddata": {
-                "loading": "eager_global_ordinals"
+                "format": "disabled"
               }
             }
           }
@@ -4004,7 +4004,7 @@
               "type": "string",
               "analyzer": "peliasPhrase",
               "fielddata": {
-                "loading": "eager_global_ordinals"
+                "format": "disabled"
               }
             }
           }
@@ -4314,7 +4314,7 @@
               "type": "string",
               "analyzer": "peliasIndexOneEdgeGram",
               "fielddata": {
-                "loading": "eager_global_ordinals"
+                "format": "disabled"
               }
             }
           }
@@ -4327,7 +4327,7 @@
               "type": "string",
               "analyzer": "peliasPhrase",
               "fielddata": {
-                "loading": "eager_global_ordinals"
+                "format": "disabled"
               }
             }
           }
@@ -4637,7 +4637,7 @@
               "type": "string",
               "analyzer": "peliasIndexOneEdgeGram",
               "fielddata": {
-                "loading": "eager_global_ordinals"
+                "format": "disabled"
               }
             }
           }
@@ -4650,7 +4650,7 @@
               "type": "string",
               "analyzer": "peliasPhrase",
               "fielddata": {
-                "loading": "eager_global_ordinals"
+                "format": "disabled"
               }
             }
           }
@@ -4960,7 +4960,7 @@
               "type": "string",
               "analyzer": "peliasIndexOneEdgeGram",
               "fielddata": {
-                "loading": "eager_global_ordinals"
+                "format": "disabled"
               }
             }
           }
@@ -4973,7 +4973,7 @@
               "type": "string",
               "analyzer": "peliasPhrase",
               "fielddata": {
-                "loading": "eager_global_ordinals"
+                "format": "disabled"
               }
             }
           }
@@ -5283,7 +5283,7 @@
               "type": "string",
               "analyzer": "peliasIndexOneEdgeGram",
               "fielddata": {
-                "loading": "eager_global_ordinals"
+                "format": "disabled"
               }
             }
           }
@@ -5296,7 +5296,7 @@
               "type": "string",
               "analyzer": "peliasPhrase",
               "fielddata": {
-                "loading": "eager_global_ordinals"
+                "format": "disabled"
               }
             }
           }
@@ -5606,7 +5606,7 @@
               "type": "string",
               "analyzer": "peliasIndexOneEdgeGram",
               "fielddata": {
-                "loading": "eager_global_ordinals"
+                "format": "disabled"
               }
             }
           }
@@ -5619,7 +5619,7 @@
               "type": "string",
               "analyzer": "peliasPhrase",
               "fielddata": {
-                "loading": "eager_global_ordinals"
+                "format": "disabled"
               }
             }
           }
@@ -5929,7 +5929,7 @@
               "type": "string",
               "analyzer": "peliasIndexOneEdgeGram",
               "fielddata": {
-                "loading": "eager_global_ordinals"
+                "format": "disabled"
               }
             }
           }
@@ -5942,7 +5942,7 @@
               "type": "string",
               "analyzer": "peliasPhrase",
               "fielddata": {
-                "loading": "eager_global_ordinals"
+                "format": "disabled"
               }
             }
           }
@@ -6252,7 +6252,7 @@
               "type": "string",
               "analyzer": "peliasIndexOneEdgeGram",
               "fielddata": {
-                "loading": "eager_global_ordinals"
+                "format": "disabled"
               }
             }
           }
@@ -6265,7 +6265,7 @@
               "type": "string",
               "analyzer": "peliasPhrase",
               "fielddata": {
-                "loading": "eager_global_ordinals"
+                "format": "disabled"
               }
             }
           }


### PR DESCRIPTION
Fieldata is only used for aggregations, sorting (by the string value of a field), and scripts. Pelias does not use any of those.

Currently, a full planet Pelias build has about 40GB of fielddata loaded into memory, but it's never used. So this is a significant savings potential.

We'll want to test this on larger builds to get a sense of the memory savings and any other possible side effects.

Fixes https://github.com/pelias/schema/issues/100