### PR TITLE
Re-enable Integration tests on TravisCI

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
     "tap-spec": "^5.0.0",
     "tape": "^4.5.0"
   },
-  "pre-commit": [
-  ],
+  "pre-commit": [],
   "release": {
     "branch": "production",
     "success": []

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "drop_index": "node scripts/drop_index",
     "reset_type": "node scripts/reset_type",
     "update_settings": "node scripts/update_settings",
-    "travis": "npm run test"
+    "travis": "npm run test && npm run integration"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I'm not sure why these were not running, considering we had all the support to set up Elasticsearch turned on. I couldn't even find a time in the file history where they _were_enabled.