### PR TITLE
Use carat ranges for all Pelias Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "elasticsearch": "^15.0.0",
     "joi": "^13.1.0",
     "lodash.merge": "^4.6.0",
-    "pelias-config": "3.0.2"
+    "pelias-config": "^3.0.2"
   },
   "devDependencies": {
     "difflet": "^1.0.1",


### PR DESCRIPTION
The overhead of having to merge a Greenkeeper PR for every single change to
every single repository (which leads to cascading PRs) is too much.

Connects https://github.com/pelias/pelias/issues/366