### PR TITLE
Pin to Node.js 10.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
-sudo: false
 language: node_js
+# Once openjdk/oraclejdk dependencies are resolved, change to dist: xenial
+dist: trusty
 notifications:
   email: false
 node_js:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ dist: trusty
 notifications:
   email: false
 node_js:
-  - 8
-  - 10
+  - 8.13.0
+  - 10.13.0
 matrix:
   fast_finish: true
 env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # base image
-FROM pelias/baseimage
+FROM pelias/baseimage:nodejs-10.13.0
 
 # change working dir
 ENV WORKDIR /code/pelias/schema


### PR DESCRIPTION
This is _just_ the changes from #337 to pin Node.js to 10.13.0 for this change.

Pinning is required because Elasticsearch 5 tends to output lots of header lines with deprecation notices, while Node.js 10.14.0 added an unconfigurable 8kb max size for headers, and all network requests with larger headers are dropped.

Eventually, Node.js will add a configuration flag for this (see https://github.com/nodejs/node/pull/24811). Until then, pinning to 10.13.0 is a good stopgap. The Schema project does not accept incoming network requests, so it is not susceptible to the vulnerabilities the 8kb header limit was designed to protect against.