### PR TITLE
Use header size parameter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
 before_script:
   - sleep 10
   - curl http://127.0.0.1:9200/
-  - node scripts/create_index.js -y
+  - ./bin/create_index
 branches:
   except:
     - /^v\d+\.\d+\.\d+$/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ dist: trusty
 notifications:
   email: false
 node_js:
-  - 8.13.0
-  - 10.13.0
+  - 8
+  - 10
 matrix:
   fast_finish: true
 env:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ This package defines the Elasticsearch schema used by Pelias. Pelias requires qu
 [![Greenkeeper badge](https://badges.greenkeeper.io/pelias/schema.svg)](https://greenkeeper.io/)
 [![NPM](https://nodei.co/npm/pelias-schema.png?downloads=true&stars=true)](https://nodei.co/npm/pelias-schema)
 [![Build Status](https://travis-ci.org/pelias/schema.png?branch=master)](https://travis-ci.org/pelias/schema)
+
+## Requirements
+
+See [Pelias Software requirements](https://github.com/pelias/documentation/blob/master/requirements.md) for general Pelias requirements.
+
+### Compatibility
+
+If using Elasticsearch 5, ensure you are using Node.js 8.15+ or Node.js 10.15+.
+
+Versions 8.14 and 10.14 fixed a security issue, but in the process [caused issues combined with deprecation headers sent by ES5](https://github.com/pelias/schema/pull/339). This precaution will no longer be necessary once Elasticsearch 2 support is removed.
+
 ## Installation
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $ npm install pelias-schema
 #### create index
 
 ```bash
-node scripts/create_index.js;               # quick start
+./bin/create_index                          # quick start
 ```
 
 #### drop index

--- a/bin/create_index
+++ b/bin/create_index
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+node scripts/create_index.js

--- a/bin/create_index
+++ b/bin/create_index
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-node scripts/create_index.js
+# create index, passing needed command line parameters
+node --max-http-header-size=16384 scripts/create_index.js

--- a/bin/integration
+++ b/bin/integration
@@ -4,4 +4,4 @@
 # see https://github.com/pelias/pelias/issues/744
 set -o pipefail
 
-node integration/run.js | npx tap-spec
+node --max-http-header-size=16384 integration/run.js | npx tap-spec

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "test": "./bin/test",
     "integration": "./bin/integration",
-    "create_index": "node scripts/create_index",
+    "create_index": "./bin/create_index",
     "drop_index": "node scripts/drop_index",
     "reset_type": "node scripts/reset_type",
     "update_settings": "node scripts/update_settings",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "elasticsearch": "^15.0.0",
     "joi": "^14.0.0",
     "lodash.merge": "^4.6.0",
-    "pelias-config": "^3.5.0"
+    "pelias-config": "^3.5.0",
+    "pelias-logger": "^1.3.0"
   },
   "devDependencies": {
     "difflet": "^1.0.1",

--- a/scripts/create_index.js
+++ b/scripts/create_index.js
@@ -2,6 +2,7 @@ const child_process = require('child_process');
 const http = require('http');
 
 const config = require('pelias-config').generate();
+const logger = require('pelias-logger').get('schema');
 const es = require('elasticsearch');
 
 const cli = require('./cli');
@@ -14,6 +15,20 @@ try {
   child_process.execSync( 'node ' + __dirname + '/check_plugins.js' );
 } catch( e ){
   console.error( "please install mandatory plugins before continuing.\n");
+  process.exit(1);
+}
+
+if (http.maxHeaderSize === undefined) {
+  logger.warning('You are using a version of Node.js that does not support the --max-http-header-size option.' +
+    'You may experience issues when using Elasticsearch 5.' +
+    'See https://github.com/pelias/schema#compatibility for more details.');
+}
+
+if (http.maxHeaderSize < 16384) {
+  logger.error('Max header size is below 16384 bytes. ' +
+    'Be sure to use the provided wrapper script in \'./bin\' rather than calling this script directly.' +
+    'Otherwise, you may experience issues when using Elasticsearch 5.' +
+    'See https://github.com/pelias/schema#compatibility for more details.');
   process.exit(1);
 }
 

--- a/scripts/create_index.js
+++ b/scripts/create_index.js
@@ -1,9 +1,9 @@
-var config = require('pelias-config').generate();
-var es = require('elasticsearch');
-var child_process = require('child_process');
-var client = new es.Client(config.esclient);
-var cli = require('./cli');
-var schema = require('../schema');
+const config = require('pelias-config').generate();
+const es = require('elasticsearch');
+const child_process = require('child_process');
+const client = new es.Client(config.esclient);
+const cli = require('./cli');
+const schema = require('../schema');
 
 // check mandatory plugins are installed before continuing
 try {
@@ -14,7 +14,7 @@ try {
 }
 
 cli.header("create index");
-var indexName = config.schema.indexName;
+const indexName = config.schema.indexName;
 
 client.indices.create( { index: indexName, body: schema }, function( err, res ){
   if( err ){

--- a/scripts/create_index.js
+++ b/scripts/create_index.js
@@ -1,9 +1,13 @@
+const child_process = require('child_process');
+const http = require('http');
+
 const config = require('pelias-config').generate();
 const es = require('elasticsearch');
-const child_process = require('child_process');
-const client = new es.Client(config.esclient);
+
 const cli = require('./cli');
 const schema = require('../schema');
+
+const client = new es.Client(config.esclient);
 
 // check mandatory plugins are installed before continuing
 try {


### PR DESCRIPTION
This provides a decent solution to the issues of compatibility with Node.js 8.14+/10.14+ and Elasticsearch 5.

It includes updates to code and documentation requiring Node.js 8.15 or 10.15, which includes a `--max-http-header-size` parameter. By creating a `create_index` wrapper script that always passes a safe value for that parameter, we can ensure that the high number of Elasticsearch 5 deprecation warning headers don't cause issue with the header size limits introduced in Node.js.

The `create_index.js` script itself now also checks for reasonable values of that parameter, and will warn if the value is non-existent (suggesting an old version of Node.js is in use) or set to the default value (in which case the issue will occur if Elasticsearch 5 is in use).

Once we drop support for Elasticsearch 2 and fix the deprecation warnings, we should be ok. Elasticsearch 6 has more powerful options for configuring these headers, so the next upgrade won't cause this issue.

Fixes https://github.com/pelias/pelias/issues/765