### PR TITLE
Compute an ngram field for all admin data

### DIFF
--- a/mappings/partial/admin.json
+++ b/mappings/partial/admin.json
@@ -1,4 +1,14 @@
 {
   "type": "string",
-  "analyzer": "peliasAdmin"
+  "analyzer": "peliasAdmin",
+  "fields": {
+    "ngram": {
+      "type": "string",
+      "analyzer": "peliasIndexOneEdgeGram",
+      "doc_values": false,
+      "fielddata": {
+        "format": "disabled"
+      }
+    }
+  }
 }

--- a/mappings/partial/postalcode.json
+++ b/mappings/partial/postalcode.json
@@ -1,4 +1,14 @@
 {
   "type": "string",
-  "analyzer": "peliasZip"
+  "analyzer": "peliasZip",
+  "fields": {
+    "ngram": {
+      "type": "string",
+      "analyzer": "peliasIndexOneEdgeGram",
+      "doc_values": false,
+      "fielddata": {
+        "format": "disabled"
+      }
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "colors": "^1.1.2",
     "elasticsearch": "^15.0.0",
     "joi": "^14.0.0",
+    "lodash.has": "^4.5.2",
     "lodash.merge": "^4.6.0",
     "pelias-config": "^3.5.0",
     "pelias-logger": "^1.3.0"

--- a/test/compile.js
+++ b/test/compile.js
@@ -65,6 +65,7 @@ module.exports.tests.current_schema = function(test, common) {
 
     // code intentionally commented to allow quick debugging of expected.json
     // common.diff(schemaCopy, fixture);
+    // console.error( JSON.stringify( schemaCopy, null, 2 ) );
 
     t.deepEqual(schemaCopy, fixture);
     t.end();

--- a/test/document.js
+++ b/test/document.js
@@ -1,4 +1,5 @@
-var schema = require('../mappings/document');
+const schema = require('../mappings/document');
+const has = require('lodash.has');
 
 module.exports.tests = {};
 
@@ -85,24 +86,26 @@ module.exports.tests.address_analysis = function(test, common) {
 // should contain the correct parent field definitions
 module.exports.tests.parent_fields = function(test, common) {
   var fields = [
-    'continent',      'continent_a',      'continent_id',
-    'ocean',          'ocean_a',          'ocean_id',
-    'empire',         'empire_a',         'empire_id',
-    'country',        'country_a',        'country_id',
-    'dependency',     'dependency_a',     'dependency_id',
-    'marinearea',     'marinearea_a',     'marinearea_id',
-    'macroregion',    'macroregion_a',    'macroregion_id',
-    'region',         'region_a',         'region_id',
-    'macrocounty',    'macrocounty_a',    'macrocounty_id',
-    'county',         'county_a',         'county_id',
-    'locality',       'locality_a',       'locality_id',
-    'borough',        'borough_a',        'borough_id',
-    'localadmin',     'localadmin_a',     'localadmin_id',
-    'neighbourhood',  'neighbourhood_a',  'neighbourhood_id',
-    'postalcode',     'postalcode_a',     'postalcode_id'
+    'continent',      'continent_a',      'continent_id',     'continent.fields.ngram',
+    'ocean',          'ocean_a',          'ocean_id',         'ocean.fields.ngram',
+    'empire',         'empire_a',         'empire_id',        'empire.fields.ngram',
+    'country',        'country_a',        'country_id',       'country.fields.ngram',
+    'dependency',     'dependency_a',     'dependency_id',    'dependency.fields.ngram',
+    'marinearea',     'marinearea_a',     'marinearea_id',    'marinearea.fields.ngram',
+    'macroregion',    'macroregion_a',    'macroregion_id',   'macroregion.fields.ngram',
+    'region',         'region_a',         'region_id',        'region.fields.ngram',
+    'macrocounty',    'macrocounty_a',    'macrocounty_id',   'macrocounty.fields.ngram',
+    'county',         'county_a',         'county_id',        'county.fields.ngram',
+    'locality',       'locality_a',       'locality_id',      'locality.fields.ngram',
+    'borough',        'borough_a',        'borough_id',       'borough.fields.ngram',
+    'localadmin',     'localadmin_a',     'localadmin_id',    'localadmin.fields.ngram',
+    'neighbourhood',  'neighbourhood_a',  'neighbourhood_id', 'neighbourhood.fields.ngram',
+    'postalcode',     'postalcode_a',     'postalcode_id',    'postalcode.fields.ngram'
   ];
   test('parent fields specified', function(t) {
-    t.deepEqual(Object.keys(schema.properties.parent.properties), fields);
+    fields.forEach( expected => {
+      t.true( has( schema.properties.parent.properties, expected ), expected );
+    });
     t.end();
   });
 };
@@ -111,7 +114,11 @@ module.exports.tests.parent_fields = function(test, common) {
 // ref: https://github.com/pelias/schema/pull/95
 module.exports.tests.parent_analysis = function(test, common) {
   var prop = schema.properties.parent.properties;
-  var fields = ['country','region','county','locality','localadmin','neighbourhood'];
+  var fields = [
+    'continent', 'ocean', 'empire', 'country', 'dependency', 'marinearea',
+    'macroregion', 'region', 'macrocounty', 'county', 'locality', 'borough',
+    'localadmin', 'neighbourhood'
+  ];
   fields.forEach( function( field ){
     test(field, function(t) {
       t.equal(prop[field].type, 'string');
@@ -120,6 +127,10 @@ module.exports.tests.parent_analysis = function(test, common) {
       t.equal(prop[field+'_a'].analyzer, 'peliasAdmin');
       t.equal(prop[field+'_id'].type, 'string');
       t.equal(prop[field+'_id'].index, 'not_analyzed');
+
+      // subfields
+      t.equal(prop[field].fields.ngram.type, 'string');
+      t.equal(prop[field].fields.ngram.analyzer, 'peliasIndexOneEdgeGram');
 
       t.end();
     });

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -728,11 +728,31 @@
           "properties": {
             "continent": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "continent_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "continent_id": {
               "type": "string",
@@ -741,11 +761,31 @@
             },
             "ocean": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "ocean_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "ocean_id": {
               "type": "string",
@@ -754,11 +794,31 @@
             },
             "empire": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "empire_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "empire_id": {
               "type": "string",
@@ -767,11 +827,31 @@
             },
             "country": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "country_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "country_id": {
               "type": "string",
@@ -780,11 +860,31 @@
             },
             "dependency": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "dependency_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "dependency_id": {
               "type": "string",
@@ -793,11 +893,31 @@
             },
             "marinearea": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "marinearea_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "marinearea_id": {
               "type": "string",
@@ -806,11 +926,31 @@
             },
             "macroregion": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macroregion_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macroregion_id": {
               "type": "string",
@@ -819,11 +959,31 @@
             },
             "region": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "region_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "region_id": {
               "type": "string",
@@ -832,11 +992,31 @@
             },
             "macrocounty": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macrocounty_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macrocounty_id": {
               "type": "string",
@@ -845,11 +1025,31 @@
             },
             "county": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "county_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "county_id": {
               "type": "string",
@@ -858,11 +1058,31 @@
             },
             "locality": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "locality_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "locality_id": {
               "type": "string",
@@ -871,11 +1091,31 @@
             },
             "borough": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "borough_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "borough_id": {
               "type": "string",
