### PR TITLE
CI and Node.js Update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,4 +9,4 @@ jobs:
       - setup_remote_docker
       - run:
           name: Build and push image to Docker Hub
-          command: apk --no-cache add curl && curl "https://raw.githubusercontent.com/pelias/ci-tools/master/build-docker-images.sh" | sh -
+          command: apk --no-cache add curl bash && curl "https://raw.githubusercontent.com/pelias/ci-tools/master/build-docker-images.sh" | bash -

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 notifications:
   email: false
 node_js:
-  - 6
   - 8
   - 10
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,4 +37,4 @@ jobs:
     - stage: release
       node_js: 10
       script: curl "https://raw.githubusercontent.com/pelias/ci-tools/master/semantic-release.sh" | bash -
-      if: branch = production
+      if: branch = master

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,4 +37,4 @@ jobs:
     - stage: release
       node_js: 10
       script: curl "https://raw.githubusercontent.com/pelias/ci-tools/master/semantic-release.sh" | bash -
-      if: branch = master
+      if: (branch = master) AND ( type = push )

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/pelias/schema/issues"
   },
   "engines": {
-    "node": ">=6.0.0",
+    "node": ">=8.0.0",
     "npm": ">=1.4.3",
     "elasticsearch": ">=1.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "pre-commit": [],
   "release": {
-    "branch": "production",
+    "branch": "master",
     "success": []
   }
 }


### PR DESCRIPTION
Several changes regarding CI and Node.js versions:
- CI Docker script now requires bash
- Support for Node.js 6 has been dropped (https://github.com/pelias/pelias/issues/752)
- Semantic-release was running (doing nothing but taking up build time) on all pull requests for no reason
- Releases are now run directly off the master branch (https://github.com/pelias/pelias/issues/749)