### PR TITLE
remove geo_point properties deprecated in 2.3 or 2.4

### DIFF
--- a/mappings/partial/centroid.js
+++ b/mappings/partial/centroid.js
@@ -1,14 +1,6 @@
 // @ref: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/mapping-geo-point-type.html
 var schema = {
-  'type': 'geo_point',
-
-  /* `lat_lon` enabled since both the geo distance and bounding box filters can either be executed using in memory checks, or using the indexed lat lon values */
-  'lat_lon': true,
-
-  /* store geohashes (with prefixes) in order to facilitate the geohash_cell filter */
-  'geohash': true,
-  'geohash_prefix': true,
-  'geohash_precision': 18
+  'type': 'geo_point'
 };
 
 module.exports = schema;

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -1690,11 +1690,7 @@
           }
         },
         "center_point": {
-          "type": "geo_point",
-          "lat_lon": true,
-          "geohash": true,
-          "geohash_prefix": true,
-          "geohash_precision": 18
+          "type": "geo_point"
         },
         "shape": {
           "type": "geo_shape",
@@ -2017,11 +2013,7 @@
           }
         },
         "center_point": {
-          "type": "geo_point",
-          "lat_lon": true,
-          "geohash": true,
-          "geohash_prefix": true,
-          "geohash_precision": 18
+          "type": "geo_point"
         },
         "shape": {
           "type": "geo_shape",
@@ -2344,11 +2336,7 @@
           }
         },
         "center_point": {
-          "type": "geo_point",
-          "lat_lon": true,
-          "geohash": true,
-          "geohash_prefix": true,
-          "geohash_precision": 18
+          "type": "geo_point"
         },
         "shape": {
           "type": "geo_shape",
@@ -2671,11 +2659,7 @@
           }
         },
         "center_point": {
-          "type": "geo_point",
-          "lat_lon": true,
-          "geohash": true,
-          "geohash_prefix": true,
-          "geohash_precision": 18
+          "type": "geo_point"
         },
         "shape": {
           "type": "geo_shape",
@@ -2998,11 +2982,7 @@
           }
         },
         "center_point": {
-          "type": "geo_point",
-          "lat_lon": true,
-          "geohash": true,
-          "geohash_prefix": true,
-          "geohash_precision": 18
+          "type": "geo_point"
         },
         "shape": {
           "type": "geo_shape",
@@ -3325,11 +3305,7 @@
           }
         },
         "center_point": {
-          "type": "geo_point",
-          "lat_lon": true,
-          "geohash": true,
-          "geohash_prefix": true,
-          "geohash_precision": 18
+          "type": "geo_point"
         },
         "shape": {
           "type": "geo_shape",
@@ -3652,11 +3628,7 @@
           }
         },
         "center_point": {
-          "type": "geo_point",
-          "lat_lon": true,
-          "geohash": true,
-          "geohash_prefix": true,
-          "geohash_precision": 18
+          "type": "geo_point"
         },
         "shape": {
           "type": "geo_shape",
@@ -3979,11 +3951,7 @@
           }
         },
         "center_point": {
-          "type": "geo_point",
-          "lat_lon": true,
-          "geohash": true,
-          "geohash_prefix": true,
-          "geohash_precision": 18
+          "type": "geo_point"
         },
         "shape": {
           "type": "geo_shape",
@@ -4306,11 +4274,7 @@
           }
         },
         "center_point": {
-          "type": "geo_point",
-          "lat_lon": true,
-          "geohash": true,
-          "geohash_prefix": true,
-          "geohash_precision": 18
+          "type": "geo_point"
         },
         "shape": {
           "type": "geo_shape",
@@ -4633,11 +4597,7 @@
           }
         },
         "center_point": {
-          "type": "geo_point",
-          "lat_lon": true,
-          "geohash": true,
-          "geohash_prefix": true,
-          "geohash_precision": 18
+          "type": "geo_point"
         },
         "shape": {
           "type": "geo_shape",
@@ -4960,11 +4920,7 @@
           }
         },
         "center_point": {
-          "type": "geo_point",
-          "lat_lon": true,
-          "geohash": true,
-          "geohash_prefix": true,
-          "geohash_precision": 18
+          "type": "geo_point"
         },
         "shape": {
           "type": "geo_shape",
@@ -5287,11 +5243,7 @@
           }
         },
         "center_point": {
-          "type": "geo_point",
-          "lat_lon": true,
-          "geohash": true,
-          "geohash_prefix": true,
-          "geohash_precision": 18
+          "type": "geo_point"
         },
         "shape": {
           "type": "geo_shape",
@@ -5614,11 +5566,7 @@
           }
         },
         "center_point": {
-          "type": "geo_point",
-          "lat_lon": true,
-          "geohash": true,
-          "geohash_prefix": true,
-          "geohash_precision": 18
+          "type": "geo_point"
         },
         "shape": {
           "type": "geo_shape",
@@ -5941,11 +5889,7 @@
           }
         },
         "center_point": {
-          "type": "geo_point",
-          "lat_lon": true,
-          "geohash": true,
-          "geohash_prefix": true,
-          "geohash_precision": 18
+          "type": "geo_point"
         },
         "shape": {
           "type": "geo_shape",
@@ -6268,11 +6212,7 @@
           }
         },
         "center_point": {
-          "type": "geo_point",
-          "lat_lon": true,
-          "geohash": true,
-          "geohash_prefix": true,
-          "geohash_precision": 18
+          "type": "geo_point"
         },
         "shape": {
           "type": "geo_shape",

--- a/test/partial-centroid.js
+++ b/test/partial-centroid.js
@@ -19,26 +19,6 @@ module.exports.tests.type = function(test, common) {
   });
 };
 
-// this should always be enabled for geo_distance filter
-// queries to execute correctly
-module.exports.tests.latlon = function(test, common) {
-  test('latlon enabled', function(t) {
-    t.equal(schema.lat_lon, true, 'correct value');
-    t.end();
-  });
-};
-
-// this should always be enabled for geohash_cell filter
-// queries to execute correctly
-module.exports.tests.geohash = function(test, common) {
-  test('geohash enabled', function(t) {
-    t.equal(schema.geohash, true, 'correct value');
-    t.equal(schema.geohash_prefix, true, 'correct value');
-    t.equal(schema.geohash_precision, 18, 'correct value');
-    t.end();
-  });
-};
-
 module.exports.all = function (tape, common) {
 
   function test(name, testFunction) {


### PR DESCRIPTION
remove geo_point properties deprecated in 2.3 or 2.4

- https://www.elastic.co/guide/en/elasticsearch/reference/2.4/geo-point.html#geo-point-params
- https://www.elastic.co/guide/en/elasticsearch/reference/2.4/release-notes-2.4.0.html