@@ -884,11 +1124,31 @@
             },
             "localadmin": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "localadmin_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "localadmin_id": {
               "type": "string",
@@ -897,11 +1157,31 @@
             },
             "neighbourhood": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "neighbourhood_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "neighbourhood_id": {
               "type": "string",
@@ -910,11 +1190,31 @@
             },
             "postalcode": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "postalcode_a": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "postalcode_id": {
               "type": "string",
@@ -1065,11 +1365,31 @@
           "properties": {
             "continent": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "continent_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "continent_id": {
               "type": "string",
@@ -1078,11 +1398,31 @@
             },
             "ocean": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "ocean_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "ocean_id": {
               "type": "string",
@@ -1091,11 +1431,31 @@
             },
             "empire": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "empire_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "empire_id": {
               "type": "string",
@@ -1104,11 +1464,31 @@
             },
             "country": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "country_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "country_id": {
               "type": "string",
@@ -1117,11 +1497,31 @@
             },
             "dependency": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "dependency_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "dependency_id": {
               "type": "string",
@@ -1130,11 +1530,31 @@
             },
             "marinearea": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "marinearea_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "marinearea_id": {
               "type": "string",
@@ -1143,11 +1563,31 @@
             },
             "macroregion": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macroregion_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macroregion_id": {
               "type": "string",
@@ -1156,11 +1596,31 @@
             },
             "region": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "region_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "region_id": {
               "type": "string",
