### PR TITLE
Split on whitespace for peliasStreet tokenizer

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -33,7 +33,7 @@ function generate(){
         },
         "peliasStreetTokenizer": {
           "type": "pattern",
-          "pattern": "[,/\\\\]+"
+          "pattern": "[\\s,/\\\\]+"
         }
       },
       "analyzer": {

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -8,7 +8,7 @@
         },
         "peliasStreetTokenizer": {
           "type": "pattern",
-          "pattern": "[,/\\\\]+"
+          "pattern": "[\\s,/\\\\]+"
         }
       },
       "analyzer": {


### PR DESCRIPTION
This is just one small part of the changes originally in https://github.com/pelias/schema/pull/291

It should help especially with synonyms and paves the way for other improvements to the `peliasStreet` analyzer/tokenizer, while being small and easy to test.

@missinglink there were lots of tests with `match_phrase` added in #291, do you remember why? should we include them in this PR?

cc @adefarge