### PR TITLE
Improved ampersand support

### DIFF
--- a/integration/analyzer_peliasIndexOneEdgeGram.js
+++ b/integration/analyzer_peliasIndexOneEdgeGram.js
@@ -21,9 +21,23 @@ module.exports.tests.analyze = function(test, common){
     assertAnalysis( 'asciifolding', 'ł', ['l']);
     assertAnalysis( 'asciifolding', 'ɰ', ['m']);
     assertAnalysis( 'trim', ' f ', ['f'] );
-    assertAnalysis( 'ampersand', 'a and b', ['a','&','b'] );
-    assertAnalysis( 'ampersand', 'a & b', ['a','&','b'] );
-    assertAnalysis( 'ampersand', 'a and & and b', ['a','&','&','&','b'] );
+    assertAnalysis( 'ampersand', 'a and b', [
+      '0:a',
+      '1:a', '1:an', '1:and', '1:&',
+      '2:b'
+    ], true );
+    assertAnalysis( 'ampersand', 'a & b', [
+      '0:a',
+      '1:&', '1:a', '1:an', '1:and', '1:u', '1:un', '1:und',
+      '2:b'
+    ], true );
+    assertAnalysis( 'ampersand', 'a and & and b', [
+      '0:a',
+      '1:a', '1:an', '1:and', '1:&',
+      '2:&', '2:a', '2:an', '2:and', '2:u', '2:un', '2:und',
+      '3:a', '3:an', '3:and', '3:&',
+      '4:b'
+    ], true );
     assertAnalysis( 'ampersand', 'land', ['l','la','lan','land'] ); // should not replace inside tokens
 
     // keyword_street_suffix
@@ -121,8 +135,9 @@ module.exports.tests.functional = function(test, common){
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     assertAnalysis( 'country', 'Trinidad and Tobago', [
-      't', 'tr', 'tri', 'trin', 'trini', 'trinid', 'trinida', 'trinidad', 
-      '&', 't', 'to', 'tob', 'toba', 'tobag', 'tobago'
+      't', 'tr', 'tri', 'trin', 'trini', 'trinid', 'trinida', 'trinidad',
+      'a', 'an', 'and', '&',
+      't', 'to', 'tob', 'toba', 'tobag', 'tobago'
     ]);
 
     assertAnalysis( 'place', 'Toys "R" Us!', [

--- a/integration/analyzer_peliasPhrase.js
+++ b/integration/analyzer_peliasPhrase.js
@@ -22,9 +22,9 @@ module.exports.tests.analyze = function(test, common){
     assertAnalysis( 'asciifolding', 'ɰ', ['m']);
     assertAnalysis( 'trim', ' f ', ['f'] );
     assertAnalysis( 'stop_words (disabled)', 'a st b ave c', ['0:a', '1:st', '1:street', '2:b', '3:ave', '3:avenue', '3:av', '4:c'], true );
-    assertAnalysis( 'ampersand', 'a and b', ['a','&','b'] );
-    assertAnalysis( 'ampersand', 'a & b', ['a','&','b'] );
-    assertAnalysis( 'ampersand', 'a and & and b', ['a','&','&','&','b'] );
+    assertAnalysis( 'ampersand', 'a and b', ['a', 'and', '&', 'b']);
+    assertAnalysis( 'ampersand', 'a & b', ['a', '&', 'and', 'und', 'b']);
+    assertAnalysis( 'ampersand', 'a and & and b', ['a', 'and', '&', '&', 'and', 'und', 'and', '&', 'b']);
     assertAnalysis( 'ampersand', 'land', ['land'] ); // should not replace inside tokens
 
     // @todo: handle multiple consecutive 'and'
@@ -60,8 +60,8 @@ module.exports.tests.functional = function(test, common){
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     assertAnalysis( 'country', 'Trinidad and Tobago', [
-      'trinidad', '&', 'tobago'
-    ]);
+      '0:trinidad', '1:and', '1:&', '2:tobago'
+    ], true);
 
     assertAnalysis( 'place', 'Toys "R" Us!', [
       'toys', 'r', 'us'

--- a/integration/analyzer_peliasQueryFullToken.js
+++ b/integration/analyzer_peliasQueryFullToken.js
@@ -27,7 +27,7 @@ module.exports.tests.analyze = function(test, common){
     assertAnalysis( 'ampersand', 'land', ['land'] ); // should not replace inside tokens
 
     assertAnalysis( 'keyword_street_suffix', 'foo Street', ['foo', 'street', 'st'] );
-    assertAnalysis( 'keyword_street_suffix', 'foo Road', ['foo', 'road', 'rd']);
+    assertAnalysis( 'keyword_street_suffix', 'foo Road', ['foo', 'road', 'rd'] );
     assertAnalysis( 'keyword_street_suffix', 'foo Crescent', ['foo', 'crescent', 'cres'] );
     assertAnalysis( 'keyword_compass', 'north foo', ['north', 'n', 'foo'] );
     assertAnalysis( 'keyword_compass', 'SouthWest foo', ['southwest', 'sw', 'foo'] );

--- a/integration/analyzer_peliasQueryFullToken.js
+++ b/integration/analyzer_peliasQueryFullToken.js
@@ -21,9 +21,9 @@ module.exports.tests.analyze = function(test, common){
     assertAnalysis( 'asciifolding', 'ł', ['l']);
     assertAnalysis( 'asciifolding', 'ɰ', ['m']);
     assertAnalysis( 'trim', ' f ', ['f'] );
-    assertAnalysis( 'ampersand', 'a and b', ['a','&','b'] );
-    assertAnalysis( 'ampersand', 'a & b', ['a','&','b'] );
-    assertAnalysis( 'ampersand', 'a and & and b', ['a','&','&','&','b'] );
+    assertAnalysis('ampersand', 'a and b', ['a', 'and', '&', 'b']);
+    assertAnalysis('ampersand', 'a & b', ['a', '&', 'and', 'und', 'b']);
+    assertAnalysis('ampersand', 'a and & and b', ['a', 'and', '&', '&', 'and', 'und', 'and', '&', 'b']);
     assertAnalysis( 'ampersand', 'land', ['land'] ); // should not replace inside tokens
 
     assertAnalysis( 'keyword_street_suffix', 'foo Street', ['foo', 'street', 'st'] );
@@ -95,8 +95,8 @@ module.exports.tests.functional = function(test, common){
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     assertAnalysis( 'country', 'Trinidad and Tobago', [
-      'trinidad', '&', 'tobago'
-    ]);
+      '0:trinidad', '1:and', '1:&', '2:tobago'
+    ], true);
 
     assertAnalysis( 'place', 'Toys "R" Us!', [
       'toys', 'r', 'us'

--- a/integration/analyzer_peliasQueryPartialToken.js
+++ b/integration/analyzer_peliasQueryPartialToken.js
@@ -21,9 +21,9 @@ module.exports.tests.analyze = function(test, common){
     assertAnalysis( 'asciifolding', 'ł', ['l']);
     assertAnalysis( 'asciifolding', 'ɰ', ['m']);
     assertAnalysis( 'trim', ' f ', ['f'] );
-    assertAnalysis( 'ampersand', 'a and b', ['a','&','b'] );
-    assertAnalysis( 'ampersand', 'a & b', ['a','&','b'] );
-    assertAnalysis( 'ampersand', 'a and & and b', ['a','&','&','&','b'] );
+    assertAnalysis( 'ampersand', 'a and b', ['a','and','&','b'] );
+    assertAnalysis( 'ampersand', 'a & b', ['a','&','and','und','b'] );
+    assertAnalysis( 'ampersand', 'a and & and b', ['a','and','&','&','and','und','and','&','b'] );
     assertAnalysis( 'ampersand', 'land', ['land'] ); // should not replace inside tokens
 
     // partial_token_address_suffix_expansion
@@ -90,7 +90,7 @@ module.exports.tests.functional = function(test, common){
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasQueryPartialToken' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
-    assertAnalysis( 'country', 'Trinidad and Tobago', [ 'trinidad', '&', 'tobago' ]);
+    assertAnalysis( 'country', 'Trinidad and Tobago', [ '0:trinidad', '1:and', '1:&', '2:tobago' ], true);
     assertAnalysis( 'place', 'Toys "R" Us!', [ 'toys', 'r', 'us' ]);
     assertAnalysis( 'address', '101 mapzen place', [ '101', 'mapzen', 'place' ]);
 

--- a/synonyms/ampersand.txt
+++ b/synonyms/ampersand.txt
@@ -1,1 +1,22 @@
-and => &
+# It seems that ampersand is not used much outside of Western European languages
+# with the exception of business names such as 'Johnson & Johnson'.
+# In most European languages other than the Germanic ones and French,
+# the 'and' word is one letter long (y, i, e, a),
+# so no need for an abbreviation made itself felt in the first place.
+# Catalan: i
+# Danish: og
+# German: und
+# English: and
+# Spanish: y
+# French: et
+# Italian: e
+# Dutch: en
+# Norwegian: og
+# Portuguese: e
+# Swedish: och
+
+# English
+&,and
+
+# German
+&,und

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -329,7 +329,8 @@
         "ampersand": {
           "type": "synonym",
           "synonyms": [
-            "and => &"
+            "&,and",
+            "&,und"
           ]
         },
         "notnull": {

--- a/test/settings.js
+++ b/test/settings.js
@@ -297,7 +297,10 @@ module.exports.tests.ampersandFilter = function(test, common) {
     t.equal(typeof s.analysis.filter.ampersand, 'object', 'there is a ampersand filter');
     var filter = s.analysis.filter.ampersand;
     t.equal(filter.type, 'synonym');
-    t.deepEqual(filter.synonyms, [ "and => &" ]);
+    t.deepEqual(filter.synonyms, [
+      "&,and",
+      "&,und"
+    ]);
     t.end();
   });
 };


### PR DESCRIPTION
~~Branched from https://github.com/pelias/schema/pull/367, need to merge that PR first.~~

This PR improves how we support the ampersand symbol:
- Allow prefix ngrams to be produced, so that an input of `an` in autocomplete will match `&`
- Add support for German language

I did some investigation and it turns out that the ampersand symbol isn't as common internationally as I suspected.
For now, we support English and German but open to supporting more languages where required.

Resolves https://github.com/pelias/schema/issues/366

This is also the last 'old style' synonyms file which uses '=>' rather than ',' for substitutions 🎉 