@@ -1169,11 +1629,31 @@
             },
             "macrocounty": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macrocounty_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macrocounty_id": {
               "type": "string",
@@ -1182,11 +1662,31 @@
             },
             "county": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "county_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "county_id": {
               "type": "string",
@@ -1195,11 +1695,31 @@
             },
             "locality": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "locality_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "locality_id": {
               "type": "string",
@@ -1208,11 +1728,31 @@
             },
             "borough": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "borough_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "borough_id": {
               "type": "string",
@@ -1221,11 +1761,31 @@
             },
             "localadmin": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "localadmin_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "localadmin_id": {
               "type": "string",
@@ -1234,11 +1794,31 @@
             },
             "neighbourhood": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "neighbourhood_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "neighbourhood_id": {
               "type": "string",
@@ -1247,11 +1827,31 @@
             },
             "postalcode": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "postalcode_a": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "postalcode_id": {
               "type": "string",
@@ -1402,11 +2002,31 @@
           "properties": {
             "continent": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "continent_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "continent_id": {
               "type": "string",
@@ -1415,11 +2035,31 @@
             },
             "ocean": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "ocean_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "ocean_id": {
               "type": "string",
@@ -1428,11 +2068,31 @@
             },
             "empire": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "empire_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "empire_id": {
               "type": "string",
@@ -1441,11 +2101,31 @@
             },
             "country": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "country_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "country_id": {
               "type": "string",
@@ -1454,11 +2134,31 @@
             },
             "dependency": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "dependency_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "dependency_id": {
               "type": "string",
@@ -1467,11 +2167,31 @@
             },
             "marinearea": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "marinearea_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "marinearea_id": {
               "type": "string",
@@ -1480,11 +2200,31 @@
             },
             "macroregion": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macroregion_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macroregion_id": {
               "type": "string",
@@ -1493,11 +2233,31 @@
             },
             "region": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "region_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "region_id": {
               "type": "string",
@@ -1506,11 +2266,31 @@
             },
             "macrocounty": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macrocounty_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macrocounty_id": {
               "type": "string",
@@ -1519,11 +2299,31 @@
             },
             "county": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "county_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "county_id": {
               "type": "string",
@@ -1532,11 +2332,31 @@
             },
             "locality": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "locality_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "locality_id": {
               "type": "string",
@@ -1545,11 +2365,31 @@
             },
             "borough": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "borough_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "borough_id": {
               "type": "string",
@@ -1558,11 +2398,31 @@
             },
             "localadmin": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "localadmin_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "localadmin_id": {
               "type": "string",
@@ -1571,11 +2431,31 @@
             },
             "neighbourhood": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "neighbourhood_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "neighbourhood_id": {
               "type": "string",
@@ -1584,11 +2464,31 @@
             },
             "postalcode": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "postalcode_a": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "postalcode_id": {
               "type": "string",
@@ -1739,11 +2639,31 @@
           "properties": {
             "continent": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "continent_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "continent_id": {
               "type": "string",
@@ -1752,11 +2672,31 @@
             },
             "ocean": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "ocean_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "ocean_id": {
               "type": "string",
@@ -1765,11 +2705,31 @@
             },
             "empire": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "empire_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "empire_id": {
               "type": "string",
@@ -1778,11 +2738,31 @@
             },
             "country": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "country_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "country_id": {
               "type": "string",
@@ -1791,11 +2771,31 @@
             },
             "dependency": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "dependency_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "dependency_id": {
               "type": "string",
@@ -1804,11 +2804,31 @@
             },
             "marinearea": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "marinearea_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "marinearea_id": {
               "type": "string",
@@ -1817,11 +2837,31 @@
             },
             "macroregion": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macroregion_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macroregion_id": {
               "type": "string",
@@ -1830,11 +2870,31 @@
             },
             "region": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "region_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "region_id": {
               "type": "string",
@@ -1843,11 +2903,31 @@
             },
             "macrocounty": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macrocounty_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macrocounty_id": {
               "type": "string",
@@ -1856,11 +2936,31 @@
             },
             "county": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "county_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "county_id": {
               "type": "string",
@@ -1869,11 +2969,31 @@
             },
             "locality": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "locality_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "locality_id": {
               "type": "string",
@@ -1882,11 +3002,31 @@
             },
             "borough": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "borough_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "borough_id": {
               "type": "string",
@@ -1895,11 +3035,31 @@
             },
             "localadmin": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "localadmin_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "localadmin_id": {
               "type": "string",
