### PR TITLE
allow arbitrary data to be stored alongside the rest of the document

### DIFF
--- a/mappings/document.js
+++ b/mappings/document.js
@@ -138,7 +138,10 @@ var schema = {
     source_id: literal,
     category: literal,
     population: multiplier,
-    popularity: multiplier
+    popularity: multiplier,
+
+    // addendum (non-indexed supplimentary data)
+    addendum: hash
   },
   dynamic_templates: [{
     nameGram: {
@@ -148,7 +151,7 @@ var schema = {
         type: 'string',
         analyzer: 'peliasIndexOneEdgeGram',
         fielddata : {
-          format: "disabled"
+          format: 'disabled'
         }
       }
     },
@@ -160,7 +163,20 @@ var schema = {
         type: 'string',
         analyzer: 'peliasPhrase',
         fielddata : {
-          format: "disabled"
+          format: 'disabled'
+        }
+      }
+    }
+  },{
+    addendum: {
+      path_match: 'addendum.*',
+      match_mapping_type: 'string',
+      mapping: {
+        type: 'string',
+        index: 'no',
+        doc_values: false,
+        fielddata : {
+          format: 'disabled'
         }
       }
     }

--- a/test/document.js
+++ b/test/document.js
@@ -22,7 +22,7 @@ module.exports.tests.properties = function(test, common) {
 module.exports.tests.fields = function(test, common) {
   var fields = ['source', 'layer', 'name', 'phrase', 'address_parts',
     'parent', 'center_point', 'shape', 'bounding_box', 'source_id', 'category',
-    'population', 'popularity'];
+    'population', 'popularity', 'addendum'];
   test('fields specified', function(t) {
     t.deepEqual(Object.keys(schema.properties), fields);
     t.end();

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -948,6 +948,10 @@
         "popularity": {
           "type": "long",
           "null_value": 0
+        },
+        "addendum": {
+          "type": "object",
+          "dynamic": true
         }
       },
       "dynamic_templates": [
@@ -972,6 +976,20 @@
               "type": "string",
               "analyzer": "peliasPhrase",
               "fielddata": {
+                "format": "disabled"
+              }
+            }
+          }
+        },
+        {
+          "addendum": {
+            "path_match": "addendum.*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "string",
+              "index": "no",
+              "doc_values": false,
+              "fielddata" : {
                 "format": "disabled"
               }
             }
@@ -1263,6 +1281,10 @@
         "popularity": {
           "type": "long",
           "null_value": 0
+        },
+        "addendum": {
+          "type": "object",
+          "dynamic": true
         }
       },
       "dynamic_templates": [
@@ -1287,6 +1309,20 @@
               "type": "string",
               "analyzer": "peliasPhrase",
               "fielddata": {
+                "format": "disabled"
+              }
+            }
+          }
+        },
+        {
+          "addendum": {
+            "path_match": "addendum.*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "string",
+              "index": "no",
+              "doc_values": false,
+              "fielddata" : {
                 "format": "disabled"
               }
             }
@@ -1578,6 +1614,10 @@
         "popularity": {
           "type": "long",
           "null_value": 0
+        },
+        "addendum": {
+          "type": "object",
+          "dynamic": true
         }
       },
       "dynamic_templates": [
@@ -1602,6 +1642,20 @@
               "type": "string",
               "analyzer": "peliasPhrase",
               "fielddata": {
+                "format": "disabled"
+              }
+            }
+          }
+        },
+        {
+          "addendum": {
+            "path_match": "addendum.*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "string",
+              "index": "no",
+              "doc_values": false,
+              "fielddata" : {
                 "format": "disabled"
               }
             }
@@ -1893,6 +1947,10 @@
         "popularity": {
           "type": "long",
           "null_value": 0
+        },
+        "addendum": {
+          "type": "object",
+          "dynamic": true
         }
       },
       "dynamic_templates": [
@@ -1917,6 +1975,20 @@
               "type": "string",
               "analyzer": "peliasPhrase",
               "fielddata": {
+                "format": "disabled"
+              }
+            }
+          }
+        },
+        {
+          "addendum": {
+            "path_match": "addendum.*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "string",
+              "index": "no",
+              "doc_values": false,
+              "fielddata" : {
                 "format": "disabled"
               }
             }
@@ -2208,6 +2280,10 @@
         "popularity": {
           "type": "long",
           "null_value": 0
+        },
+        "addendum": {
+          "type": "object",
+          "dynamic": true
         }
       },
       "dynamic_templates": [
@@ -2232,6 +2308,20 @@
               "type": "string",
               "analyzer": "peliasPhrase",
               "fielddata": {
+                "format": "disabled"
+              }
+            }
+          }
+        },
+        {
+          "addendum": {
+            "path_match": "addendum.*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "string",
+              "index": "no",
+              "doc_values": false,
+              "fielddata" : {
                 "format": "disabled"
               }
             }
@@ -2523,6 +2613,10 @@
         "popularity": {
           "type": "long",
           "null_value": 0
+        },
+        "addendum": {
+          "type": "object",
+          "dynamic": true
         }
       },
       "dynamic_templates": [
@@ -2547,6 +2641,20 @@
               "type": "string",
               "analyzer": "peliasPhrase",
               "fielddata": {
+                "format": "disabled"
+              }
+            }
+          }
+        },
+        {
+          "addendum": {
+            "path_match": "addendum.*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "string",
+              "index": "no",
+              "doc_values": false,
+              "fielddata" : {
                 "format": "disabled"
               }
             }
@@ -2838,6 +2946,10 @@
         "popularity": {
           "type": "long",
           "null_value": 0
+        },
+        "addendum": {
+          "type": "object",
+          "dynamic": true
         }
       },
       "dynamic_templates": [
@@ -2862,6 +2974,20 @@
               "type": "string",
               "analyzer": "peliasPhrase",
               "fielddata": {
+                "format": "disabled"
+              }
+            }
+          }
+        },
+        {
+          "addendum": {
+            "path_match": "addendum.*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "string",
+              "index": "no",
+              "doc_values": false,
+              "fielddata" : {
                 "format": "disabled"
               }
             }
@@ -3153,6 +3279,10 @@
         "popularity": {
           "type": "long",
           "null_value": 0
+        },
+        "addendum": {
+          "type": "object",
+          "dynamic": true
         }
       },
       "dynamic_templates": [
@@ -3177,6 +3307,20 @@
               "type": "string",
               "analyzer": "peliasPhrase",
               "fielddata": {
+                "format": "disabled"
+              }
+            }
+          }
+        },
+        {
+          "addendum": {
+            "path_match": "addendum.*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "string",
+              "index": "no",
+              "doc_values": false,
+              "fielddata" : {
                 "format": "disabled"
               }
             }
@@ -3468,6 +3612,10 @@
         "popularity": {
           "type": "long",
           "null_value": 0
+        },
+        "addendum": {
+          "type": "object",
+          "dynamic": true
         }
       },
       "dynamic_templates": [
@@ -3492,6 +3640,20 @@
               "type": "string",
               "analyzer": "peliasPhrase",
               "fielddata": {
+                "format": "disabled"
+              }
+            }
+          }
+        },
+        {
+          "addendum": {
+            "path_match": "addendum.*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "string",
+              "index": "no",
+              "doc_values": false,
+              "fielddata" : {
                 "format": "disabled"
               }
             }
@@ -3783,6 +3945,10 @@
         "popularity": {
           "type": "long",
           "null_value": 0
+        },
+        "addendum": {
+          "type": "object",
+          "dynamic": true
         }
       },
       "dynamic_templates": [
@@ -3807,6 +3973,20 @@
               "type": "string",
               "analyzer": "peliasPhrase",
               "fielddata": {
+                "format": "disabled"
+              }
+            }
+          }
+        },
+        {
+          "addendum": {
+            "path_match": "addendum.*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "string",
+              "index": "no",
+              "doc_values": false,
+              "fielddata" : {
                 "format": "disabled"
               }
             }
@@ -4098,6 +4278,10 @@
         "popularity": {
           "type": "long",
           "null_value": 0
+        },
+        "addendum": {
+          "type": "object",
+          "dynamic": true
         }
       },
       "dynamic_templates": [
@@ -4122,6 +4306,20 @@
               "type": "string",
               "analyzer": "peliasPhrase",
               "fielddata": {
+                "format": "disabled"
+              }
+            }
+          }
+        },
+        {
+          "addendum": {
+            "path_match": "addendum.*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "string",
+              "index": "no",
+              "doc_values": false,
+              "fielddata" : {
                 "format": "disabled"
               }
             }
@@ -4413,6 +4611,10 @@
         "popularity": {
           "type": "long",
           "null_value": 0
+        },
+        "addendum": {
+          "type": "object",
+          "dynamic": true
         }
       },
       "dynamic_templates": [
@@ -4437,6 +4639,20 @@
               "type": "string",
               "analyzer": "peliasPhrase",
               "fielddata": {
+                "format": "disabled"
+              }
+            }
+          }
+        },
+        {
+          "addendum": {
+            "path_match": "addendum.*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "string",
+              "index": "no",
+              "doc_values": false,
+              "fielddata" : {
                 "format": "disabled"
               }
             }
@@ -4728,6 +4944,10 @@
         "popularity": {
           "type": "long",
           "null_value": 0
+        },
+        "addendum": {
+          "type": "object",
+          "dynamic": true
         }
       },
       "dynamic_templates": [
@@ -4752,6 +4972,20 @@
               "type": "string",
               "analyzer": "peliasPhrase",
               "fielddata": {
+                "format": "disabled"
+              }
+            }
+          }
+        },
+        {
+          "addendum": {
+            "path_match": "addendum.*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "string",
+              "index": "no",
+              "doc_values": false,
+              "fielddata" : {
                 "format": "disabled"
               }
             }
@@ -5043,6 +5277,10 @@
         "popularity": {
           "type": "long",
           "null_value": 0
+        },
+        "addendum": {
+          "type": "object",
+          "dynamic": true
         }
       },
       "dynamic_templates": [
@@ -5067,6 +5305,20 @@
               "type": "string",
               "analyzer": "peliasPhrase",
               "fielddata": {
+                "format": "disabled"
+              }
+            }
+          }
+        },
+        {
+          "addendum": {
+            "path_match": "addendum.*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "string",
+              "index": "no",
+              "doc_values": false,
+              "fielddata" : {
                 "format": "disabled"
               }
             }
@@ -5358,6 +5610,10 @@
         "popularity": {
           "type": "long",
           "null_value": 0
+        },
+        "addendum": {
+          "type": "object",
+          "dynamic": true
         }
       },
       "dynamic_templates": [
@@ -5382,6 +5638,20 @@
               "type": "string",
               "analyzer": "peliasPhrase",
               "fielddata": {
+                "format": "disabled"
+              }
+            }
+          }
+        },
+        {
+          "addendum": {
+            "path_match": "addendum.*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "string",
+              "index": "no",
+              "doc_values": false,
+              "fielddata" : {
                 "format": "disabled"
               }
             }


### PR DESCRIPTION
This PR addresses the issue mentioned in https://github.com/pelias/pelias/issues/747, also known as 'custom data'.

This change would allow the operators of a Pelias instance to store arbitrary data alongside any document.

The intention here is that the field `addendum` is of type `map[string]string`, with each entry being namespaced in order to avoid property collision.

It's intended that the value of the field is encoded as a string (although the codec nor the data type are actually enforced here).

paired with:
- https://github.com/pelias/model/pull/112
- https://github.com/pelias/api/pull/1255

resolves https://github.com/pelias/pelias/issues/747