### PR TITLE
unique token filter bugfix

### DIFF
--- a/integration/analyzer_peliasPhrase.js
+++ b/integration/analyzer_peliasPhrase.js
@@ -24,7 +24,7 @@ module.exports.tests.analyze = function(test, common){
     assertAnalysis( 'stop_words (disabled)', 'a st b ave c', ['0:a', '1:st', '1:street', '2:b', '3:ave', '3:avenue', '3:av', '4:c'], true );
     assertAnalysis( 'ampersand', 'a and b', ['a','&','b'] );
     assertAnalysis( 'ampersand', 'a & b', ['a','&','b'] );
-    assertAnalysis( 'ampersand', 'a and & and b', ['a','&','b'] );
+    assertAnalysis( 'ampersand', 'a and & and b', ['a','&','&','&','b'] );
     assertAnalysis( 'ampersand', 'land', ['land'] ); // should not replace inside tokens
 
     // @todo: handle multiple consecutive 'and'
@@ -35,7 +35,7 @@ module.exports.tests.analyze = function(test, common){
     assertAnalysis( 'no kstem', 'peoples', ['peoples'] );
 
     assertAnalysis( 'peliasShinglesFilter', '1 a ab abc abcdefghijk', ['1','a','ab','abc','abcdefghijk'] );
-    assertAnalysis( 'unique', '1 1 1', ['1'] );
+    assertAnalysis( 'unique', '1 1 1', ['1','1','1'] );
     assertAnalysis( 'notnull', ' ^ ', [] );
 
     assertAnalysis( 'stem street suffixes', 'streets avenue', ['0:streets', '1:avenue', '1:ave', '1:av'], true );

--- a/integration/analyzer_peliasQueryFullToken.js
+++ b/integration/analyzer_peliasQueryFullToken.js
@@ -23,7 +23,7 @@ module.exports.tests.analyze = function(test, common){
     assertAnalysis( 'trim', ' f ', ['f'] );
     assertAnalysis( 'ampersand', 'a and b', ['a','&','b'] );
     assertAnalysis( 'ampersand', 'a & b', ['a','&','b'] );
-    assertAnalysis( 'ampersand', 'a and & and b', ['a','&','b'] );
+    assertAnalysis( 'ampersand', 'a and & and b', ['a','&','&','&','b'] );
     assertAnalysis( 'ampersand', 'land', ['land'] ); // should not replace inside tokens
 
     assertAnalysis( 'keyword_street_suffix', 'foo Street', ['foo', 'street', 'st'] );
@@ -35,7 +35,7 @@ module.exports.tests.analyze = function(test, common){
 
     assertAnalysis( 'peliasQueryFullTokenFilter', '1 a ab abc abcdefghij', ['1','a','ab','abc','abcdefghij'] );
     assertAnalysis( 'removeAllZeroNumericPrefix', '00001', ['1'] );
-    assertAnalysis( 'unique', '1 1 1', ['1'] );
+    assertAnalysis( 'unique', '1 1 1', ['1','1','1'] );
     assertAnalysis( 'notnull', ' / / ', [] );
 
     assertAnalysis( 'no kstem', 'mcdonalds', ['mcdonalds'] );

--- a/integration/analyzer_peliasQueryPartialToken.js
+++ b/integration/analyzer_peliasQueryPartialToken.js
@@ -23,7 +23,7 @@ module.exports.tests.analyze = function(test, common){
     assertAnalysis( 'trim', ' f ', ['f'] );
     assertAnalysis( 'ampersand', 'a and b', ['a','&','b'] );
     assertAnalysis( 'ampersand', 'a & b', ['a','&','b'] );
-    assertAnalysis( 'ampersand', 'a and & and b', ['a','&','b'] );
+    assertAnalysis( 'ampersand', 'a and & and b', ['a','&','&','&','b'] );
     assertAnalysis( 'ampersand', 'land', ['land'] ); // should not replace inside tokens
 
     // partial_token_address_suffix_expansion
@@ -32,7 +32,7 @@ module.exports.tests.analyze = function(test, common){
 
     assertAnalysis( 'peliasQueryPartialTokenFilter', '1 a ab abc abcdefghij', ['1','a','ab','abc','abcdefghij'] );
     assertAnalysis( 'removeAllZeroNumericPrefix', '00001', ['1'] );
-    assertAnalysis( 'unique', '1 1 1', ['1'] );
+    assertAnalysis( 'unique', '1 1 1', ['1','1','1'] );
     assertAnalysis( 'notnull', ' / / ', [] );
 
     assertAnalysis( 'no kstem', 'mcdonalds', ['mcdonalds'] );

--- a/settings.js
+++ b/settings.js
@@ -71,7 +71,7 @@ function generate(){
             "peliasOneEdgeGramFilter",
             "eliminate_tokens_starting_with_word_marker",
             "remove_encapsulating_word_markers",
-            "unique",
+            "unique_only_same_position",
             "notnull"
           ]
         },
@@ -87,7 +87,7 @@ function generate(){
             "ampersand",
             "remove_ordinals",
             "removeAllZeroNumericPrefix",
-            "unique",
+            "unique_only_same_position",
             "notnull"
           ]
         },
@@ -104,7 +104,7 @@ function generate(){
             "directionals",
             "ampersand",
             "removeAllZeroNumericPrefix",
-            "unique",
+            "unique_only_same_position",
             "notnull"
           ]
         },
@@ -122,7 +122,7 @@ function generate(){
             "directionals",
             "icu_folding",
             "remove_ordinals",
-            "unique",
+            "unique_only_same_position",
             "notnull"
           ]
         },
@@ -170,6 +170,10 @@ function generate(){
         "notnull" :{
           "type" : "length",
           "min" : 1
+        },
+        "unique_only_same_position": {
+          "type": "unique",
+          "only_on_same_position": "true"
         },
         "peliasOneEdgeGramFilter": {
           "type" : "edgeNGram",

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -52,7 +52,7 @@
             "peliasOneEdgeGramFilter",
             "eliminate_tokens_starting_with_word_marker",
             "remove_encapsulating_word_markers",
-            "unique",
+            "unique_only_same_position",
             "notnull"
           ]
         },
@@ -71,7 +71,7 @@
             "ampersand",
             "remove_ordinals",
             "removeAllZeroNumericPrefix",
-            "unique",
+            "unique_only_same_position",
             "notnull"
           ]
         },
