### PR TITLE
Support Travis VM Infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
-sudo: false
 language: node_js
+# Once openjdk/oraclejdk dependencies are resolved, change to dist: xenial
+dist: trusty
 notifications:
   email: false
 node_js:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ env:
 jdk:
   - oraclejdk8
 install:
-  - mkdir /tmp/elasticsearch
   - ./scripts/setup_ci.sh
   - npm i
 script:


### PR DESCRIPTION
Building on the changes to Travis config in #336, this PR modifies our Elasticsearch setup to be compatible with VM based infrastructure. It's based heavily on the [Travis Elasticsearch](https://docs.travis-ci.com/user/database-setup/#elasticsearch) docs.

However, there currently appears to be an issue where for some reason, the Elasticsearch 5 builds think the Pelias index already exists. It almost looks as if the different builds are sharing data. However, that shouldn't be the case.

Since Travis has already started rolling out the switch to VM based builds, we have to fix this soon, and until then live with failing schema builds.

@missinglink any ideas?