### PR TITLE
update Germanic street suffix synonyms

### DIFF
--- a/integration/analyzer_peliasPhrase.js
+++ b/integration/analyzer_peliasPhrase.js
@@ -67,7 +67,7 @@ module.exports.tests.functional = function(test, common){
     ]);
 
     assertAnalysis( 'address', '101 geocode pl', [
-      '0:101', '1:geocode', '2:pl', '2:place'
+      '0:101', '1:geocode', '2:pl', '2:place', '2:platz'
     ], true);
 
     // both terms should map to same tokens

--- a/integration/analyzer_peliasStreet.js
+++ b/integration/analyzer_peliasStreet.js
@@ -196,6 +196,28 @@ module.exports.tests.unicode = function(test, common){
   });
 };
 
+module.exports.tests.germanic_street_suffixes = function (test, common) {
+  test('germanic_street_suffixes', function (t) {
+
+    var suite = new elastictest.Suite(common.clientOpts, { schema: schema });
+    var assertAnalysis = analyze.bind(null, suite, t, 'peliasStreet');
+    suite.action(function (done) { setTimeout(done, 500); }); // wait for es to bring some shards up
+
+    // Germanic street suffixes
+    assertAnalysis('straße', 'straße', ['0:strasse', '0:str'], true);
+    assertAnalysis('strasse', 'strasse', ['0:strasse', '0:str'], true);
+    assertAnalysis('str.', 'str.', ['0:str', '0:strasse'], true);
+    assertAnalysis('str', 'str', ['0:str', '0:strasse'], true);
+    assertAnalysis('brücke', 'brücke', [ '0:bruecke', '0:brucke', '0:br' ], true);
+    assertAnalysis('bruecke', 'bruecke', [ '0:bruecke', '0:brucke', '0:br' ], true);
+    assertAnalysis('brucke', 'brucke', ['0:brucke', '0:bruecke', '0:br'], true);
+    assertAnalysis('br.', 'br.', ['0:br', '0:branch', '0:bruecke', '0:brucke'], true);
+    assertAnalysis('br', 'br', ['0:br', '0:branch', '0:bruecke', '0:brucke'], true);
+
+    suite.run(t.end);
+  });
+};
+
 module.exports.all = function (tape, common) {
 
   function test(name, testFunction) {

--- a/synonyms/street_suffix.txt
+++ b/synonyms/street_suffix.txt
@@ -118,3 +118,12 @@ valley, vly
 vista, vis
 village, vlg
 way, wy
+
+# Germanic street suffixes
+straße => strasse, str
+strasse, str
+brücke => bruecke, brucke, br
+bruecke, brucke, br
+bahnhof, bhf, bf
+chaussee, ch
+platz, pl

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -471,7 +471,14 @@
             "valley,vly",
             "vista,vis",
             "village,vlg",
-            "way,wy"
+            "way,wy",
+            "straße => strasse,str",
+            "strasse,str",
+            "brücke => bruecke,brucke,br",
+            "bruecke,brucke,br",
+            "bahnhof,bhf,bf",
+            "chaussee,ch",
+            "platz,pl"
           ]
         },
         "partial_token_address_suffix_expansion": {

--- a/test/settings.js
+++ b/test/settings.js
@@ -320,7 +320,7 @@ module.exports.tests.streetSynonymFilter = function(test, common) {
     var filter = s.analysis.filter.street_suffix;
     t.equal(filter.type, 'synonym');
     t.true(Array.isArray(filter.synonyms));
-    t.equal(filter.synonyms.length, 120);
+    t.equal(filter.synonyms.length, 127);
     t.end();
   });
 };


### PR DESCRIPTION
A user reported that `Aufderhöher Str` is not synonymous with `Aufderhöher Straße` and `Aufderhöher Strasse`.
This PR adds street suffix synonyms for common Germanic street names.

It doesn't handle contracted and expanded version of compound words as per `Aufderhöherstr.` or `Aufderhöherstraße`.