### PR TITLE
[experiment] Disable Elasticsearch field norms

### DIFF
--- a/integration/analyzer_peliasPhrase.js
+++ b/integration/analyzer_peliasPhrase.js
@@ -216,8 +216,8 @@ module.exports.tests.slop_query = function(test, common){
         var hits = res.hits.hits;
 
         t.equal( hits[0]._source.name.default, 'Lake Cayuga' );
-        t.equal( hits[1]._source.name.default, 'Cayuga Lake' );
-        t.equal( hits[2]._source.name.default, '7991 Lake Cayuga Dr' );
+        t.equal( hits[1]._source.name.default, '7991 Lake Cayuga Dr' );
+        t.equal( hits[2]._source.name.default, 'Cayuga Lake' );
 
         t.true( hits[0]._score >= hits[1]._score );
         t.true( hits[1]._score >= hits[2]._score );

--- a/mappings/document.js
+++ b/mappings/document.js
@@ -27,22 +27,27 @@ var schema = {
         name: {
           type: 'string',
           analyzer: 'keyword',
+          norms: { enabled: false }
         },
         unit: {
           type: 'string',
           analyzer: 'peliasUnit',
+          norms: { enabled: false }
         },
         number: {
           type: 'string',
           analyzer: 'peliasHousenumber',
+          norms: { enabled: false }
         },
         street: {
           type: 'string',
           analyzer: 'peliasStreet',
+          norms: { enabled: false }
         },
         zip: {
           type: 'string',
           analyzer: 'peliasZip',
+          norms: { enabled: false }
         }
       }
     },