@@ -1908,11 +3068,31 @@
             },
             "neighbourhood": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "neighbourhood_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "neighbourhood_id": {
               "type": "string",
@@ -1921,11 +3101,31 @@
             },
             "postalcode": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "postalcode_a": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "postalcode_id": {
               "type": "string",
@@ -2076,11 +3276,31 @@
           "properties": {
             "continent": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "continent_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "continent_id": {
               "type": "string",
@@ -2089,11 +3309,31 @@
             },
             "ocean": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "ocean_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "ocean_id": {
               "type": "string",
@@ -2102,11 +3342,31 @@
             },
             "empire": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "empire_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "empire_id": {
               "type": "string",
@@ -2115,11 +3375,31 @@
             },
             "country": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "country_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "country_id": {
               "type": "string",
@@ -2128,11 +3408,31 @@
             },
             "dependency": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "dependency_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "dependency_id": {
               "type": "string",
@@ -2141,11 +3441,31 @@
             },
             "marinearea": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "marinearea_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "marinearea_id": {
               "type": "string",
@@ -2154,11 +3474,31 @@
             },
             "macroregion": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macroregion_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macroregion_id": {
               "type": "string",
@@ -2167,11 +3507,31 @@
             },
             "region": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "region_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "region_id": {
               "type": "string",
@@ -2180,11 +3540,31 @@
             },
             "macrocounty": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macrocounty_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macrocounty_id": {
               "type": "string",
@@ -2193,11 +3573,31 @@
             },
             "county": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "county_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "county_id": {
               "type": "string",
@@ -2206,11 +3606,31 @@
             },
             "locality": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "locality_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "locality_id": {
               "type": "string",
@@ -2219,11 +3639,31 @@
             },
             "borough": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "borough_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "borough_id": {
               "type": "string",
@@ -2232,11 +3672,31 @@
             },
             "localadmin": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "localadmin_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "localadmin_id": {
               "type": "string",
@@ -2245,11 +3705,31 @@
             },
             "neighbourhood": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "neighbourhood_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "neighbourhood_id": {
               "type": "string",
@@ -2258,11 +3738,31 @@
             },
             "postalcode": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "postalcode_a": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "postalcode_id": {
               "type": "string",
@@ -2413,11 +3913,31 @@
           "properties": {
             "continent": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "continent_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "continent_id": {
               "type": "string",
@@ -2426,11 +3946,31 @@
             },
             "ocean": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "ocean_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "ocean_id": {
               "type": "string",
@@ -2439,11 +3979,31 @@
             },
             "empire": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "empire_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "empire_id": {
               "type": "string",
@@ -2452,11 +4012,31 @@
             },
             "country": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "country_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "country_id": {
               "type": "string",
@@ -2465,11 +4045,31 @@
             },
             "dependency": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "dependency_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "dependency_id": {
               "type": "string",
@@ -2478,11 +4078,31 @@
             },
             "marinearea": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "marinearea_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "marinearea_id": {
               "type": "string",
@@ -2491,11 +4111,31 @@
             },
             "macroregion": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macroregion_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macroregion_id": {
               "type": "string",
@@ -2504,11 +4144,31 @@
             },
             "region": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "region_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "region_id": {
               "type": "string",
@@ -2517,11 +4177,31 @@
             },
             "macrocounty": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macrocounty_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macrocounty_id": {
               "type": "string",
@@ -2530,11 +4210,31 @@
             },
             "county": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "county_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "county_id": {
               "type": "string",
@@ -2543,11 +4243,31 @@
             },
             "locality": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "locality_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "locality_id": {
               "type": "string",
@@ -2556,11 +4276,31 @@
             },
             "borough": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "borough_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "borough_id": {
               "type": "string",
@@ -2569,11 +4309,31 @@
             },
             "localadmin": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "localadmin_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "localadmin_id": {
               "type": "string",
@@ -2582,11 +4342,31 @@
             },
             "neighbourhood": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "neighbourhood_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "neighbourhood_id": {
               "type": "string",
@@ -2595,11 +4375,31 @@
             },
             "postalcode": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "postalcode_a": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "postalcode_id": {
               "type": "string",
@@ -2750,11 +4550,31 @@
           "properties": {
             "continent": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "continent_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "continent_id": {
               "type": "string",
@@ -2763,11 +4583,31 @@
             },
             "ocean": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "ocean_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "ocean_id": {
               "type": "string",
@@ -2776,11 +4616,31 @@
             },
             "empire": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "empire_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "empire_id": {
               "type": "string",