@@ -91,7 +91,7 @@
             "directionals",
             "ampersand",
             "removeAllZeroNumericPrefix",
-            "unique",
+            "unique_only_same_position",
             "notnull"
           ]
         },
@@ -112,7 +112,7 @@
             "directionals",
             "icu_folding",
             "remove_ordinals",
-            "unique",
+            "unique_only_same_position",
             "notnull"
           ]
         },
@@ -335,6 +335,10 @@
         "notnull": {
           "type": "length",
           "min": 1
+        },
+        "unique_only_same_position": {
+          "type": "unique",
+          "only_on_same_position": "true"
         },
         "peliasOneEdgeGramFilter": {
           "type": "edgeNGram",

--- a/test/settings.js
+++ b/test/settings.js
@@ -94,7 +94,7 @@ module.exports.tests.peliasIndexOneEdgeGramAnalyzer = function(test, common) {
       "peliasOneEdgeGramFilter",
       "eliminate_tokens_starting_with_word_marker",
       "remove_encapsulating_word_markers",
-      "unique",
+      "unique_only_same_position",
       "notnull"
     ]);
     t.end();
@@ -123,7 +123,7 @@ module.exports.tests.peliasQueryFullTokenAnalyzer = function (test, common) {
       "directionals",
       "ampersand",
       "removeAllZeroNumericPrefix",
-      "unique",
+      "unique_only_same_position",
       "notnull"
     ]);
     t.end();
@@ -153,7 +153,7 @@ module.exports.tests.peliasPhraseAnalyzer = function(test, common) {
       "directionals",
       "icu_folding",
       "remove_ordinals",
-      "unique",
+      "unique_only_same_position",
       "notnull"
     ]);
     t.end();


### PR DESCRIPTION
I discovered a bug today which can cause `match_phrase` queries to fail in certain situations.

I was investigating the query `SE 23rd Ave & SE Madison St` and discovered that the `unique` token filter was stripping the first `SE` token, and since the second `SE` token position was too far away according to the `slop` value, it failed to match the input `23rd Ave & SE Madison St`.

A simplified example is something like this (with token positions shown):
```
input: 'A AB'

['0:A', '0:AB'] // before
['0:A', '1:A', '1:AB'] // after
```

The first 'A' ngram would be removed and also the other token positions would be incorrect as a result!

I'm not sure about the full extent of how many queries this affects but I suspect it causes jitter issues.
Only `phrase` type queries are affected and it's only really relevant for `ngram` analysis.

This PR switches all analyzers to use a new `unique_only_same_position` filter which uses the `only_on_same_position` option.

~~I kind of regret it (because the PR is harder to read), but I also changed the way the tests are run to remove duplication in the test code, so it added some noise to this PR.~~