### PR TITLE
Catch index already exists exception

### DIFF
--- a/scripts/create_index.js
+++ b/scripts/create_index.js
@@ -18,8 +18,13 @@ var indexName = config.schema.indexName;
 
 client.indices.create( { index: indexName, body: schema }, function( err, res ){
   if( err ){
-    console.error( err.message || err, '\n' );
-    process.exit(1);
+    if( err.message.indexOf('index_already_exists_exception') > -1){
+      console.log( '[put mapping]: Index Already Exists', '\t', indexName, '\n' );
+      process.exit(0);
+    } else {
+      console.error( err.message || err, '\n' );
+      process.exit(1);
+    }
   }
   console.log( '[put mapping]', '\t', indexName, res, '\n' );
   process.exit( !!err );


### PR DESCRIPTION
In our deployment, the schema container fails on the create_index job if the schema already exists in elasticsearch.  This patch resolves that issue and breaks the cycle of k8s constantly attempting to restart the job.