@@ -2789,11 +4649,31 @@
             },
             "country": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "country_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "country_id": {
               "type": "string",
@@ -2802,11 +4682,31 @@
             },
             "dependency": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "dependency_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "dependency_id": {
               "type": "string",
@@ -2815,11 +4715,31 @@
             },
             "marinearea": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "marinearea_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "marinearea_id": {
               "type": "string",
@@ -2828,11 +4748,31 @@
             },
             "macroregion": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macroregion_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macroregion_id": {
               "type": "string",
@@ -2841,11 +4781,31 @@
             },
             "region": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "region_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "region_id": {
               "type": "string",
@@ -2854,11 +4814,31 @@
             },
             "macrocounty": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macrocounty_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macrocounty_id": {
               "type": "string",
@@ -2867,11 +4847,31 @@
             },
             "county": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "county_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "county_id": {
               "type": "string",
@@ -2880,11 +4880,31 @@
             },
             "locality": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "locality_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "locality_id": {
               "type": "string",
@@ -2893,11 +4913,31 @@
             },
             "borough": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "borough_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "borough_id": {
               "type": "string",
@@ -2906,11 +4946,31 @@
             },
             "localadmin": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "localadmin_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "localadmin_id": {
               "type": "string",
@@ -2919,11 +4979,31 @@
             },
             "neighbourhood": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "neighbourhood_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "neighbourhood_id": {
               "type": "string",
@@ -2932,11 +5012,31 @@
             },
             "postalcode": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "postalcode_a": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "postalcode_id": {
               "type": "string",
@@ -3087,11 +5187,31 @@
           "properties": {
             "continent": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "continent_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "continent_id": {
               "type": "string",
@@ -3100,11 +5220,31 @@
             },
             "ocean": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "ocean_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "ocean_id": {
               "type": "string",
@@ -3113,11 +5253,31 @@
             },
             "empire": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "empire_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "empire_id": {
               "type": "string",
@@ -3126,11 +5286,31 @@
             },
             "country": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "country_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "country_id": {
               "type": "string",
@@ -3139,11 +5319,31 @@
             },
             "dependency": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "dependency_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "dependency_id": {
               "type": "string",
@@ -3152,11 +5352,31 @@
             },
             "marinearea": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "marinearea_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "marinearea_id": {
               "type": "string",
@@ -3165,11 +5385,31 @@
             },
             "macroregion": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macroregion_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macroregion_id": {
               "type": "string",
@@ -3178,11 +5418,31 @@
             },
             "region": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "region_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "region_id": {
               "type": "string",
@@ -3191,11 +5451,31 @@
             },
             "macrocounty": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macrocounty_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macrocounty_id": {
               "type": "string",
@@ -3204,11 +5484,31 @@
             },
             "county": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "county_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "county_id": {
               "type": "string",
@@ -3217,11 +5517,31 @@
             },
             "locality": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "locality_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "locality_id": {
               "type": "string",
@@ -3230,11 +5550,31 @@
             },
             "borough": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "borough_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "borough_id": {
               "type": "string",
@@ -3243,11 +5583,31 @@
             },
             "localadmin": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "localadmin_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "localadmin_id": {
               "type": "string",
@@ -3256,11 +5616,31 @@
             },
             "neighbourhood": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "neighbourhood_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "neighbourhood_id": {
               "type": "string",
@@ -3269,11 +5649,31 @@
             },
             "postalcode": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "postalcode_a": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "postalcode_id": {
               "type": "string",
@@ -3424,11 +5824,31 @@
           "properties": {
             "continent": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "continent_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "continent_id": {
               "type": "string",
@@ -3437,11 +5857,31 @@
             },
             "ocean": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "ocean_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "ocean_id": {
               "type": "string",
@@ -3450,11 +5890,31 @@
             },
             "empire": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "empire_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "empire_id": {
               "type": "string",
@@ -3463,11 +5923,31 @@
             },
             "country": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "country_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "country_id": {
               "type": "string",
@@ -3476,11 +5956,31 @@
             },
             "dependency": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "dependency_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "dependency_id": {
               "type": "string",
@@ -3489,11 +5989,31 @@
             },
             "marinearea": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "marinearea_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "marinearea_id": {
               "type": "string",
@@ -3502,11 +6022,31 @@
             },
             "macroregion": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macroregion_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macroregion_id": {
               "type": "string",
