### PR TITLE
feat(test): Use test running binary to catch errors

### DIFF
--- a/bin/integration
+++ b/bin/integration
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# run tests with pipefail to avoid false passes
+# see https://github.com/pelias/pelias/issues/744
+set -o pipefail
+
+node integration/run.js | npx tap-spec

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# run tests with pipefail to avoid false passes
+# see https://github.com/pelias/pelias/issues/744
+set -o pipefail
+
+node test/run.js | npx tap-spec

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "license": "MIT",
   "main": "schema.js",
   "scripts": {
-    "test": "node test/run.js | tap-spec",
-    "integration": "node integration/run.js | tap-spec",
+    "test": "./bin/test",
+    "integration": "./bin/integration",
     "create_index": "node scripts/create_index",
     "drop_index": "node scripts/drop_index",
     "reset_type": "node scripts/reset_type",


### PR DESCRIPTION
The way we were running our unit tests does not catch fatal errors in the unit test run, even though they return non-zero status codes.

By using a dedicated script to run the tests, with the `pipefail` option, we can catch them.

Connects https://github.com/pelias/pelias/issues/744