@@ -137,6 +142,7 @@ var schema = {
       mapping: {
         type: 'string',
         analyzer: 'peliasIndexOneEdgeGram',
+        norms: { enabled: false },
         fielddata : {
           format: "disabled"
         }
@@ -149,6 +155,7 @@ var schema = {
       mapping: {
         type: 'string',
         analyzer: 'peliasPhrase',
+        norms: { enabled: false },
         fielddata : {
           format: "disabled"
         }

--- a/mappings/partial/admin.json
+++ b/mappings/partial/admin.json
@@ -1,5 +1,6 @@
 {
   "type": "string",
   "analyzer": "peliasAdmin",
-  "store": "yes"
+  "store": "yes",
+  "norms": { "enabled": false }
 }

--- a/mappings/partial/boundingbox.json
+++ b/mappings/partial/boundingbox.json
@@ -1,5 +1,6 @@
 {
   "type": "string",
   "index": "no",
-  "store": "yes"
+  "store": "yes",
+  "norms": { "enabled": false }
 }

--- a/mappings/partial/literal.json
+++ b/mappings/partial/literal.json
@@ -1,5 +1,6 @@
 {
   "type": "string",
   "analyzer": "keyword",
-  "store": "yes"
+  "store": "yes",
+  "norms": { "enabled": false }
 }

--- a/mappings/partial/postalcode.json
+++ b/mappings/partial/postalcode.json
@@ -1,5 +1,6 @@
 {
   "type": "string",
   "analyzer": "peliasZip",
-  "store": "yes"
+  "store": "yes",
+  "norms": { "enabled": false }
 }

--- a/test/compile.js
+++ b/test/compile.js
@@ -42,6 +42,7 @@ module.exports.tests.dynamic_templates = function(test, common) {
     t.deepEqual(template.mapping, {
       type: 'string',
       analyzer: 'peliasIndexOneEdgeGram',
+      norms: { enabled: false },
       fielddata : {
         format: "disabled"
       }

--- a/test/document.js
+++ b/test/document.js
@@ -153,6 +153,7 @@ module.exports.tests.dynamic_templates = function(test, common) {
     t.deepEqual(template.mapping, {
       type: 'string',
       analyzer: 'peliasIndexOneEdgeGram',
+      norms: { enabled: false },
       fielddata : {
         format: "disabled"
       }
@@ -167,6 +168,7 @@ module.exports.tests.dynamic_templates = function(test, common) {
     t.deepEqual(template.mapping, {
       type: 'string',
       analyzer: 'peliasPhrase',
+      norms: { enabled: false },
       fielddata : {
         format: "disabled"
       }

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -1442,17 +1442,20 @@
         "source": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "layer": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "alpha3": {
           "type": "string",
           "analyzer": "peliasAdmin",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "name": {
           "type": "object",
@@ -1468,23 +1471,28 @@
           "properties": {
             "name": {
               "type": "string",
-              "analyzer": "keyword"
+              "analyzer": "keyword",
+              "norms": { "enabled": false }
             },
             "unit": {
               "type": "string",
-              "analyzer": "peliasUnit"
+              "analyzer": "peliasUnit",
+              "norms": { "enabled": false }
             },
             "number": {
               "type": "string",
-              "analyzer": "peliasHousenumber"
+              "analyzer": "peliasHousenumber",
+              "norms": { "enabled": false }
             },
             "street": {
               "type": "string",
-              "analyzer": "peliasStreet"
+              "analyzer": "peliasStreet",
+              "norms": { "enabled": false }
             },
             "zip": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "norms": { "enabled": false }
             }
           }
         },
@@ -1495,197 +1503,236 @@
             "continent": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "continent_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "continent_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode": {
               "type": "string",
               "analyzer": "peliasZip",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode_a": {
               "type": "string",
               "analyzer": "peliasZip",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             }
           }
         },
@@ -1700,17 +1747,20 @@
         "bounding_box": {
           "type": "string",
           "index": "no",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "source_id": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "category": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "population": {
           "type": "long",
@@ -1729,6 +1779,7 @@
             "mapping": {
               "type": "string",
               "analyzer": "peliasIndexOneEdgeGram",
+              "norms": { "enabled": false },
               "fielddata": {
                 "format": "disabled"
               }
@@ -1742,6 +1793,7 @@
             "mapping": {
               "type": "string",
               "analyzer": "peliasPhrase",
+              "norms": { "enabled": false },
               "fielddata": {
                 "format": "disabled"
               }
@@ -1765,17 +1817,20 @@
         "source": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "layer": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "alpha3": {
           "type": "string",
           "analyzer": "peliasAdmin",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "name": {
           "type": "object",
@@ -1791,23 +1846,28 @@
           "properties": {
             "name": {
               "type": "string",
-              "analyzer": "keyword"
+              "analyzer": "keyword",
+              "norms": { "enabled": false }
             },
             "unit": {
               "type": "string",
-              "analyzer": "peliasUnit"
+              "analyzer": "peliasUnit",
+              "norms": { "enabled": false }
             },
             "number": {
               "type": "string",
-              "analyzer": "peliasHousenumber"
+              "analyzer": "peliasHousenumber",
+              "norms": { "enabled": false }
             },
             "street": {
               "type": "string",
-              "analyzer": "peliasStreet"
+              "analyzer": "peliasStreet",
+              "norms": { "enabled": false }
             },
             "zip": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "norms": { "enabled": false }
             }
           }
         },
@@ -1818,197 +1878,236 @@
             "continent": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "continent_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "continent_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode": {
               "type": "string",
               "analyzer": "peliasZip",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode_a": {
               "type": "string",
               "analyzer": "peliasZip",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             }
           }
         },
@@ -2023,17 +2122,20 @@
         "bounding_box": {
           "type": "string",
           "index": "no",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "source_id": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "category": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "population": {
           "type": "long",
@@ -2052,6 +2154,7 @@
             "mapping": {
               "type": "string",
               "analyzer": "peliasIndexOneEdgeGram",
+              "norms": { "enabled": false },
               "fielddata": {
                 "format": "disabled"
               }
@@ -2065,6 +2168,7 @@
             "mapping": {
               "type": "string",
               "analyzer": "peliasPhrase",
+              "norms": { "enabled": false },
               "fielddata": {
                 "format": "disabled"
               }
@@ -2088,17 +2192,20 @@
         "source": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "layer": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "alpha3": {
           "type": "string",
           "analyzer": "peliasAdmin",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "name": {
           "type": "object",
@@ -2114,23 +2221,28 @@
           "properties": {
             "name": {
               "type": "string",
-              "analyzer": "keyword"
+              "analyzer": "keyword",
+              "norms": { "enabled": false }
             },
             "unit": {
               "type": "string",
-              "analyzer": "peliasUnit"
+              "analyzer": "peliasUnit",
+              "norms": { "enabled": false }
             },
             "number": {
               "type": "string",
-              "analyzer": "peliasHousenumber"
+              "analyzer": "peliasHousenumber",
+              "norms": { "enabled": false }
             },
             "street": {
               "type": "string",
-              "analyzer": "peliasStreet"
+              "analyzer": "peliasStreet",
+              "norms": { "enabled": false }
             },
             "zip": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "norms": { "enabled": false }
             }
           }
         },
@@ -2141,197 +2253,236 @@
             "continent": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "continent_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "continent_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode": {
               "type": "string",
               "analyzer": "peliasZip",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode_a": {
               "type": "string",
               "analyzer": "peliasZip",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             }
           }
         },
@@ -2346,17 +2497,20 @@
         "bounding_box": {
           "type": "string",
           "index": "no",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "source_id": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "category": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "population": {
           "type": "long",
@@ -2375,6 +2529,7 @@
             "mapping": {
               "type": "string",
               "analyzer": "peliasIndexOneEdgeGram",
+              "norms": { "enabled": false },
               "fielddata": {
                 "format": "disabled"
               }
@@ -2388,6 +2543,7 @@
             "mapping": {
               "type": "string",
               "analyzer": "peliasPhrase",
+              "norms": { "enabled": false },
               "fielddata": {
                 "format": "disabled"
               }
@@ -2411,17 +2567,20 @@
         "source": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "layer": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "alpha3": {
           "type": "string",
           "analyzer": "peliasAdmin",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "name": {
           "type": "object",
@@ -2437,23 +2596,28 @@
           "properties": {
             "name": {
               "type": "string",
-              "analyzer": "keyword"
+              "analyzer": "keyword",
+              "norms": { "enabled": false }
             },
             "unit": {
               "type": "string",
-              "analyzer": "peliasUnit"
+              "analyzer": "peliasUnit",
+              "norms": { "enabled": false }
             },
             "number": {
               "type": "string",
-              "analyzer": "peliasHousenumber"
+              "analyzer": "peliasHousenumber",
+              "norms": { "enabled": false }
             },
             "street": {
               "type": "string",
-              "analyzer": "peliasStreet"
+              "analyzer": "peliasStreet",
+              "norms": { "enabled": false }
             },
             "zip": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "norms": { "enabled": false }
             }
           }
         },
@@ -2464,197 +2628,236 @@
             "continent": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "continent_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "continent_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode": {
               "type": "string",
               "analyzer": "peliasZip",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode_a": {
               "type": "string",
               "analyzer": "peliasZip",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             }
           }
         },
@@ -2669,17 +2872,20 @@
         "bounding_box": {
           "type": "string",
           "index": "no",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "source_id": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "category": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "population": {
           "type": "long",
@@ -2698,6 +2904,7 @@
             "mapping": {
               "type": "string",
               "analyzer": "peliasIndexOneEdgeGram",
+              "norms": { "enabled": false },
               "fielddata": {
                 "format": "disabled"
               }
@@ -2711,6 +2918,7 @@
             "mapping": {
               "type": "string",
               "analyzer": "peliasPhrase",
+              "norms": { "enabled": false },
               "fielddata": {
                 "format": "disabled"
               }
@@ -2734,17 +2942,20 @@
         "source": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "layer": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "alpha3": {
           "type": "string",
           "analyzer": "peliasAdmin",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "name": {
           "type": "object",
@@ -2760,23 +2971,28 @@
           "properties": {
             "name": {
               "type": "string",
-              "analyzer": "keyword"
+              "analyzer": "keyword",
+              "norms": { "enabled": false }
             },
             "unit": {
               "type": "string",
-              "analyzer": "peliasUnit"
+              "analyzer": "peliasUnit",
+              "norms": { "enabled": false }
             },
             "number": {
               "type": "string",
-              "analyzer": "peliasHousenumber"
+              "analyzer": "peliasHousenumber",
+              "norms": { "enabled": false }
             },
             "street": {
               "type": "string",
-              "analyzer": "peliasStreet"
+              "analyzer": "peliasStreet",
+              "norms": { "enabled": false }
             },
             "zip": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "norms": { "enabled": false }
             }
           }
         },
@@ -2787,197 +3003,236 @@
             "continent": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "continent_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "continent_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode": {
               "type": "string",
               "analyzer": "peliasZip",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode_a": {
               "type": "string",
               "analyzer": "peliasZip",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             }
           }
         },
@@ -2992,17 +3247,20 @@
         "bounding_box": {
           "type": "string",
           "index": "no",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "source_id": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "category": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "population": {
           "type": "long",
@@ -3021,6 +3279,7 @@
             "mapping": {
               "type": "string",
               "analyzer": "peliasIndexOneEdgeGram",
+              "norms": { "enabled": false },
               "fielddata": {
                 "format": "disabled"
               }
@@ -3034,6 +3293,7 @@
             "mapping": {
               "type": "string",
               "analyzer": "peliasPhrase",
+              "norms": { "enabled": false },
               "fielddata": {
                 "format": "disabled"
               }
@@ -3057,17 +3317,20 @@
         "source": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "layer": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "alpha3": {
           "type": "string",
           "analyzer": "peliasAdmin",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "name": {
           "type": "object",
@@ -3083,23 +3346,28 @@
           "properties": {
             "name": {
               "type": "string",
-              "analyzer": "keyword"
+              "analyzer": "keyword",
+              "norms": { "enabled": false }
             },
             "unit": {
               "type": "string",
-              "analyzer": "peliasUnit"
+              "analyzer": "peliasUnit",
+              "norms": { "enabled": false }
             },
             "number": {
               "type": "string",
-              "analyzer": "peliasHousenumber"
+              "analyzer": "peliasHousenumber",
+              "norms": { "enabled": false }
             },
             "street": {
               "type": "string",
-              "analyzer": "peliasStreet"
+              "analyzer": "peliasStreet",
+              "norms": { "enabled": false }
             },
             "zip": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "norms": { "enabled": false }
             }
           }
         },
@@ -3110,197 +3378,236 @@
             "continent": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "continent_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "continent_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode": {
               "type": "string",
               "analyzer": "peliasZip",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode_a": {
               "type": "string",
               "analyzer": "peliasZip",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             }
           }
         },
@@ -3315,17 +3622,20 @@
         "bounding_box": {
           "type": "string",
           "index": "no",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "source_id": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "category": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "population": {
           "type": "long",
@@ -3344,6 +3654,7 @@
             "mapping": {
               "type": "string",
               "analyzer": "peliasIndexOneEdgeGram",
+              "norms": { "enabled": false },
               "fielddata": {
                 "format": "disabled"
               }
@@ -3357,6 +3668,7 @@
             "mapping": {
               "type": "string",
               "analyzer": "peliasPhrase",
+              "norms": { "enabled": false },
               "fielddata": {
                 "format": "disabled"
               }
@@ -3380,17 +3692,20 @@
         "source": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "layer": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "alpha3": {
           "type": "string",
           "analyzer": "peliasAdmin",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "name": {
           "type": "object",
@@ -3406,23 +3721,28 @@
           "properties": {
             "name": {
               "type": "string",
-              "analyzer": "keyword"
+              "analyzer": "keyword",
+              "norms": { "enabled": false }
             },
             "unit": {
               "type": "string",
-              "analyzer": "peliasUnit"
+              "analyzer": "peliasUnit",
+              "norms": { "enabled": false }
             },
             "number": {
               "type": "string",
-              "analyzer": "peliasHousenumber"
+              "analyzer": "peliasHousenumber",
+              "norms": { "enabled": false }
             },
             "street": {
               "type": "string",
-              "analyzer": "peliasStreet"
+              "analyzer": "peliasStreet",
+              "norms": { "enabled": false }
             },
             "zip": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "norms": { "enabled": false }
             }
           }
         },
@@ -3433,197 +3753,236 @@
             "continent": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "continent_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "continent_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode": {
               "type": "string",
               "analyzer": "peliasZip",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode_a": {
               "type": "string",
               "analyzer": "peliasZip",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             }
           }
         },
@@ -3638,17 +3997,20 @@
         "bounding_box": {
           "type": "string",
           "index": "no",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "source_id": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "category": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "population": {
           "type": "long",
@@ -3667,6 +4029,7 @@
             "mapping": {
               "type": "string",
               "analyzer": "peliasIndexOneEdgeGram",
+              "norms": { "enabled": false },
               "fielddata": {
                 "format": "disabled"
               }
@@ -3680,6 +4043,7 @@
             "mapping": {
               "type": "string",
               "analyzer": "peliasPhrase",
+              "norms": { "enabled": false },
               "fielddata": {
                 "format": "disabled"
               }
@@ -3703,17 +4067,20 @@
         "source": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "layer": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "alpha3": {
           "type": "string",
           "analyzer": "peliasAdmin",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "name": {
           "type": "object",
@@ -3729,23 +4096,28 @@
           "properties": {
             "name": {
               "type": "string",
-              "analyzer": "keyword"
+              "analyzer": "keyword",
+              "norms": { "enabled": false }
             },
             "unit": {
               "type": "string",
-              "analyzer": "peliasUnit"
+              "analyzer": "peliasUnit",
+              "norms": { "enabled": false }
             },
             "number": {
               "type": "string",
-              "analyzer": "peliasHousenumber"
+              "analyzer": "peliasHousenumber",
+              "norms": { "enabled": false }
             },
             "street": {
               "type": "string",
-              "analyzer": "peliasStreet"
+              "analyzer": "peliasStreet",
+              "norms": { "enabled": false }
             },
             "zip": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "norms": { "enabled": false }
             }
           }
         },
@@ -3756,197 +4128,236 @@
             "continent": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "continent_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "continent_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode": {
               "type": "string",
               "analyzer": "peliasZip",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode_a": {
               "type": "string",
               "analyzer": "peliasZip",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             }
           }
         },
@@ -3961,17 +4372,20 @@
         "bounding_box": {
           "type": "string",
           "index": "no",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "source_id": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "category": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "population": {
           "type": "long",
@@ -3990,6 +4404,7 @@
             "mapping": {
               "type": "string",
               "analyzer": "peliasIndexOneEdgeGram",
+              "norms": { "enabled": false },
               "fielddata": {
                 "format": "disabled"
               }
@@ -4003,6 +4418,7 @@
             "mapping": {
               "type": "string",
               "analyzer": "peliasPhrase",
+              "norms": { "enabled": false },
               "fielddata": {
                 "format": "disabled"
               }
@@ -4026,17 +4442,20 @@
         "source": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "layer": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "alpha3": {
           "type": "string",
           "analyzer": "peliasAdmin",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "name": {
           "type": "object",
@@ -4052,23 +4471,28 @@
           "properties": {
             "name": {
               "type": "string",
-              "analyzer": "keyword"
+              "analyzer": "keyword",
+              "norms": { "enabled": false }
             },
             "unit": {
               "type": "string",
-              "analyzer": "peliasUnit"
+              "analyzer": "peliasUnit",
+              "norms": { "enabled": false }
             },
             "number": {
               "type": "string",
-              "analyzer": "peliasHousenumber"
+              "analyzer": "peliasHousenumber",
+              "norms": { "enabled": false }
             },
             "street": {
               "type": "string",
-              "analyzer": "peliasStreet"
+              "analyzer": "peliasStreet",
+              "norms": { "enabled": false }
             },
             "zip": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "norms": { "enabled": false }
             }
           }
         },
@@ -4079,197 +4503,236 @@
             "continent": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "continent_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "continent_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode": {
               "type": "string",
               "analyzer": "peliasZip",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode_a": {
               "type": "string",
               "analyzer": "peliasZip",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             }
           }
         },
@@ -4284,17 +4747,20 @@
         "bounding_box": {
           "type": "string",
           "index": "no",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "source_id": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "category": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "population": {
           "type": "long",
@@ -4313,6 +4779,7 @@
             "mapping": {
               "type": "string",
               "analyzer": "peliasIndexOneEdgeGram",
+              "norms": { "enabled": false },
               "fielddata": {
                 "format": "disabled"
               }
@@ -4326,6 +4793,7 @@
             "mapping": {
               "type": "string",
               "analyzer": "peliasPhrase",
+              "norms": { "enabled": false },
               "fielddata": {
                 "format": "disabled"
               }
@@ -4349,17 +4817,20 @@
         "source": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "layer": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "alpha3": {
           "type": "string",
           "analyzer": "peliasAdmin",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "name": {
           "type": "object",
@@ -4375,23 +4846,28 @@
           "properties": {
             "name": {
               "type": "string",
-              "analyzer": "keyword"
+              "analyzer": "keyword",
+              "norms": { "enabled": false }
             },
             "unit": {
               "type": "string",
-              "analyzer": "peliasUnit"
+              "analyzer": "peliasUnit",
+              "norms": { "enabled": false }
             },
             "number": {
               "type": "string",
-              "analyzer": "peliasHousenumber"
+              "analyzer": "peliasHousenumber",
+              "norms": { "enabled": false }
             },
             "street": {
               "type": "string",
-              "analyzer": "peliasStreet"
+              "analyzer": "peliasStreet",
+              "norms": { "enabled": false }
             },
             "zip": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "norms": { "enabled": false }
             }
           }
         },
@@ -4402,197 +4878,236 @@
             "continent": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "continent_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "continent_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode": {
               "type": "string",
               "analyzer": "peliasZip",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode_a": {
               "type": "string",
               "analyzer": "peliasZip",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             }
           }
         },
@@ -4607,17 +5122,20 @@
         "bounding_box": {
           "type": "string",
           "index": "no",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "source_id": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "category": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "population": {
           "type": "long",
@@ -4636,6 +5154,7 @@
             "mapping": {
               "type": "string",
               "analyzer": "peliasIndexOneEdgeGram",
+              "norms": { "enabled": false },
               "fielddata": {
                 "format": "disabled"
               }
@@ -4649,6 +5168,7 @@
             "mapping": {
               "type": "string",
               "analyzer": "peliasPhrase",
+              "norms": { "enabled": false },
               "fielddata": {
                 "format": "disabled"
               }
@@ -4672,17 +5192,20 @@
         "source": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "layer": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "alpha3": {
           "type": "string",
           "analyzer": "peliasAdmin",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "name": {
           "type": "object",
@@ -4698,23 +5221,28 @@
           "properties": {
             "name": {
               "type": "string",
-              "analyzer": "keyword"
+              "analyzer": "keyword",
+              "norms": { "enabled": false }
             },
             "unit": {
               "type": "string",
-              "analyzer": "peliasUnit"
+              "analyzer": "peliasUnit",
+              "norms": { "enabled": false }
             },
             "number": {
               "type": "string",
-              "analyzer": "peliasHousenumber"
+              "analyzer": "peliasHousenumber",
+              "norms": { "enabled": false }
             },
             "street": {
               "type": "string",
-              "analyzer": "peliasStreet"
+              "analyzer": "peliasStreet",
+              "norms": { "enabled": false }
             },
             "zip": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "norms": { "enabled": false }
             }
           }
         },
@@ -4725,197 +5253,236 @@
             "continent": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "continent_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "continent_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode": {
               "type": "string",
               "analyzer": "peliasZip",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode_a": {
               "type": "string",
               "analyzer": "peliasZip",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             }
           }
         },
@@ -4930,17 +5497,20 @@
         "bounding_box": {
           "type": "string",
           "index": "no",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "source_id": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "category": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "population": {
           "type": "long",
@@ -4959,6 +5529,7 @@
             "mapping": {
               "type": "string",
               "analyzer": "peliasIndexOneEdgeGram",
+              "norms": { "enabled": false },
               "fielddata": {
                 "format": "disabled"
               }
@@ -4972,6 +5543,7 @@
             "mapping": {
               "type": "string",
               "analyzer": "peliasPhrase",
+              "norms": { "enabled": false },
               "fielddata": {
                 "format": "disabled"
               }
@@ -4995,17 +5567,20 @@
         "source": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "layer": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "alpha3": {
           "type": "string",
           "analyzer": "peliasAdmin",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "name": {
           "type": "object",
@@ -5021,23 +5596,28 @@
           "properties": {
             "name": {
               "type": "string",
-              "analyzer": "keyword"
+              "analyzer": "keyword",
+              "norms": { "enabled": false }
             },
             "unit": {
               "type": "string",
-              "analyzer": "peliasUnit"
+              "analyzer": "peliasUnit",
+              "norms": { "enabled": false }
             },
             "number": {
               "type": "string",
-              "analyzer": "peliasHousenumber"
+              "analyzer": "peliasHousenumber",
+              "norms": { "enabled": false }
             },
             "street": {
               "type": "string",
-              "analyzer": "peliasStreet"
+              "analyzer": "peliasStreet",
+              "norms": { "enabled": false }
             },
             "zip": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "norms": { "enabled": false }
             }
           }
         },
@@ -5048,197 +5628,236 @@
             "continent": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "continent_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "continent_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode": {
               "type": "string",
               "analyzer": "peliasZip",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode_a": {
               "type": "string",
               "analyzer": "peliasZip",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             }
           }
         },
@@ -5253,17 +5872,20 @@
         "bounding_box": {
           "type": "string",
           "index": "no",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "source_id": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "category": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "population": {
           "type": "long",
@@ -5282,6 +5904,7 @@
             "mapping": {
               "type": "string",
               "analyzer": "peliasIndexOneEdgeGram",
+              "norms": { "enabled": false },
               "fielddata": {
                 "format": "disabled"
               }
@@ -5295,6 +5918,7 @@
             "mapping": {
               "type": "string",
               "analyzer": "peliasPhrase",
+              "norms": { "enabled": false },
               "fielddata": {
                 "format": "disabled"
               }
@@ -5318,17 +5942,20 @@
         "source": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "layer": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "alpha3": {
           "type": "string",
           "analyzer": "peliasAdmin",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "name": {
           "type": "object",
@@ -5344,23 +5971,28 @@
           "properties": {
             "name": {
               "type": "string",
-              "analyzer": "keyword"
+              "analyzer": "keyword",
+              "norms": { "enabled": false }
             },
             "unit": {
               "type": "string",
-              "analyzer": "peliasUnit"
+              "analyzer": "peliasUnit",
+              "norms": { "enabled": false }
             },
             "number": {
               "type": "string",
-              "analyzer": "peliasHousenumber"
+              "analyzer": "peliasHousenumber",
+              "norms": { "enabled": false }
             },
             "street": {
               "type": "string",
-              "analyzer": "peliasStreet"
+              "analyzer": "peliasStreet",
+              "norms": { "enabled": false }
             },
             "zip": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "norms": { "enabled": false }
             }
           }
         },
@@ -5371,197 +6003,236 @@
             "continent": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "continent_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "continent_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode": {
               "type": "string",
               "analyzer": "peliasZip",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode_a": {
               "type": "string",
               "analyzer": "peliasZip",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             }
           }
         },
@@ -5576,17 +6247,20 @@
         "bounding_box": {
           "type": "string",
           "index": "no",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "source_id": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "category": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "population": {
           "type": "long",
@@ -5605,6 +6279,7 @@
             "mapping": {
               "type": "string",
               "analyzer": "peliasIndexOneEdgeGram",
+              "norms": { "enabled": false },
               "fielddata": {
                 "format": "disabled"
               }
@@ -5618,6 +6293,7 @@
             "mapping": {
               "type": "string",
               "analyzer": "peliasPhrase",
+              "norms": { "enabled": false },
               "fielddata": {
                 "format": "disabled"
               }
@@ -5641,17 +6317,20 @@
         "source": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "layer": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "alpha3": {
           "type": "string",
           "analyzer": "peliasAdmin",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "name": {
           "type": "object",
@@ -5667,23 +6346,28 @@
           "properties": {
             "name": {
               "type": "string",
-              "analyzer": "keyword"
+              "analyzer": "keyword",
+              "norms": { "enabled": false }
             },
             "unit": {
               "type": "string",
-              "analyzer": "peliasUnit"
+              "analyzer": "peliasUnit",
+              "norms": { "enabled": false }
             },
             "number": {
               "type": "string",
-              "analyzer": "peliasHousenumber"
+              "analyzer": "peliasHousenumber",
+              "norms": { "enabled": false }
             },
             "street": {
               "type": "string",
-              "analyzer": "peliasStreet"
+              "analyzer": "peliasStreet",
+              "norms": { "enabled": false }
             },
             "zip": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "norms": { "enabled": false }
             }
           }
         },
@@ -5694,197 +6378,236 @@
             "continent": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "continent_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "continent_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode": {
               "type": "string",
               "analyzer": "peliasZip",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode_a": {
               "type": "string",
               "analyzer": "peliasZip",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             }
           }
         },
@@ -5899,17 +6622,20 @@
         "bounding_box": {
           "type": "string",
           "index": "no",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "source_id": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "category": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "population": {
           "type": "long",
@@ -5928,6 +6654,7 @@
             "mapping": {
               "type": "string",
               "analyzer": "peliasIndexOneEdgeGram",
+              "norms": { "enabled": false },
               "fielddata": {
                 "format": "disabled"
               }
@@ -5941,6 +6668,7 @@
             "mapping": {
               "type": "string",
               "analyzer": "peliasPhrase",
+              "norms": { "enabled": false },
               "fielddata": {
                 "format": "disabled"
               }
@@ -5964,17 +6692,20 @@
         "source": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "layer": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "alpha3": {
           "type": "string",
           "analyzer": "peliasAdmin",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "name": {
           "type": "object",
@@ -5990,23 +6721,28 @@
           "properties": {
             "name": {
               "type": "string",
-              "analyzer": "keyword"
+              "analyzer": "keyword",
+              "norms": { "enabled": false }
             },
             "unit": {
               "type": "string",
-              "analyzer": "peliasUnit"
+              "analyzer": "peliasUnit",
+              "norms": { "enabled": false }
             },
             "number": {
               "type": "string",
-              "analyzer": "peliasHousenumber"
+              "analyzer": "peliasHousenumber",
+              "norms": { "enabled": false }
             },
             "street": {
               "type": "string",
-              "analyzer": "peliasStreet"
+              "analyzer": "peliasStreet",
+              "norms": { "enabled": false }
             },
             "zip": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "norms": { "enabled": false }
             }
           }
         },
@@ -6017,197 +6753,236 @@
             "continent": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "continent_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "continent_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "empire_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "country_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "dependency_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macroregion_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "region_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "macrocounty_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "county_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "locality_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "borough_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "localadmin_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood_a": {
               "type": "string",
               "analyzer": "peliasAdmin",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "neighbourhood_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode": {
               "type": "string",
               "analyzer": "peliasZip",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode_a": {
               "type": "string",
               "analyzer": "peliasZip",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             },
             "postalcode_id": {
               "type": "string",
               "analyzer": "keyword",
-              "store": "yes"
+              "store": "yes",
+              "norms": { "enabled": false }
             }
           }
         },
@@ -6222,17 +6997,20 @@
         "bounding_box": {
           "type": "string",
           "index": "no",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "source_id": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "category": {
           "type": "string",
           "analyzer": "keyword",
-          "store": "yes"
+          "store": "yes",
+          "norms": { "enabled": false }
         },
         "population": {
           "type": "long",
@@ -6251,6 +7029,7 @@
             "mapping": {
               "type": "string",
               "analyzer": "peliasIndexOneEdgeGram",
+              "norms": { "enabled": false },
               "fielddata": {
                 "format": "disabled"
               }
@@ -6264,6 +7043,7 @@
             "mapping": {
               "type": "string",
               "analyzer": "peliasPhrase",
+              "norms": { "enabled": false },
               "fielddata": {
                 "format": "disabled"
               }


### PR DESCRIPTION
This is the PR to add schema support for **elasticsearch 5.6.12** while still maintaining backwards compatibility with 2.4.

This feature has been long requested, so I'm happy to have a PR ready for testing :smiley: 

#### About the upgrade

Elasticsearch 5.x is mostly backwards compatible with 2.x, so not many changes are required at this stage, we will make more significant changes in the migration from 5->6, but this PR is the start of a bunch of work to modernize the elasticsearch version supported by Pelias.

One of the *major* changes between the two versions is the 'Similarity', in 2.4 this was something called 'default' (now called 'classic'). In version 5 this was replaced by BM25 as the default similarity scoring engine.

As a result of the similarity algorthm changes, queries will score differently, the actual floating point numbers allocated by elasticsearch are different when compared to 2.4.

Pelias is only concerned with relative scoring between documents, however in some cases there are minor difference in relative scoring.

These scoring differences are fairly rare, I have disabled 'norms' in this PR which helps in mitigating this issue.

Please be aware that there will inevitably be changes to sorting order in a small amount of queries, for the most part these will be improvements, if there are regressions please open an issue to discuss.

The other major change was in query composition, for instance the error message `no [query] registered for [filtered]` is thrown for queries which begin `{ "query": { "filtered"`.

We started rewriting these queries in Pelias some time ago, when I ran automated tests and manual checks I was not able to trigger any query errors, I suspect that we have already completed the query migration, again we would be happy to hear if we've missed any :smiley: 

#### Upgrade period & deprecation notice

I wanted to do this in a way that is also backwards compatible with ES@2.4, so that users don't have a 'hard cutover', giving them some time to allocate resources to get their infrastructure moved over to `5.6.12`.

The plan is to maintain support for both 2.4 & 5.6 for only as long is required to confirm that the transition was successful, at which stage we deprecate support for 2.4.

We'll try to support both where we can, but sometime in 2019 we will completely drop support for 2.4 so that we can move forward and start taking advantage of new features only available in versions 5 & 6.

#### How to enable support for 5.6?

You'll need to run the code in this PR and ensure you have a current version of `npm elasticsearch` installed. (ie. run `npm install`)

Then you will need to change the `esclient.apiVersion` in your `pelias.json` file.

```bash
head -n3 ~/pelias.json 
{
  "esclient": {
    "apiVersion": "2.4",
```

```bash
head -n3 ~/pelias.json 
{
  "esclient": {
    "apiVersion": "5.6",
```

A quick note on versions:
- If you set your `apiVersion` to `5.6` then it will work fine against either version of elasticsearch.
- If you set your `apiVersion` to `2.4` then it will only work against `2.4`, an error will be thrown when trying to use a `5.6` server with a `2.4` client.
- I will soon update the default version in `pelias/config` to be `5.6`

#### Which docker images should I use?

For elasticsearch 5.6 you can use `pelias/elasticsearch:5.6.12`:

```bash
docker run --rm -p 9200:9200 pelias/elasticsearch:5.6.12
```

For elasticsearch 2.4 you can use `pelias/elasticsearch:2.4`:

```bash
docker run --rm -p 9200:9200 pelias/elasticsearch:2.4
```

Note that a PR will be coming soon for [pelias/docker](https://github.com/pelias/docker) which updates the existing 'projects'.

#### What's in the PR?

- Updates to `npm elastictest` to support `5.6`
- Update `npm elasticsearch` to support new APIs
- Updated Travis config to run integration tests against `5.6.12` (updated readme on how to run this locally)
- Pass esclient version to `elastictest` so that the correct APIs are used for integration tests
- Rewite any integration test queries which used the old query syntax

#### Schema Changes

##### geo_point

The geo_point properties were removed in https://github.com/pelias/schema/pull/321

##### norms

[norms](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/norms.html) have been disabled for all relevant fields using the syntax: `norms: { enabled: false }`

norms are useful for a traditional fulltext search engine where 'smaller' fields like a title are considered more important than 'larger' fields such as the text body.

this is not relevant to geocoding so I have disabled norms, this is required in this PR because without it the BM25 algorithm takes norms in to account and scores integration test queries in a way which isn't compatible between versions.

the other benefit of disabling norms is reducing the amount of disk storage (see the documentation linked above for more info).