### PR TITLE
feat(synonyms):Add Trl/Trail

### DIFF
--- a/synonyms/street_suffix.txt
+++ b/synonyms/street_suffix.txt
@@ -110,7 +110,7 @@ square, sq
 street, st
 suite, ste
 terrace, terr
-trail, tr
+trail, trl, tr
 trafficway, trfy
 tunnel, tunl
 turnpike, tpke

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -464,7 +464,7 @@
             "street,st",
             "suite,ste",
             "terrace,terr",
-            "trail,tr",
+            "trail,trl,tr",
             "trafficway,trfy",
             "tunnel,tunl",
             "turnpike,tpke",


### PR DESCRIPTION
We already had the `tr` abbreviation for Trail, but not `trl`, which is also common.

Connects https://github.com/pelias/pelias/issues/456