@@ -3515,11 +6055,31 @@
             },
             "region": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "region_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "region_id": {
               "type": "string",
@@ -3528,11 +6088,31 @@
             },
             "macrocounty": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macrocounty_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macrocounty_id": {
               "type": "string",
@@ -3541,11 +6121,31 @@
             },
             "county": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "county_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "county_id": {
               "type": "string",
@@ -3554,11 +6154,31 @@
             },
             "locality": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "locality_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "locality_id": {
               "type": "string",
@@ -3567,11 +6187,31 @@
             },
             "borough": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "borough_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "borough_id": {
               "type": "string",
@@ -3580,11 +6220,31 @@
             },
             "localadmin": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "localadmin_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "localadmin_id": {
               "type": "string",
@@ -3593,11 +6253,31 @@
             },
             "neighbourhood": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "neighbourhood_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "neighbourhood_id": {
               "type": "string",
@@ -3606,11 +6286,31 @@
             },
             "postalcode": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "postalcode_a": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "postalcode_id": {
               "type": "string",
@@ -3761,11 +6461,31 @@
           "properties": {
             "continent": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "continent_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "continent_id": {
               "type": "string",
@@ -3774,11 +6494,31 @@
             },
             "ocean": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "ocean_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "ocean_id": {
               "type": "string",
@@ -3787,11 +6527,31 @@
             },
             "empire": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "empire_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "empire_id": {
               "type": "string",
@@ -3800,11 +6560,31 @@
             },
             "country": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "country_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "country_id": {
               "type": "string",
@@ -3813,11 +6593,31 @@
             },
             "dependency": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "dependency_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "dependency_id": {
               "type": "string",
@@ -3826,11 +6626,31 @@
             },
             "marinearea": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "marinearea_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "marinearea_id": {
               "type": "string",
@@ -3839,11 +6659,31 @@
             },
             "macroregion": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macroregion_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macroregion_id": {
               "type": "string",
@@ -3852,11 +6692,31 @@
             },
             "region": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "region_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "region_id": {
               "type": "string",
@@ -3865,11 +6725,31 @@
             },
             "macrocounty": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macrocounty_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macrocounty_id": {
               "type": "string",
@@ -3878,11 +6758,31 @@
             },
             "county": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "county_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "county_id": {
               "type": "string",
@@ -3891,11 +6791,31 @@
             },
             "locality": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "locality_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "locality_id": {
               "type": "string",
@@ -3904,11 +6824,31 @@
             },
             "borough": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "borough_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "borough_id": {
               "type": "string",
@@ -3917,11 +6857,31 @@
             },
             "localadmin": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "localadmin_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "localadmin_id": {
               "type": "string",
@@ -3930,11 +6890,31 @@
             },
             "neighbourhood": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "neighbourhood_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "neighbourhood_id": {
               "type": "string",
@@ -3943,11 +6923,31 @@
             },
             "postalcode": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "postalcode_a": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "postalcode_id": {
               "type": "string",
@@ -4098,11 +7098,31 @@
           "properties": {
             "continent": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "continent_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "continent_id": {
               "type": "string",
@@ -4111,11 +7131,31 @@
             },
             "ocean": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "ocean_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "ocean_id": {
               "type": "string",
@@ -4124,11 +7164,31 @@
             },
             "empire": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "empire_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "empire_id": {
               "type": "string",
@@ -4137,11 +7197,31 @@
             },
             "country": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "country_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "country_id": {
               "type": "string",
@@ -4150,11 +7230,31 @@
             },
             "dependency": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "dependency_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "dependency_id": {
               "type": "string",
@@ -4163,11 +7263,31 @@
             },
             "marinearea": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "marinearea_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "marinearea_id": {
               "type": "string",
@@ -4176,11 +7296,31 @@
             },
             "macroregion": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macroregion_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macroregion_id": {
               "type": "string",
@@ -4189,11 +7329,31 @@
             },
             "region": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "region_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "region_id": {
               "type": "string",
@@ -4202,11 +7362,31 @@
             },
             "macrocounty": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macrocounty_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macrocounty_id": {
               "type": "string",
@@ -4215,11 +7395,31 @@
             },
             "county": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "county_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "county_id": {
               "type": "string",
@@ -4228,11 +7428,31 @@
             },
             "locality": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "locality_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "locality_id": {
               "type": "string",
