### PR TITLE
feat(mapping): Remove unused `alpha3` field

### DIFF
--- a/integration/admin_matching.js
+++ b/integration/admin_matching.js
@@ -18,7 +18,6 @@ module.exports.tests.functional = function(test, common){
       suite.client.index({
         index: suite.props.index, type: 'test',
         id: '1', body: { admin: {
-          alpha3: 'TST',
           country: 'Test Country',
           country_a: 'TestCountry',
           country_id: '100',
@@ -39,19 +38,6 @@ module.exports.tests.functional = function(test, common){
           neighbourhood_id: '600',
         }}
       }, done );
-    });
-
-    // search by alpha3
-    suite.assert( function( done ){
-      suite.client.search({
-        index: suite.props.index,
-        type: 'test',
-        body: { query: { match: { 'admin.alpha3': 'TST' } } }
-      }, function( err, res ){
-        t.equal( err, undefined );
-        t.equal( res.hits.total, 1, 'document found' );
-        done();
-      });
     });
 
     // search by country

--- a/mappings/document.js
+++ b/mappings/document.js
@@ -12,7 +12,6 @@ var schema = {
     // data partitioning
     source: literal_with_doc_values,
     layer: literal_with_doc_values,
-    alpha3: admin,
 
     // place name (ngram analysis)
     name: hash,

--- a/test/document.js
+++ b/test/document.js
@@ -20,7 +20,7 @@ module.exports.tests.properties = function(test, common) {
 
 // should contain the correct field definitions
 module.exports.tests.fields = function(test, common) {
-  var fields = ['source', 'layer', 'alpha3', 'name', 'phrase', 'address_parts',
+  var fields = ['source', 'layer', 'name', 'phrase', 'address_parts',
     'parent', 'center_point', 'shape', 'bounding_box', 'source_id', 'category',
     'population', 'popularity'];
   test('fields specified', function(t) {
@@ -131,15 +131,6 @@ module.exports.tests.parent_analysis = function(test, common) {
     t.equal(prop['postalcode'+'_id'].type, 'string');
     t.equal(prop['postalcode'+'_id'].index, 'not_analyzed');
 
-    t.end();
-  });
-};
-
-module.exports.tests.alpha3_analysis = function(test, common) {
-  var prop = schema.properties.alpha3;
-  test('alpha3', function(t) {
-    t.equal(prop.type, 'string');
-    t.equal(prop.analyzer, 'peliasAdmin');
     t.end();
   });
 };

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -1447,10 +1447,6 @@
           "type": "string",
           "index": "not_analyzed"
         },
-        "alpha3": {
-          "type": "string",
-          "analyzer": "peliasAdmin"
-        },
         "name": {
           "type": "object",
           "dynamic": true
@@ -1739,10 +1735,6 @@
         "layer": {
           "type": "string",
           "index": "not_analyzed"
-        },
-        "alpha3": {
-          "type": "string",
-          "analyzer": "peliasAdmin"
         },
         "name": {
           "type": "object",
@@ -2033,10 +2025,6 @@
           "type": "string",
           "index": "not_analyzed"
         },
-        "alpha3": {
-          "type": "string",
-          "analyzer": "peliasAdmin"
-        },
         "name": {
           "type": "object",
           "dynamic": true
@@ -2325,10 +2313,6 @@
         "layer": {
           "type": "string",
           "index": "not_analyzed"
-        },
-        "alpha3": {
-          "type": "string",
-          "analyzer": "peliasAdmin"
         },
         "name": {
           "type": "object",
@@ -2619,10 +2603,6 @@
           "type": "string",
           "index": "not_analyzed"
         },
-        "alpha3": {
-          "type": "string",
-          "analyzer": "peliasAdmin"
-        },
         "name": {
           "type": "object",
           "dynamic": true
@@ -2911,10 +2891,6 @@
         "layer": {
           "type": "string",
           "index": "not_analyzed"
-        },
-        "alpha3": {
-          "type": "string",
-          "analyzer": "peliasAdmin"
         },
         "name": {
           "type": "object",
@@ -3205,10 +3181,6 @@
           "type": "string",
           "index": "not_analyzed"
         },
-        "alpha3": {
-          "type": "string",
-          "analyzer": "peliasAdmin"
-        },
         "name": {
           "type": "object",
           "dynamic": true
@@ -3497,10 +3469,6 @@
         "layer": {
           "type": "string",
           "index": "not_analyzed"
-        },
-        "alpha3": {
-          "type": "string",
-          "analyzer": "peliasAdmin"
         },
         "name": {
           "type": "object",
@@ -3791,10 +3759,6 @@
           "type": "string",
           "index": "not_analyzed"
         },
-        "alpha3": {
-          "type": "string",
-          "analyzer": "peliasAdmin"
-        },
         "name": {
           "type": "object",
           "dynamic": true
@@ -4083,10 +4047,6 @@
         "layer": {
           "type": "string",
           "index": "not_analyzed"
-        },
-        "alpha3": {
-          "type": "string",
-          "analyzer": "peliasAdmin"
         },
         "name": {
           "type": "object",
@@ -4377,10 +4337,6 @@
           "type": "string",
           "index": "not_analyzed"
         },
-        "alpha3": {
-          "type": "string",
-          "analyzer": "peliasAdmin"
-        },
         "name": {
           "type": "object",
           "dynamic": true
@@ -4669,10 +4625,6 @@
         "layer": {
           "type": "string",
           "index": "not_analyzed"
-        },
-        "alpha3": {
-          "type": "string",
-          "analyzer": "peliasAdmin"
         },
         "name": {
           "type": "object",
@@ -4963,10 +4915,6 @@
           "type": "string",
           "index": "not_analyzed"
         },
-        "alpha3": {
-          "type": "string",
-          "analyzer": "peliasAdmin"
-        },
         "name": {
           "type": "object",
           "dynamic": true
@@ -5256,10 +5204,6 @@
           "type": "string",
           "index": "not_analyzed"
         },
-        "alpha3": {
-          "type": "string",
-          "analyzer": "peliasAdmin"
-        },
         "name": {
           "type": "object",
           "dynamic": true
@@ -5548,10 +5492,6 @@
         "layer": {
           "type": "string",
           "index": "not_analyzed"
-        },
-        "alpha3": {
-          "type": "string",
-          "analyzer": "peliasAdmin"
         },
         "name": {
           "type": "object",


### PR DESCRIPTION
We stopped using the `alpha3` field over [two years ago](https://github.com/pelias/query/pull/6), but it was still lingering in our schema including some tests.

This was discovered while updating and testing https://github.com/pelias/schema/pull/282.