@@ -4241,11 +7461,31 @@
             },
             "borough": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "borough_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "borough_id": {
               "type": "string",
@@ -4254,11 +7494,31 @@
             },
             "localadmin": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "localadmin_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "localadmin_id": {
               "type": "string",
@@ -4267,11 +7527,31 @@
             },
             "neighbourhood": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "neighbourhood_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "neighbourhood_id": {
               "type": "string",
@@ -4280,11 +7560,31 @@
             },
             "postalcode": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "postalcode_a": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "postalcode_id": {
               "type": "string",
@@ -4435,11 +7735,31 @@
           "properties": {
             "continent": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "continent_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "continent_id": {
               "type": "string",
@@ -4448,11 +7768,31 @@
             },
             "ocean": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "ocean_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "ocean_id": {
               "type": "string",
@@ -4461,11 +7801,31 @@
             },
             "empire": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "empire_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "empire_id": {
               "type": "string",
@@ -4474,11 +7834,31 @@
             },
             "country": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "country_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "country_id": {
               "type": "string",
@@ -4487,11 +7867,31 @@
             },
             "dependency": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "dependency_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "dependency_id": {
               "type": "string",
@@ -4500,11 +7900,31 @@
             },
             "marinearea": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "marinearea_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "marinearea_id": {
               "type": "string",
@@ -4513,11 +7933,31 @@
             },
             "macroregion": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macroregion_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macroregion_id": {
               "type": "string",
@@ -4526,11 +7966,31 @@
             },
             "region": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "region_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "region_id": {
               "type": "string",
@@ -4539,11 +7999,31 @@
             },
             "macrocounty": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macrocounty_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macrocounty_id": {
               "type": "string",
@@ -4552,11 +8032,31 @@
             },
             "county": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "county_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "county_id": {
               "type": "string",
@@ -4565,11 +8065,31 @@
             },
             "locality": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "locality_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "locality_id": {
               "type": "string",
@@ -4578,11 +8098,31 @@
             },
             "borough": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "borough_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "borough_id": {
               "type": "string",
@@ -4591,11 +8131,31 @@
             },
             "localadmin": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "localadmin_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "localadmin_id": {
               "type": "string",
@@ -4604,11 +8164,31 @@
             },
             "neighbourhood": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "neighbourhood_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "neighbourhood_id": {
               "type": "string",
@@ -4617,11 +8197,31 @@
             },
             "postalcode": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "postalcode_a": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "postalcode_id": {
               "type": "string",
@@ -4772,11 +8372,31 @@
           "properties": {
             "continent": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "continent_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "continent_id": {
               "type": "string",
@@ -4785,11 +8405,31 @@
             },
             "ocean": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "ocean_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "ocean_id": {
               "type": "string",
@@ -4798,11 +8438,31 @@
             },
             "empire": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "empire_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "empire_id": {
               "type": "string",
@@ -4811,11 +8471,31 @@
             },
             "country": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "country_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "country_id": {
               "type": "string",
@@ -4824,11 +8504,31 @@
             },
             "dependency": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "dependency_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "dependency_id": {
               "type": "string",
@@ -4837,11 +8537,31 @@
             },
             "marinearea": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "marinearea_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "marinearea_id": {
               "type": "string",
@@ -4850,11 +8570,31 @@
             },
             "macroregion": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macroregion_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macroregion_id": {
               "type": "string",
@@ -4863,11 +8603,31 @@
             },
             "region": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "region_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "region_id": {
               "type": "string",
@@ -4876,11 +8636,31 @@
             },
             "macrocounty": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macrocounty_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macrocounty_id": {
               "type": "string",
@@ -4889,11 +8669,31 @@
             },
             "county": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "county_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "county_id": {
               "type": "string",
@@ -4902,11 +8702,31 @@
             },
             "locality": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "locality_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "locality_id": {
               "type": "string",
@@ -4915,11 +8735,31 @@
             },
             "borough": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "borough_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "borough_id": {
               "type": "string",
@@ -4928,11 +8768,31 @@
             },
             "localadmin": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "localadmin_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "localadmin_id": {
               "type": "string",
@@ -4941,11 +8801,31 @@
             },
             "neighbourhood": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "neighbourhood_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "neighbourhood_id": {
               "type": "string",
@@ -4954,11 +8834,31 @@
             },
             "postalcode": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "postalcode_a": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "postalcode_id": {
               "type": "string",
@@ -5109,11 +9009,31 @@
           "properties": {
             "continent": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "continent_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "continent_id": {
               "type": "string",
@@ -5122,11 +9042,31 @@
             },
             "ocean": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "ocean_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "ocean_id": {
               "type": "string",
@@ -5135,11 +9075,31 @@
             },
             "empire": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "empire_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "empire_id": {
               "type": "string",
@@ -5148,11 +9108,31 @@
             },
             "country": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "country_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "country_id": {
               "type": "string",
@@ -5161,11 +9141,31 @@
             },
             "dependency": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "dependency_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "dependency_id": {
               "type": "string",
@@ -5174,11 +9174,31 @@
             },
             "marinearea": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "marinearea_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "marinearea_id": {
               "type": "string",
@@ -5187,11 +9207,31 @@
             },
             "macroregion": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macroregion_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macroregion_id": {
               "type": "string",
@@ -5200,11 +9240,31 @@
             },
             "region": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "region_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "region_id": {
               "type": "string",
@@ -5213,11 +9273,31 @@
             },
             "macrocounty": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macrocounty_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macrocounty_id": {
               "type": "string",
@@ -5226,11 +9306,31 @@
             },
             "county": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "county_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "county_id": {
               "type": "string",
@@ -5239,11 +9339,31 @@
             },
             "locality": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "locality_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "locality_id": {
               "type": "string",
@@ -5252,11 +9372,31 @@
             },
             "borough": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "borough_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "borough_id": {
               "type": "string",
@@ -5265,11 +9405,31 @@
             },
             "localadmin": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "localadmin_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "localadmin_id": {
               "type": "string",
@@ -5278,11 +9438,31 @@
             },
             "neighbourhood": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "neighbourhood_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "neighbourhood_id": {
               "type": "string",
@@ -5291,11 +9471,31 @@
             },
             "postalcode": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "postalcode_a": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "postalcode_id": {
               "type": "string",
@@ -5446,11 +9646,31 @@
           "properties": {
             "continent": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "continent_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "continent_id": {
               "type": "string",
@@ -5459,11 +9679,31 @@
             },
             "ocean": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "ocean_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "ocean_id": {
               "type": "string",
@@ -5472,11 +9712,31 @@
             },
             "empire": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "empire_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "empire_id": {
               "type": "string",
@@ -5485,11 +9745,31 @@
             },
             "country": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "country_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "country_id": {
               "type": "string",
@@ -5498,11 +9778,31 @@
             },
             "dependency": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "dependency_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "dependency_id": {
               "type": "string",
@@ -5511,11 +9811,31 @@
             },
             "marinearea": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "marinearea_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "marinearea_id": {
               "type": "string",
@@ -5524,11 +9844,31 @@
             },
             "macroregion": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macroregion_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macroregion_id": {
               "type": "string",
@@ -5537,11 +9877,31 @@
             },
             "region": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "region_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "region_id": {
               "type": "string",
@@ -5550,11 +9910,31 @@
             },
             "macrocounty": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macrocounty_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "macrocounty_id": {
               "type": "string",
@@ -5563,11 +9943,31 @@
             },
             "county": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "county_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "county_id": {
               "type": "string",
@@ -5576,11 +9976,31 @@
             },
             "locality": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "locality_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "locality_id": {
               "type": "string",
@@ -5589,11 +10009,31 @@
             },
             "borough": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "borough_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "borough_id": {
               "type": "string",
@@ -5602,11 +10042,31 @@
             },
             "localadmin": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "localadmin_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "localadmin_id": {
               "type": "string",
@@ -5615,11 +10075,31 @@
             },
             "neighbourhood": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "neighbourhood_a": {
               "type": "string",
-              "analyzer": "peliasAdmin"
+              "analyzer": "peliasAdmin",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "neighbourhood_id": {
               "type": "string",
@@ -5628,11 +10108,31 @@
             },
             "postalcode": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "postalcode_a": {
               "type": "string",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "fields": {
+                "ngram": {
+                  "type": "string",
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "doc_values": false,
+                  "fielddata": {
+                    "format": "disabled"
+                  }
+                }
+              }
             },
             "postalcode_id": {
               "type": "string",


### PR DESCRIPTION
This PR is a replacement for https://github.com/pelias/schema/pull/345 which uses the [multi-fields](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/multi-fields.html) feature of elasticsearch in order to achieve the same thing but using less HDD space.

See linked PR for original issue notes and comments.

Closes https://github.com/pelias/schema/pull/345

 