### PR TITLE
Update schema for Elasticsearch 5 and 6 

### DIFF
--- a/bin/integration
+++ b/bin/integration
@@ -4,4 +4,4 @@
 # see https://github.com/pelias/pelias/issues/744
 set -o pipefail
 
-node --max-http-header-size=16384 integration/run.js | npx tap-spec
+node integration/run.js | npx tap-spec

--- a/integration/dynamic_templates.js
+++ b/integration/dynamic_templates.js
@@ -129,19 +129,12 @@ function addendumAssertion( type, namespace, value, common ){
         var addendumProperties = properties.addendum.properties;
 
         t.true([
-          'string', // elasticsearch 2.4
           'keyword' // elasticsearch 5.6
         ].includes( addendumProperties[namespace].type ));
 
         t.true([
-          'no', // elasticsearch 2.4
           false // elasticsearch 5.6
         ].includes( addendumProperties[namespace].index ));
-
-        // elasticsearch 2.4
-        if( addendumProperties[namespace].fielddata ){
-          t.equal( addendumProperties[namespace].fielddata.format, 'disabled' );
-        }
 
         // elasticsearch 5.6
         if( addendumProperties[namespace].doc_values ){

--- a/mappings/document.js
+++ b/mappings/document.js
@@ -2,16 +2,16 @@ const admin = require('./partial/admin');
 const postalcode = require('./partial/postalcode');
 const hash = require('./partial/hash');
 const multiplier = require('./partial/multiplier');
-const literal = require('./partial/literal');
-const literal_with_doc_values = require('./partial/literal_with_doc_values');
+const keyword = require('./partial/keyword');
+const keyword_with_doc_values = require('./partial/keyword_with_doc_values');
 const config = require('pelias-config').generate();
 
 var schema = {
   properties: {
 
     // data partitioning
-    source: literal_with_doc_values,
-    layer: literal_with_doc_values,
+    source: keyword_with_doc_values,
+    layer: keyword_with_doc_values,
 
     // place name (ngram analysis)
     name: hash,
@@ -25,27 +25,27 @@ var schema = {
       dynamic: 'strict',
       properties: {
         name: {
-          type: 'string',
+          type: 'text',
           analyzer: 'keyword',
         },
         unit: {
-          type: 'string',
+          type: 'text',
           analyzer: 'peliasUnit',
         },
         number: {
-          type: 'string',
+          type: 'text',
           analyzer: 'peliasHousenumber',
         },
         street: {
-          type: 'string',
+          type: 'text',
           analyzer: 'peliasStreet',
         },
         cross_street: {
-          type: 'string',
+          type: 'text',
           analyzer: 'peliasStreet',
         },
         zip: {
-          type: 'string',
+          type: 'text',
           analyzer: 'peliasZip',
         },
       }
@@ -59,77 +59,77 @@ var schema = {
         // https://github.com/whosonfirst/whosonfirst-placetypes#continent
         continent: admin,
         continent_a: admin,
-        continent_id: literal,
+        continent_id: keyword,
 
         // https://github.com/whosonfirst/whosonfirst-placetypes#ocean
         ocean: admin,
         ocean_a: admin,
-        ocean_id: literal,
+        ocean_id: keyword,
 
         // https://github.com/whosonfirst/whosonfirst-placetypes#empire
         empire: admin,
         empire_a: admin,
-        empire_id: literal,
+        empire_id: keyword,
 
         // https://github.com/whosonfirst/whosonfirst-placetypes#country
         country: admin,
         country_a: admin,
-        country_id: literal,
+        country_id: keyword,
 
         // https://github.com/whosonfirst/whosonfirst-placetypes#dependency
         dependency: admin,
         dependency_a: admin,
-        dependency_id: literal,
+        dependency_id: keyword,
 
         // https://github.com/whosonfirst/whosonfirst-placetypes#marinearea
         marinearea: admin,
         marinearea_a: admin,
-        marinearea_id: literal,
+        marinearea_id: keyword,
 
         // https://github.com/whosonfirst/whosonfirst-placetypes#macroregion
         macroregion: admin,
         macroregion_a: admin,
-        macroregion_id: literal,
+        macroregion_id: keyword,
 
         // https://github.com/whosonfirst/whosonfirst-placetypes#region
         region: admin,
         region_a: admin,
-        region_id: literal,
+        region_id: keyword,
 
         // https://github.com/whosonfirst/whosonfirst-placetypes#macrocounty
         macrocounty: admin,
         macrocounty_a: admin,
-        macrocounty_id: literal,
+        macrocounty_id: keyword,
 
         // https://github.com/whosonfirst/whosonfirst-placetypes#county
         county: admin,
         county_a: admin,
-        county_id: literal,
+        county_id: keyword,
 
         // https://github.com/whosonfirst/whosonfirst-placetypes#locality
         locality: admin,
         locality_a: admin,
-        locality_id: literal,
+        locality_id: keyword,
 
         // https://github.com/whosonfirst/whosonfirst-placetypes#borough
         borough: admin,
         borough_a: admin,
-        borough_id: literal,
+        borough_id: keyword,
 
         // https://github.com/whosonfirst/whosonfirst-placetypes#localadmin
         localadmin: admin,
         localadmin_a: admin,
-        localadmin_id: literal,
+        localadmin_id: keyword,
 
         // https://github.com/whosonfirst/whosonfirst-placetypes#neighbourhood
         neighbourhood: admin,
         neighbourhood_a: admin,
-        neighbourhood_id: literal,
+        neighbourhood_id: keyword,
 
         // https://github.com/whosonfirst/whosonfirst-placetypes#postalcode
         postalcode: postalcode,
         postalcode_a: postalcode,
-        postalcode_id: literal
+        postalcode_id: keyword
       }
     },
 
@@ -139,8 +139,8 @@ var schema = {
     bounding_box: require('./partial/boundingbox'),
 
     // meta info
-    source_id: literal,
-    category: literal,
+    source_id: keyword,
+    category: keyword,
     population: multiplier,
     popularity: multiplier,
 
@@ -152,11 +152,8 @@ var schema = {
       path_match: 'name.*',
       match_mapping_type: 'string',
       mapping: {
-        type: 'string',
-        analyzer: 'peliasIndexOneEdgeGram',
-        fielddata : {
-          format: 'disabled'
-        }
+        type: 'text',
+        analyzer: 'peliasIndexOneEdgeGram'
       }
     },
   },{
@@ -164,11 +161,8 @@ var schema = {
       path_match: 'phrase.*',
       match_mapping_type: 'string',
       mapping: {
-        type: 'string',
-        analyzer: 'peliasPhrase',
-        fielddata : {
-          format: 'disabled'
-        }
+        type: 'text',
+        analyzer: 'peliasPhrase'
       }
     }
   },{
@@ -176,12 +170,9 @@ var schema = {
       path_match: 'addendum.*',
       match_mapping_type: 'string',
       mapping: {
-        type: 'string',
-        index: 'no',
-        doc_values: false,
-        fielddata : {
-          format: 'disabled'
-        }
+        type: 'keyword',
+        index: false,
+        doc_values: false
       }
     }
   }],

--- a/mappings/partial/admin.json
+++ b/mappings/partial/admin.json
@@ -1,14 +1,11 @@
 {
-  "type": "string",
+  "type": "text",
   "analyzer": "peliasAdmin",
   "fields": {
     "ngram": {
-      "type": "string",
+      "type": "text",
       "analyzer": "peliasIndexOneEdgeGram",
-      "doc_values": false,
-      "fielddata": {
-        "format": "disabled"
-      }
+      "doc_values": false
     }
   }
 }

--- a/mappings/partial/keyword.json
+++ b/mappings/partial/keyword.json
@@ -1,4 +1,4 @@
 {
   "type": "keyword",
-  "index": false
+  "doc_values": false
 }

--- a/mappings/partial/keyword_with_doc_values.json
+++ b/mappings/partial/keyword_with_doc_values.json
@@ -1,0 +1,3 @@
+{
+  "type": "keyword"
+}

--- a/mappings/partial/literal.json
+++ b/mappings/partial/literal.json
@@ -1,5 +1,0 @@
-{
-  "type": "string",
-  "index": "not_analyzed",
-  "doc_values": false
-}

--- a/mappings/partial/literal_with_doc_values.json
+++ b/mappings/partial/literal_with_doc_values.json
@@ -1,4 +1,0 @@
-{
-  "type": "string",
-  "index": "not_analyzed"
-}

--- a/mappings/partial/postalcode.json
+++ b/mappings/partial/postalcode.json
@@ -1,14 +1,10 @@
 {
-  "type": "string",
+  "type": "text",
   "analyzer": "peliasZip",
   "fields": {
     "ngram": {
-      "type": "string",
-      "analyzer": "peliasIndexOneEdgeGram",
-      "doc_values": false,
-      "fielddata": {
-        "format": "disabled"
-      }
+      "type": "text",
+      "analyzer": "peliasIndexOneEdgeGram"
     }
   }
 }

--- a/scripts/create_index.js
+++ b/scripts/create_index.js
@@ -18,20 +18,6 @@ try {
   process.exit(1);
 }
 
-if (http.maxHeaderSize === undefined) {
-  logger.warn('You are using a version of Node.js that does not support the --max-http-header-size option.' +
-    'You may experience issues when using Elasticsearch 5.' +
-    'See https://github.com/pelias/schema#compatibility for more details.');
-}
-
-if (http.maxHeaderSize < 16384) {
-  logger.error('Max header size is below 16384 bytes. ' +
-    'Be sure to use the provided wrapper script in \'./bin\' rather than calling this script directly.' +
-    'Otherwise, you may experience issues when using Elasticsearch 5.' +
-    'See https://github.com/pelias/schema#compatibility for more details.');
-  process.exit(1);
-}
-
 cli.header("create index");
 const indexName = config.schema.indexName;
 

--- a/test/compile.js
+++ b/test/compile.js
@@ -40,11 +40,8 @@ module.exports.tests.dynamic_templates = function(test, common) {
     t.equal(template.path_match, 'name.*');
     t.equal(template.match_mapping_type, 'string');
     t.deepEqual(template.mapping, {
-      type: 'string',
-      analyzer: 'peliasIndexOneEdgeGram',
-      fielddata : {
-        format: "disabled"
-      }
+      type: 'text',
+      analyzer: 'peliasIndexOneEdgeGram'
     });
     t.end();
   });

--- a/test/document.js
+++ b/test/document.js
@@ -47,28 +47,28 @@ module.exports.tests.address_analysis = function(test, common) {
   // $name analysis is pretty basic, work can be done to improve this, although
   // at time of writing this field was not used by any API queries.
   test('name', function(t) {
-    t.equal(prop.name.type, 'string');
+    t.equal(prop.name.type, 'text');
     t.equal(prop.name.analyzer, 'keyword');
     t.end();
   });
 
   // $unit analysis
   test('unit', function(t) {
-    t.equal(prop.unit.type, 'string');
-    t.equal(prop.unit.analyzer, 'peliasUnit');
+    t.equal(prop.unit.type, 'text', 'unit has full text type');
+    t.equal(prop.unit.analyzer, 'peliasUnit', 'unit analyzer is peliasUnit');
     t.end();
   });
 
   // $number analysis is discussed in: https://github.com/pelias/schema/pull/77
   test('number', function(t) {
-    t.equal(prop.number.type, 'string');
+    t.equal(prop.number.type, 'text');
     t.equal(prop.number.analyzer, 'peliasHousenumber');
     t.end();
   });
 
   // $street analysis is discussed in: https://github.com/pelias/schema/pull/77
   test('street', function(t) {
-    t.equal(prop.street.type, 'string');
+    t.equal(prop.street.type, 'text');
     t.equal(prop.street.analyzer, 'peliasStreet');
     t.end();
   });
@@ -77,7 +77,7 @@ module.exports.tests.address_analysis = function(test, common) {
   // note: this is a poor name, it would be better to rename this field to a more
   // generic term such as $postalcode as it is not specific to the USA.
   test('zip', function(t) {
-    t.equal(prop.zip.type, 'string');
+    t.equal(prop.zip.type, 'text');
     t.equal(prop.zip.analyzer, 'peliasZip');
     t.end();
   });
@@ -121,28 +121,28 @@ module.exports.tests.parent_analysis = function(test, common) {
   ];
   fields.forEach( function( field ){
     test(field, function(t) {
-      t.equal(prop[field].type, 'string');
-      t.equal(prop[field].analyzer, 'peliasAdmin');
-      t.equal(prop[field+'_a'].type, 'string');
-      t.equal(prop[field+'_a'].analyzer, 'peliasAdmin');
-      t.equal(prop[field+'_id'].type, 'string');
-      t.equal(prop[field+'_id'].index, 'not_analyzed');
+      t.equal(prop[field].type, 'text', `${field} is set to text type`);
+      t.equal(prop[field].analyzer, 'peliasAdmin', `${field} analyzer is peliasAdmin`);
+      t.equal(prop[field+'_a'].type, 'text', `${field}_a type is text`);
+      t.equal(prop[field+'_a'].analyzer, 'peliasAdmin', `${field}_a analyzer is peliasAdmin`);
+      t.equal(prop[field+'_id'].type, 'keyword', `${field}_id type is keyword`);
+      t.equal(prop[field+'_id'].index, undefined, `${field}_id index left at default`);
 
       // subfields
-      t.equal(prop[field].fields.ngram.type, 'string');
-      t.equal(prop[field].fields.ngram.analyzer, 'peliasIndexOneEdgeGram');
+      t.equal(prop[field].fields.ngram.type, 'text', `${field}.ngram type is full text`);
+      t.equal(prop[field].fields.ngram.analyzer, 'peliasIndexOneEdgeGram', `${field}.ngram analyzer is peliasIndexOneEdgeGram`);
 
       t.end();
     });
   });
 
   test('postalcode', function(t) {
-    t.equal(prop['postalcode'].type, 'string');
-    t.equal(prop['postalcode'].analyzer, 'peliasZip');
-    t.equal(prop['postalcode'+'_a'].type, 'string');
-    t.equal(prop['postalcode'+'_a'].analyzer, 'peliasZip');
-    t.equal(prop['postalcode'+'_id'].type, 'string');
-    t.equal(prop['postalcode'+'_id'].index, 'not_analyzed');
+    t.equal(prop['postalcode'].type, 'text', 'postalcode is full text field');
+    t.equal(prop['postalcode'].analyzer, 'peliasZip', 'postalcode analyzer is peliasZip');
+    t.equal(prop['postalcode'+'_a'].type, 'text', 'postalcode_a is full text field');
+    t.equal(prop['postalcode'+'_a'].analyzer, 'peliasZip', 'postalcode_a analyzer is peliasZip');
+    t.equal(prop['postalcode'+'_id'].type, 'keyword', 'postalcode_id field is keyword type');
+    t.equal(prop['postalcode'+'_id'].index, undefined, 'postalcode_id index left at default');
 
     t.end();
   });
@@ -154,13 +154,9 @@ module.exports.tests.dynamic_templates = function(test, common) {
     var template = schema.dynamic_templates[0].nameGram;
     t.equal(template.path_match, 'name.*');
     t.equal(template.match_mapping_type, 'string');
-    t.deepEqual(template.mapping, {
-      type: 'string',
-      analyzer: 'peliasIndexOneEdgeGram',
-      fielddata : {
-        format: "disabled"
-      }
-    });
+    t.equal(template.mapping.type, 'text', 'set to full text type');
+    t.equal(template.mapping.fielddata, undefined, 'fielddata is left to default (disabled)');
+    t.equal(template.mapping.analyzer, 'peliasIndexOneEdgeGram', 'analyzer set');
     t.end();
   });
   test('dynamic_templates: phrase', function(t) {
@@ -168,13 +164,9 @@ module.exports.tests.dynamic_templates = function(test, common) {
     var template = schema.dynamic_templates[1].phrase;
     t.equal(template.path_match, 'phrase.*');
     t.equal(template.match_mapping_type, 'string');
-    t.deepEqual(template.mapping, {
-      type: 'string',
-      analyzer: 'peliasPhrase',
-      fielddata : {
-        format: "disabled"
-      }
-    });
+    t.equal(template.mapping.type, 'text', 'set to full text type');
+    t.equal(template.mapping.fielddata, undefined, 'fielddata is left to default (disabled)');
+    t.equal(template.mapping.analyzer, 'peliasPhrase', 'analyzer set');
     t.end();
   });
 };

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -183,6 +183,91 @@
         }
       },
       "filter": {
+        "notnull": {
+          "type": "length",
+          "min": 1
+        },
+        "unique_only_same_position": {
+          "type": "unique",
+          "only_on_same_position": "true"
+        },
+        "peliasOneEdgeGramFilter": {
+          "type": "edgeNGram",
+          "min_gram": 1,
+          "max_gram": 24
+        },
+        "peliasTwoEdgeGramFilter": {
+          "type": "edgeNGram",
+          "min_gram": 2,
+          "max_gram": 24
+        },
+        "removeAllZeroNumericPrefix": {
+          "type": "pattern_replace",
+          "pattern": "^(0*)",
+          "replacement": ""
+        },
+        "remove_ordinals": {
+          "type": "pattern_replace",
+          "pattern": "(?i)((^| )((1)st?|(2)nd?|(3)rd?|([4-9])th?)|(([0-9]*)(1[0-9])th?)|(([0-9]*[02-9])((1)st?|(2)nd?|(3)rd?|([04-9])th?))($| ))",
+          "replacement": "$2$4$5$6$7$9$10$12$14$15$16$17$18"
+        },
+        "remove_duplicate_spaces": {
+          "type": "pattern_replace",
+          "pattern": " +",
+          "replacement": " "
+        },
+        "surround_single_characters_with_word_markers": {
+          "description": "wraps single characters with markers, needed to protect valid single characters and not those extracted from house numbers (14a creates an 'a' token)",
+          "type": "pattern_replace",
+          "pattern": "^(.{1})$",
+          "replacement": "\u0002$1\u0003"
+        },
+        "house_number_word_delimiter": {
+          "description": "splits on letter-to-number transition and vice versa, splits 14a -> [14, 14a, a]",
+          "type": "word_delimiter",
+          "split_on_numerics": "true",
+          "preserve_original": "true"
+        },
+        "remove_single_characters": {
+          "description": "removes single characters created from house_number_word_delimiter, removes the letter portion of a house number",
+          "type": "length",
+          "min": 2
+        },
+        "surround_house_numbers_with_word_markers": {
+          "description": "surrounds house numbers with markers, needed to protect whole house numbers from elimination step after prefix n-gramming",
+          "type": "pattern_replace",
+          "pattern": "^([0-9]+[a-z]?)$",
+          "replacement": "\u0002$1\u0003"
+        },
+        "eliminate_tokens_starting_with_word_marker": {
+          "description": "remove tokens starting but not ending with markers, saves whole house numbers wrapped in markers",
+          "type": "pattern_replace",
+          "pattern": "^\u0002(.*[^\u0003])?$",
+          "replacement": ""
+        },
+        "remove_encapsulating_word_markers": {
+          "description": "extract the stuff between the markers, extract 14 from \u000214\u0003 since we're done the prefix n-gramming step",
+          "type": "pattern_replace",
+          "pattern": "^\u0002(.*)\u0003$",
+          "replacement": "$1"
+        },
+        "ampersand": {
+          "type": "synonym",
+          "synonyms": [
+            "&,and",
+            "&,und"
+          ]
+        },
+        "custom_admin": {
+          "type": "synonym",
+          "synonyms": [
+            "saint,st",
+            "sainte,ste",
+            "fort,ft",
+            "mount,mt",
+            "mont,mt"
+          ]
+        },
         "custom_name": {
           "type": "synonym",
           "synonyms": [
@@ -331,47 +416,123 @@
         },
         "custom_street": {
           "type": "synonym",
-          "synonyms": [""]
-        },
-        "custom_admin": {
-          "type": "synonym",
           "synonyms": [
-            "saint,st",
-            "sainte,ste",
-            "fort,ft",
-            "mount,mt",
-            "mont,mt"
+            ""
           ]
         },
-        "ampersand": {
+        "directionals": {
           "type": "synonym",
           "synonyms": [
-            "&,and",
-            "&,und"
+            "southwest,sw",
+            "southeast,se",
+            "northwest,nw",
+            "northeast,ne",
+            "north,n",
+            "south,s",
+            "east,e",
+            "west,w"
           ]
         },
-        "notnull": {
-          "type": "length",
-          "min": 1
-        },
-        "unique_only_same_position": {
-          "type": "unique",
-          "only_on_same_position": "true"
-        },
-        "peliasOneEdgeGramFilter": {
-          "type": "edgeNGram",
-          "min_gram": 1,
-          "max_gram": 24
-        },
-        "peliasTwoEdgeGramFilter": {
-          "type": "edgeNGram",
-          "min_gram": 2,
-          "max_gram": 24
-        },
-        "removeAllZeroNumericPrefix": {
-          "type": "pattern_replace",
-          "pattern": "^(0*)",
-          "replacement": ""
+        "partial_token_address_suffix_expansion": {
+          "type": "synonym",
+          "synonyms": [
+            "aly => alley",
+            "anx => annex",
+            "byu => bayou",
+            "bch => beach",
+            "bnd => bend",
+            "blf => bluff",
+            "blfs => bluffs",
+            "btm => bottom",
+            "blvd => boulevard",
+            "brg => bridge",
+            "brk => brook",
+            "cyn => canyon",
+            "cp => cape",
+            "cswy => causeway",
+            "ctr => center",
+            "chnnl => channel",
+            "clf => cliff",
+            "clb => club",
+            "cmn => common",
+            "cmns => commons",
+            "crse => course",
+            "cv => cove",
+            "crk => creek",
+            "crst => crest",
+            "xing => crossing",
+            "xrd => crossroad",
+            "xrds => crossroads",
+            "dl => dale",
+            "dm => dam",
+            "expy => expressway",
+            "fls => falls",
+            "fry => ferry",
+            "fld => field",
+            "flds => fields",
+            "flt => flat",
+            "flts => flats",
+            "frd => ford",
+            "frst => forest",
+            "frg => forge",
+            "frk => fork",
+            "frks => forks",
+            "fwy => freeway",
+            "gdn => garden",
+            "gdns => gardens",
+            "gtwy => gateway",
+            "gln => glenn",
+            "grn => green",
+            "grv => grove",
+            "hbr => harbor",
+            "hvn => haven",
+            "hts => heights",
+            "hwy => highway",
+            "hl => hill",
+            "hls => hills",
+            "holw => hollow",
+            "jct => junction",
+            "ky => key",
+            "kys => keys",
+            "knl => knoll",
+            "knls => knolls",
+            "lndg => landing",
+            "ln => lane",
+            "lgt => light",
+            "lgts => lights",
+            "lck => lock",
+            "lcks => locks",
+            "mnr => manor",
+            "mdw => meadow",
+            "mdws => meadows",
+            "ml => mill",
+            "mls => mills",
+            "mnt => mountain",
+            "mtwy => motorway",
+            "nck => neck",
+            "pkwy => parkway",
+            "psge => pasage",
+            "pne => pine",
+            "pnes => pines",
+            "plz => plaza",
+            "rnch => ranch",
+            "rdg => ridge",
+            "rdgs => ridges",
+            "rd => road",
+            "rte => route",
+            "shr => shore",
+            "shrs => shores",
+            "skwy => skyway",
+            "spg => spring",
+            "spgs => springs",
+            "ste => suite",
+            "trfy => trafficway",
+            "tunl => tunnel",
+            "tpke => turnpike",
+            "vly => valley",
+            "vlg => village",
+            "wy => way"
+          ]
         },
         "street_suffix": {
           "type": "synonym",
@@ -504,165 +665,6 @@
             "chaussee,ch",
             "platz,pl"
           ]
-        },
-        "partial_token_address_suffix_expansion": {
-          "type": "synonym",
-          "synonyms": [
-            "aly => alley",
-            "anx => annex",
-            "byu => bayou",
-            "bch => beach",
-            "bnd => bend",
-            "blf => bluff",
-            "blfs => bluffs",
-            "btm => bottom",
-            "blvd => boulevard",
-            "brg => bridge",
-            "brk => brook",
-            "cyn => canyon",
-            "cp => cape",
-            "cswy => causeway",
-            "ctr => center",
-            "chnnl => channel",
-            "clf => cliff",
-            "clb => club",
-            "cmn => common",
-            "cmns => commons",
-            "crse => course",
-            "cv => cove",
-            "crk => creek",
-            "crst => crest",
-            "xing => crossing",
-            "xrd => crossroad",
-            "xrds => crossroads",
-            "dl => dale",
-            "dm => dam",
-            "expy => expressway",
-            "fls => falls",
-            "fry => ferry",
-            "fld => field",
-            "flds => fields",
-            "flt => flat",
-            "flts => flats",
-            "frd => ford",
-            "frst => forest",
-            "frg => forge",
-            "frk => fork",
-            "frks => forks",
-            "fwy => freeway",
-            "gdn => garden",
-            "gdns => gardens",
-            "gtwy => gateway",
-            "gln => glenn",
-            "grn => green",
-            "grv => grove",
-            "hbr => harbor",
-            "hvn => haven",
-            "hts => heights",
-            "hwy => highway",
-            "hl => hill",
-            "hls => hills",
-            "holw => hollow",
-            "jct => junction",
-            "ky => key",
-            "kys => keys",
-            "knl => knoll",
-            "knls => knolls",
-            "lndg => landing",
-            "ln => lane",
-            "lgt => light",
-            "lgts => lights",
-            "lck => lock",
-            "lcks => locks",
-            "mnr => manor",
-            "mdw => meadow",
-            "mdws => meadows",
-            "ml => mill",
-            "mls => mills",
-            "mnt => mountain",
-            "mtwy => motorway",
-            "nck => neck",
-            "pkwy => parkway",
-            "psge => pasage",
-            "pne => pine",
-            "pnes => pines",
-            "plz => plaza",
-            "rnch => ranch",
-            "rdg => ridge",
-            "rdgs => ridges",
-            "rd => road",
-            "rte => route",
-            "shr => shore",
-            "shrs => shores",
-            "skwy => skyway",
-            "spg => spring",
-            "spgs => springs",
-            "ste => suite",
-            "trfy => trafficway",
-            "tunl => tunnel",
-            "tpke => turnpike",
-            "vly => valley",
-            "vlg => village",
-            "wy => way"
-          ]
-        },
-        "directionals": {
-          "type": "synonym",
-          "synonyms": [
-            "southwest,sw",
-            "southeast,se",
-            "northwest,nw",
-            "northeast,ne",
-            "north,n",
-            "south,s",
-            "east,e",
-            "west,w"
-          ]
-        },
-        "remove_ordinals": {
-          "type": "pattern_replace",
-          "pattern": "(?i)((^| )((1)st?|(2)nd?|(3)rd?|([4-9])th?)|(([0-9]*)(1[0-9])th?)|(([0-9]*[02-9])((1)st?|(2)nd?|(3)rd?|([04-9])th?))($| ))",
-          "replacement": "$2$4$5$6$7$9$10$12$14$15$16$17$18"
-        },
-        "remove_duplicate_spaces": {
-          "type": "pattern_replace",
-          "pattern": " +",
-          "replacement": " "
-        },
-        "surround_single_characters_with_word_markers": {
-          "description": "wraps single characters with markers, needed to protect valid single characters and not those extracted from house numbers (14a creates an 'a' token)",
-          "type": "pattern_replace",
-          "pattern": "^(.{1})$",
-          "replacement": "\u0002$1\u0003"
-        },
-        "house_number_word_delimiter": {
-          "description": "splits on letter-to-number transition and vice versa, splits 14a -> [14, 14a, a]",
-          "type": "word_delimiter",
-          "split_on_numerics": "true",
-          "preserve_original": "true"
-        },
-        "remove_single_characters": {
-          "description": "removes single characters created from house_number_word_delimiter, removes the letter portion of a house number",
-          "type": "length",
-          "min": 2
-        },
-        "surround_house_numbers_with_word_markers": {
-          "description": "surrounds house numbers with markers, needed to protect whole house numbers from elimination step after prefix n-gramming",
-          "type": "pattern_replace",
-          "pattern": "^([0-9]+[a-z]?)$",
-          "replacement": "\u0002$1\u0003"
-        },
-        "eliminate_tokens_starting_with_word_marker": {
-          "description": "remove tokens starting but not ending with markers, saves whole house numbers wrapped in markers",
-          "type": "pattern_replace",
-          "pattern": "^\u0002(.*[^\u0003])?$",
-          "replacement": ""
-        },
-        "remove_encapsulating_word_markers": {
-          "description": "extract the stuff between the markers, extract 14 from \u000214\u0003 since we're done the prefix n-gramming step",
-          "type": "pattern_replace",
-          "pattern": "^\u0002(.*)\u0003$",
-          "replacement": "$1"
         }
       },
       "char_filter": {
@@ -746,12 +748,10 @@
     "_default_": {
       "properties": {
         "source": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "keyword"
         },
         "layer": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "keyword"
         },
         "name": {
           "type": "object",
@@ -766,27 +766,27 @@
           "dynamic": "strict",
           "properties": {
             "name": {
-              "type": "string",
+              "type": "text",
               "analyzer": "keyword"
             },
             "unit": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasUnit"
             },
             "number": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasHousenumber"
             },
             "street": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasStreet"
             },
             "cross_street": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasStreet"
             },
             "zip": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip"
             }
           }
@@ -796,498 +796,391 @@
           "dynamic": "strict",
           "properties": {
             "continent": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "continent_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "continent_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "ocean": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "ocean_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "ocean_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "empire": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "empire_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "empire_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "country": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "country_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "country_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "dependency": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "dependency_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "dependency_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "marinearea": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "marinearea_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "marinearea_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "macroregion": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macroregion_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macroregion_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "region": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "region_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "region_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "macrocounty": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macrocounty_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macrocounty_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "county": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "county_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "county_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "locality": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "locality_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "locality_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "borough": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "borough_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "borough_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "localadmin": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "localadmin_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "localadmin_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "neighbourhood": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "neighbourhood_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "neighbourhood_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "postalcode": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip",
               "fields": {
                 "ngram": {
-                  "type": "string",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "type": "text",
+                  "analyzer": "peliasIndexOneEdgeGram"
                 }
               }
             },
             "postalcode_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip",
               "fields": {
                 "ngram": {
-                  "type": "string",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "type": "text",
+                  "analyzer": "peliasIndexOneEdgeGram"
                 }
               }
             },
             "postalcode_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             }
           }
@@ -1301,17 +1194,15 @@
           "tree_levels": "20"
         },
         "bounding_box": {
-          "type": "string",
-          "index": "no"
+          "type": "keyword",
+          "index": false
         },
         "source_id": {
-          "type": "string",
-          "index": "not_analyzed",
+          "type": "keyword",
           "doc_values": false
         },
         "category": {
-          "type": "string",
-          "index": "not_analyzed",
+          "type": "keyword",
           "doc_values": false
         },
         "population": {
@@ -1333,11 +1224,8 @@
             "path_match": "name.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
-              "analyzer": "peliasIndexOneEdgeGram",
-              "fielddata": {
-                "format": "disabled"
-              }
+              "type": "text",
+              "analyzer": "peliasIndexOneEdgeGram"
             }
           }
         },
@@ -1346,11 +1234,8 @@
             "path_match": "phrase.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
-              "analyzer": "peliasPhrase",
-              "fielddata": {
-                "format": "disabled"
-              }
+              "type": "text",
+              "analyzer": "peliasPhrase"
             }
           }
         },
@@ -1359,12 +1244,9 @@
             "path_match": "addendum.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
+              "type": "keyword",
               "index": "no",
-              "doc_values": false,
-              "fielddata" : {
-                "format": "disabled"
-              }
+              "doc_values": false
             }
           }
         }
@@ -1383,12 +1265,10 @@
     "venue": {
       "properties": {
         "source": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "keyword"
         },
         "layer": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "keyword"
         },
         "name": {
           "type": "object",
@@ -1403,27 +1283,27 @@
           "dynamic": "strict",
           "properties": {
             "name": {
-              "type": "string",
+              "type": "text",
               "analyzer": "keyword"
             },
             "unit": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasUnit"
             },
             "number": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasHousenumber"
             },
             "street": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasStreet"
             },
             "cross_street": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasStreet"
             },
             "zip": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip"
             }
           }
@@ -1433,498 +1313,391 @@
           "dynamic": "strict",
           "properties": {
             "continent": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "continent_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "continent_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "ocean": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "ocean_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "ocean_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "empire": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "empire_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "empire_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "country": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "country_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "country_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "dependency": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "dependency_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "dependency_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "marinearea": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "marinearea_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "marinearea_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "macroregion": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macroregion_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macroregion_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "region": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "region_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "region_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "macrocounty": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macrocounty_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macrocounty_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "county": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "county_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "county_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "locality": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "locality_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "locality_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "borough": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "borough_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "borough_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "localadmin": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "localadmin_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "localadmin_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "neighbourhood": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "neighbourhood_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "neighbourhood_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "postalcode": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip",
               "fields": {
                 "ngram": {
-                  "type": "string",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "type": "text",
+                  "analyzer": "peliasIndexOneEdgeGram"
                 }
               }
             },
             "postalcode_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip",
               "fields": {
                 "ngram": {
-                  "type": "string",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "type": "text",
+                  "analyzer": "peliasIndexOneEdgeGram"
                 }
               }
             },
             "postalcode_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             }
           }
@@ -1938,17 +1711,15 @@
           "tree_levels": "20"
         },
         "bounding_box": {
-          "type": "string",
-          "index": "no"
+          "type": "keyword",
+          "index": false
         },
         "source_id": {
-          "type": "string",
-          "index": "not_analyzed",
+          "type": "keyword",
           "doc_values": false
         },
         "category": {
-          "type": "string",
-          "index": "not_analyzed",
+          "type": "keyword",
           "doc_values": false
         },
         "population": {
@@ -1970,11 +1741,8 @@
             "path_match": "name.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
-              "analyzer": "peliasIndexOneEdgeGram",
-              "fielddata": {
-                "format": "disabled"
-              }
+              "type": "text",
+              "analyzer": "peliasIndexOneEdgeGram"
             }
           }
         },
@@ -1983,11 +1751,8 @@
             "path_match": "phrase.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
-              "analyzer": "peliasPhrase",
-              "fielddata": {
-                "format": "disabled"
-              }
+              "type": "text",
+              "analyzer": "peliasPhrase"
             }
           }
         },
@@ -1996,12 +1761,9 @@
             "path_match": "addendum.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
+              "type": "keyword",
               "index": "no",
-              "doc_values": false,
-              "fielddata" : {
-                "format": "disabled"
-              }
+              "doc_values": false
             }
           }
         }
@@ -2020,12 +1782,10 @@
     "address": {
       "properties": {
         "source": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "keyword"
         },
         "layer": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "keyword"
         },
         "name": {
           "type": "object",
@@ -2040,27 +1800,27 @@
           "dynamic": "strict",
           "properties": {
             "name": {
-              "type": "string",
+              "type": "text",
               "analyzer": "keyword"
             },
             "unit": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasUnit"
             },
             "number": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasHousenumber"
             },
             "street": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasStreet"
             },
             "cross_street": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasStreet"
             },
             "zip": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip"
             }
           }
@@ -2070,498 +1830,391 @@
           "dynamic": "strict",
           "properties": {
             "continent": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "continent_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "continent_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "ocean": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "ocean_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "ocean_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "empire": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "empire_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "empire_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "country": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "country_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "country_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "dependency": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "dependency_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "dependency_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "marinearea": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "marinearea_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "marinearea_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "macroregion": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macroregion_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macroregion_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "region": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "region_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "region_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "macrocounty": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macrocounty_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macrocounty_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "county": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "county_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "county_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "locality": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "locality_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "locality_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "borough": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "borough_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "borough_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "localadmin": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "localadmin_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "localadmin_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "neighbourhood": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "neighbourhood_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "neighbourhood_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "postalcode": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip",
               "fields": {
                 "ngram": {
-                  "type": "string",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "type": "text",
+                  "analyzer": "peliasIndexOneEdgeGram"
                 }
               }
             },
             "postalcode_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip",
               "fields": {
                 "ngram": {
-                  "type": "string",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "type": "text",
+                  "analyzer": "peliasIndexOneEdgeGram"
                 }
               }
             },
             "postalcode_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             }
           }
@@ -2575,17 +2228,15 @@
           "tree_levels": "20"
         },
         "bounding_box": {
-          "type": "string",
-          "index": "no"
+          "type": "keyword",
+          "index": false
         },
         "source_id": {
-          "type": "string",
-          "index": "not_analyzed",
+          "type": "keyword",
           "doc_values": false
         },
         "category": {
-          "type": "string",
-          "index": "not_analyzed",
+          "type": "keyword",
           "doc_values": false
         },
         "population": {
@@ -2607,11 +2258,8 @@
             "path_match": "name.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
-              "analyzer": "peliasIndexOneEdgeGram",
-              "fielddata": {
-                "format": "disabled"
-              }
+              "type": "text",
+              "analyzer": "peliasIndexOneEdgeGram"
             }
           }
         },
@@ -2620,11 +2268,8 @@
             "path_match": "phrase.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
-              "analyzer": "peliasPhrase",
-              "fielddata": {
-                "format": "disabled"
-              }
+              "type": "text",
+              "analyzer": "peliasPhrase"
             }
           }
         },
@@ -2633,12 +2278,9 @@
             "path_match": "addendum.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
+              "type": "keyword",
               "index": "no",
-              "doc_values": false,
-              "fielddata" : {
-                "format": "disabled"
-              }
+              "doc_values": false
             }
           }
         }
@@ -2657,12 +2299,10 @@
     "street": {
       "properties": {
         "source": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "keyword"
         },
         "layer": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "keyword"
         },
         "name": {
           "type": "object",
@@ -2677,27 +2317,27 @@
           "dynamic": "strict",
           "properties": {
             "name": {
-              "type": "string",
+              "type": "text",
               "analyzer": "keyword"
             },
             "unit": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasUnit"
             },
             "number": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasHousenumber"
             },
             "street": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasStreet"
             },
             "cross_street": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasStreet"
             },
             "zip": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip"
             }
           }
@@ -2707,498 +2347,391 @@
           "dynamic": "strict",
           "properties": {
             "continent": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "continent_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "continent_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "ocean": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "ocean_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "ocean_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "empire": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "empire_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "empire_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "country": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "country_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "country_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "dependency": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "dependency_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "dependency_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "marinearea": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "marinearea_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "marinearea_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "macroregion": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macroregion_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macroregion_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "region": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "region_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "region_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "macrocounty": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macrocounty_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macrocounty_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "county": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "county_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "county_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "locality": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "locality_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "locality_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "borough": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "borough_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "borough_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "localadmin": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "localadmin_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "localadmin_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "neighbourhood": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "neighbourhood_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "neighbourhood_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "postalcode": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip",
               "fields": {
                 "ngram": {
-                  "type": "string",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "type": "text",
+                  "analyzer": "peliasIndexOneEdgeGram"
                 }
               }
             },
             "postalcode_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip",
               "fields": {
                 "ngram": {
-                  "type": "string",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "type": "text",
+                  "analyzer": "peliasIndexOneEdgeGram"
                 }
               }
             },
             "postalcode_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             }
           }
@@ -3212,17 +2745,15 @@
           "tree_levels": "20"
         },
         "bounding_box": {
-          "type": "string",
-          "index": "no"
+          "type": "keyword",
+          "index": false
         },
         "source_id": {
-          "type": "string",
-          "index": "not_analyzed",
+          "type": "keyword",
           "doc_values": false
         },
         "category": {
-          "type": "string",
-          "index": "not_analyzed",
+          "type": "keyword",
           "doc_values": false
         },
         "population": {
@@ -3244,11 +2775,8 @@
             "path_match": "name.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
-              "analyzer": "peliasIndexOneEdgeGram",
-              "fielddata": {
-                "format": "disabled"
-              }
+              "type": "text",
+              "analyzer": "peliasIndexOneEdgeGram"
             }
           }
         },
@@ -3257,11 +2785,8 @@
             "path_match": "phrase.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
-              "analyzer": "peliasPhrase",
-              "fielddata": {
-                "format": "disabled"
-              }
+              "type": "text",
+              "analyzer": "peliasPhrase"
             }
           }
         },
@@ -3270,12 +2795,9 @@
             "path_match": "addendum.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
+              "type": "keyword",
               "index": "no",
-              "doc_values": false,
-              "fielddata" : {
-                "format": "disabled"
-              }
+              "doc_values": false
             }
           }
         }
@@ -3294,12 +2816,10 @@
     "neighbourhood": {
       "properties": {
         "source": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "keyword"
         },
         "layer": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "keyword"
         },
         "name": {
           "type": "object",
@@ -3314,27 +2834,27 @@
           "dynamic": "strict",
           "properties": {
             "name": {
-              "type": "string",
+              "type": "text",
               "analyzer": "keyword"
             },
             "unit": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasUnit"
             },
             "number": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasHousenumber"
             },
             "street": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasStreet"
             },
             "cross_street": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasStreet"
             },
             "zip": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip"
             }
           }
@@ -3344,498 +2864,391 @@
           "dynamic": "strict",
           "properties": {
             "continent": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "continent_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "continent_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "ocean": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "ocean_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "ocean_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "empire": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "empire_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "empire_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "country": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "country_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "country_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "dependency": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "dependency_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "dependency_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "marinearea": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "marinearea_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "marinearea_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "macroregion": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macroregion_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macroregion_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "region": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "region_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "region_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "macrocounty": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macrocounty_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macrocounty_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "county": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "county_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "county_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "locality": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "locality_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "locality_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "borough": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "borough_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "borough_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "localadmin": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "localadmin_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "localadmin_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "neighbourhood": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "neighbourhood_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "neighbourhood_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "postalcode": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip",
               "fields": {
                 "ngram": {
-                  "type": "string",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "type": "text",
+                  "analyzer": "peliasIndexOneEdgeGram"
                 }
               }
             },
             "postalcode_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip",
               "fields": {
                 "ngram": {
-                  "type": "string",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "type": "text",
+                  "analyzer": "peliasIndexOneEdgeGram"
                 }
               }
             },
             "postalcode_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             }
           }
@@ -3849,17 +3262,15 @@
           "tree_levels": "20"
         },
         "bounding_box": {
-          "type": "string",
-          "index": "no"
+          "type": "keyword",
+          "index": false
         },
         "source_id": {
-          "type": "string",
-          "index": "not_analyzed",
+          "type": "keyword",
           "doc_values": false
         },
         "category": {
-          "type": "string",
-          "index": "not_analyzed",
+          "type": "keyword",
           "doc_values": false
         },
         "population": {
@@ -3881,11 +3292,8 @@
             "path_match": "name.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
-              "analyzer": "peliasIndexOneEdgeGram",
-              "fielddata": {
-                "format": "disabled"
-              }
+              "type": "text",
+              "analyzer": "peliasIndexOneEdgeGram"
             }
           }
         },
@@ -3894,11 +3302,8 @@
             "path_match": "phrase.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
-              "analyzer": "peliasPhrase",
-              "fielddata": {
-                "format": "disabled"
-              }
+              "type": "text",
+              "analyzer": "peliasPhrase"
             }
           }
         },
@@ -3907,12 +3312,9 @@
             "path_match": "addendum.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
+              "type": "keyword",
               "index": "no",
-              "doc_values": false,
-              "fielddata" : {
-                "format": "disabled"
-              }
+              "doc_values": false
             }
           }
         }
@@ -3931,12 +3333,10 @@
     "borough": {
       "properties": {
         "source": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "keyword"
         },
         "layer": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "keyword"
         },
         "name": {
           "type": "object",
@@ -3951,27 +3351,27 @@
           "dynamic": "strict",
           "properties": {
             "name": {
-              "type": "string",
+              "type": "text",
               "analyzer": "keyword"
             },
             "unit": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasUnit"
             },
             "number": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasHousenumber"
             },
             "street": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasStreet"
             },
             "cross_street": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasStreet"
             },
             "zip": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip"
             }
           }
@@ -3981,498 +3381,391 @@
           "dynamic": "strict",
           "properties": {
             "continent": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "continent_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "continent_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "ocean": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "ocean_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "ocean_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "empire": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "empire_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "empire_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "country": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "country_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "country_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "dependency": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "dependency_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "dependency_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "marinearea": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "marinearea_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "marinearea_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "macroregion": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macroregion_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macroregion_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "region": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "region_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "region_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "macrocounty": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macrocounty_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macrocounty_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "county": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "county_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "county_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "locality": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "locality_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "locality_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "borough": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "borough_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "borough_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "localadmin": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "localadmin_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "localadmin_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "neighbourhood": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "neighbourhood_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "neighbourhood_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "postalcode": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip",
               "fields": {
                 "ngram": {
-                  "type": "string",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "type": "text",
+                  "analyzer": "peliasIndexOneEdgeGram"
                 }
               }
             },
             "postalcode_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip",
               "fields": {
                 "ngram": {
-                  "type": "string",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "type": "text",
+                  "analyzer": "peliasIndexOneEdgeGram"
                 }
               }
             },
             "postalcode_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             }
           }
@@ -4486,17 +3779,15 @@
           "tree_levels": "20"
         },
         "bounding_box": {
-          "type": "string",
-          "index": "no"
+          "type": "keyword",
+          "index": false
         },
         "source_id": {
-          "type": "string",
-          "index": "not_analyzed",
+          "type": "keyword",
           "doc_values": false
         },
         "category": {
-          "type": "string",
-          "index": "not_analyzed",
+          "type": "keyword",
           "doc_values": false
         },
         "population": {
@@ -4518,11 +3809,8 @@
             "path_match": "name.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
-              "analyzer": "peliasIndexOneEdgeGram",
-              "fielddata": {
-                "format": "disabled"
-              }
+              "type": "text",
+              "analyzer": "peliasIndexOneEdgeGram"
             }
           }
         },
@@ -4531,11 +3819,8 @@
             "path_match": "phrase.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
-              "analyzer": "peliasPhrase",
-              "fielddata": {
-                "format": "disabled"
-              }
+              "type": "text",
+              "analyzer": "peliasPhrase"
             }
           }
         },
@@ -4544,12 +3829,9 @@
             "path_match": "addendum.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
+              "type": "keyword",
               "index": "no",
-              "doc_values": false,
-              "fielddata" : {
-                "format": "disabled"
-              }
+              "doc_values": false
             }
           }
         }
@@ -4568,12 +3850,10 @@
     "postalcode": {
       "properties": {
         "source": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "keyword"
         },
         "layer": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "keyword"
         },
         "name": {
           "type": "object",
@@ -4588,27 +3868,27 @@
           "dynamic": "strict",
           "properties": {
             "name": {
-              "type": "string",
+              "type": "text",
               "analyzer": "keyword"
             },
             "unit": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasUnit"
             },
             "number": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasHousenumber"
             },
             "street": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasStreet"
             },
             "cross_street": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasStreet"
             },
             "zip": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip"
             }
           }
@@ -4618,498 +3898,391 @@
           "dynamic": "strict",
           "properties": {
             "continent": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "continent_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "continent_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "ocean": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "ocean_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "ocean_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "empire": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "empire_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "empire_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "country": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "country_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "country_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "dependency": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "dependency_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "dependency_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "marinearea": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "marinearea_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "marinearea_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "macroregion": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macroregion_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macroregion_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "region": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "region_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "region_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "macrocounty": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macrocounty_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macrocounty_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "county": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "county_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "county_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "locality": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "locality_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "locality_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "borough": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "borough_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "borough_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "localadmin": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "localadmin_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "localadmin_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "neighbourhood": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "neighbourhood_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "neighbourhood_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "postalcode": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip",
               "fields": {
                 "ngram": {
-                  "type": "string",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "type": "text",
+                  "analyzer": "peliasIndexOneEdgeGram"
                 }
               }
             },
             "postalcode_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip",
               "fields": {
                 "ngram": {
-                  "type": "string",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "type": "text",
+                  "analyzer": "peliasIndexOneEdgeGram"
                 }
               }
             },
             "postalcode_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             }
           }
@@ -5123,17 +4296,15 @@
           "tree_levels": "20"
         },
         "bounding_box": {
-          "type": "string",
-          "index": "no"
+          "type": "keyword",
+          "index": false
         },
         "source_id": {
-          "type": "string",
-          "index": "not_analyzed",
+          "type": "keyword",
           "doc_values": false
         },
         "category": {
-          "type": "string",
-          "index": "not_analyzed",
+          "type": "keyword",
           "doc_values": false
         },
         "population": {
@@ -5155,11 +4326,8 @@
             "path_match": "name.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
-              "analyzer": "peliasIndexOneEdgeGram",
-              "fielddata": {
-                "format": "disabled"
-              }
+              "type": "text",
+              "analyzer": "peliasIndexOneEdgeGram"
             }
           }
         },
@@ -5168,11 +4336,8 @@
             "path_match": "phrase.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
-              "analyzer": "peliasPhrase",
-              "fielddata": {
-                "format": "disabled"
-              }
+              "type": "text",
+              "analyzer": "peliasPhrase"
             }
           }
         },
@@ -5181,12 +4346,9 @@
             "path_match": "addendum.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
+              "type": "keyword",
               "index": "no",
-              "doc_values": false,
-              "fielddata" : {
-                "format": "disabled"
-              }
+              "doc_values": false
             }
           }
         }
@@ -5205,12 +4367,10 @@
     "locality": {
       "properties": {
         "source": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "keyword"
         },
         "layer": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "keyword"
         },
         "name": {
           "type": "object",
@@ -5225,27 +4385,27 @@
           "dynamic": "strict",
           "properties": {
             "name": {
-              "type": "string",
+              "type": "text",
               "analyzer": "keyword"
             },
             "unit": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasUnit"
             },
             "number": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasHousenumber"
             },
             "street": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasStreet"
             },
             "cross_street": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasStreet"
             },
             "zip": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip"
             }
           }
@@ -5255,498 +4415,391 @@
           "dynamic": "strict",
           "properties": {
             "continent": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "continent_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "continent_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "ocean": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "ocean_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "ocean_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "empire": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "empire_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "empire_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "country": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "country_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "country_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "dependency": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "dependency_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "dependency_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "marinearea": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "marinearea_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "marinearea_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "macroregion": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macroregion_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macroregion_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "region": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "region_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "region_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "macrocounty": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macrocounty_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macrocounty_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "county": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "county_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "county_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "locality": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "locality_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "locality_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "borough": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "borough_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "borough_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "localadmin": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "localadmin_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "localadmin_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "neighbourhood": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "neighbourhood_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "neighbourhood_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "postalcode": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip",
               "fields": {
                 "ngram": {
-                  "type": "string",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "type": "text",
+                  "analyzer": "peliasIndexOneEdgeGram"
                 }
               }
             },
             "postalcode_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip",
               "fields": {
                 "ngram": {
-                  "type": "string",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "type": "text",
+                  "analyzer": "peliasIndexOneEdgeGram"
                 }
               }
             },
             "postalcode_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             }
           }
@@ -5760,17 +4813,15 @@
           "tree_levels": "20"
         },
         "bounding_box": {
-          "type": "string",
-          "index": "no"
+          "type": "keyword",
+          "index": false
         },
         "source_id": {
-          "type": "string",
-          "index": "not_analyzed",
+          "type": "keyword",
           "doc_values": false
         },
         "category": {
-          "type": "string",
-          "index": "not_analyzed",
+          "type": "keyword",
           "doc_values": false
         },
         "population": {
@@ -5792,11 +4843,8 @@
             "path_match": "name.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
-              "analyzer": "peliasIndexOneEdgeGram",
-              "fielddata": {
-                "format": "disabled"
-              }
+              "type": "text",
+              "analyzer": "peliasIndexOneEdgeGram"
             }
           }
         },
@@ -5805,11 +4853,8 @@
             "path_match": "phrase.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
-              "analyzer": "peliasPhrase",
-              "fielddata": {
-                "format": "disabled"
-              }
+              "type": "text",
+              "analyzer": "peliasPhrase"
             }
           }
         },
@@ -5818,12 +4863,9 @@
             "path_match": "addendum.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
+              "type": "keyword",
               "index": "no",
-              "doc_values": false,
-              "fielddata" : {
-                "format": "disabled"
-              }
+              "doc_values": false
             }
           }
         }
@@ -5842,12 +4884,10 @@
     "localadmin": {
       "properties": {
         "source": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "keyword"
         },
         "layer": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "keyword"
         },
         "name": {
           "type": "object",
@@ -5862,27 +4902,27 @@
           "dynamic": "strict",
           "properties": {
             "name": {
-              "type": "string",
+              "type": "text",
               "analyzer": "keyword"
             },
             "unit": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasUnit"
             },
             "number": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasHousenumber"
             },
             "street": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasStreet"
             },
             "cross_street": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasStreet"
             },
             "zip": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip"
             }
           }
@@ -5892,498 +4932,391 @@
           "dynamic": "strict",
           "properties": {
             "continent": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "continent_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "continent_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "ocean": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "ocean_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "ocean_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "empire": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "empire_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "empire_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "country": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "country_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "country_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "dependency": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "dependency_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "dependency_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "marinearea": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "marinearea_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "marinearea_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "macroregion": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macroregion_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macroregion_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "region": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "region_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "region_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "macrocounty": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macrocounty_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macrocounty_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "county": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "county_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "county_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "locality": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "locality_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "locality_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "borough": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "borough_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "borough_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "localadmin": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "localadmin_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "localadmin_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "neighbourhood": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "neighbourhood_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "neighbourhood_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "postalcode": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip",
               "fields": {
                 "ngram": {
-                  "type": "string",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "type": "text",
+                  "analyzer": "peliasIndexOneEdgeGram"
                 }
               }
             },
             "postalcode_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip",
               "fields": {
                 "ngram": {
-                  "type": "string",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "type": "text",
+                  "analyzer": "peliasIndexOneEdgeGram"
                 }
               }
             },
             "postalcode_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             }
           }
@@ -6397,17 +5330,15 @@
           "tree_levels": "20"
         },
         "bounding_box": {
-          "type": "string",
-          "index": "no"
+          "type": "keyword",
+          "index": false
         },
         "source_id": {
-          "type": "string",
-          "index": "not_analyzed",
+          "type": "keyword",
           "doc_values": false
         },
         "category": {
-          "type": "string",
-          "index": "not_analyzed",
+          "type": "keyword",
           "doc_values": false
         },
         "population": {
@@ -6429,11 +5360,8 @@
             "path_match": "name.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
-              "analyzer": "peliasIndexOneEdgeGram",
-              "fielddata": {
-                "format": "disabled"
-              }
+              "type": "text",
+              "analyzer": "peliasIndexOneEdgeGram"
             }
           }
         },
@@ -6442,11 +5370,8 @@
             "path_match": "phrase.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
-              "analyzer": "peliasPhrase",
-              "fielddata": {
-                "format": "disabled"
-              }
+              "type": "text",
+              "analyzer": "peliasPhrase"
             }
           }
         },
@@ -6455,12 +5380,9 @@
             "path_match": "addendum.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
+              "type": "keyword",
               "index": "no",
-              "doc_values": false,
-              "fielddata" : {
-                "format": "disabled"
-              }
+              "doc_values": false
             }
           }
         }
@@ -6479,12 +5401,10 @@
     "county": {
       "properties": {
         "source": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "keyword"
         },
         "layer": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "keyword"
         },
         "name": {
           "type": "object",
@@ -6499,27 +5419,27 @@
           "dynamic": "strict",
           "properties": {
             "name": {
-              "type": "string",
+              "type": "text",
               "analyzer": "keyword"
             },
             "unit": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasUnit"
             },
             "number": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasHousenumber"
             },
             "street": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasStreet"
             },
             "cross_street": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasStreet"
             },
             "zip": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip"
             }
           }
@@ -6529,498 +5449,391 @@
           "dynamic": "strict",
           "properties": {
             "continent": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "continent_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "continent_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "ocean": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "ocean_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "ocean_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "empire": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "empire_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "empire_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "country": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "country_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "country_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "dependency": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "dependency_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "dependency_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "marinearea": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "marinearea_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "marinearea_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "macroregion": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macroregion_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macroregion_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "region": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "region_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "region_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "macrocounty": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macrocounty_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macrocounty_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "county": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "county_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "county_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "locality": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "locality_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "locality_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "borough": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "borough_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "borough_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "localadmin": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "localadmin_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "localadmin_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "neighbourhood": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "neighbourhood_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "neighbourhood_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "postalcode": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip",
               "fields": {
                 "ngram": {
-                  "type": "string",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "type": "text",
+                  "analyzer": "peliasIndexOneEdgeGram"
                 }
               }
             },
             "postalcode_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip",
               "fields": {
                 "ngram": {
-                  "type": "string",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "type": "text",
+                  "analyzer": "peliasIndexOneEdgeGram"
                 }
               }
             },
             "postalcode_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             }
           }
@@ -7034,17 +5847,15 @@
           "tree_levels": "20"
         },
         "bounding_box": {
-          "type": "string",
-          "index": "no"
+          "type": "keyword",
+          "index": false
         },
         "source_id": {
-          "type": "string",
-          "index": "not_analyzed",
+          "type": "keyword",
           "doc_values": false
         },
         "category": {
-          "type": "string",
-          "index": "not_analyzed",
+          "type": "keyword",
           "doc_values": false
         },
         "population": {
@@ -7066,11 +5877,8 @@
             "path_match": "name.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
-              "analyzer": "peliasIndexOneEdgeGram",
-              "fielddata": {
-                "format": "disabled"
-              }
+              "type": "text",
+              "analyzer": "peliasIndexOneEdgeGram"
             }
           }
         },
@@ -7079,11 +5887,8 @@
             "path_match": "phrase.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
-              "analyzer": "peliasPhrase",
-              "fielddata": {
-                "format": "disabled"
-              }
+              "type": "text",
+              "analyzer": "peliasPhrase"
             }
           }
         },
@@ -7092,12 +5897,9 @@
             "path_match": "addendum.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
+              "type": "keyword",
               "index": "no",
-              "doc_values": false,
-              "fielddata" : {
-                "format": "disabled"
-              }
+              "doc_values": false
             }
           }
         }
@@ -7116,12 +5918,10 @@
     "macrocounty": {
       "properties": {
         "source": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "keyword"
         },
         "layer": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "keyword"
         },
         "name": {
           "type": "object",
@@ -7136,27 +5936,27 @@
           "dynamic": "strict",
           "properties": {
             "name": {
-              "type": "string",
+              "type": "text",
               "analyzer": "keyword"
             },
             "unit": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasUnit"
             },
             "number": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasHousenumber"
             },
             "street": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasStreet"
             },
             "cross_street": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasStreet"
             },
             "zip": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip"
             }
           }
@@ -7166,498 +5966,391 @@
           "dynamic": "strict",
           "properties": {
             "continent": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "continent_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "continent_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "ocean": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "ocean_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "ocean_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "empire": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "empire_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "empire_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "country": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "country_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "country_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "dependency": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "dependency_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "dependency_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "marinearea": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "marinearea_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "marinearea_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "macroregion": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macroregion_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macroregion_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "region": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "region_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "region_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "macrocounty": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macrocounty_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macrocounty_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "county": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "county_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "county_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "locality": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "locality_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "locality_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "borough": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "borough_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "borough_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "localadmin": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "localadmin_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "localadmin_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "neighbourhood": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "neighbourhood_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "neighbourhood_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "postalcode": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip",
               "fields": {
                 "ngram": {
-                  "type": "string",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "type": "text",
+                  "analyzer": "peliasIndexOneEdgeGram"
                 }
               }
             },
             "postalcode_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip",
               "fields": {
                 "ngram": {
-                  "type": "string",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "type": "text",
+                  "analyzer": "peliasIndexOneEdgeGram"
                 }
               }
             },
             "postalcode_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             }
           }
@@ -7671,17 +6364,15 @@
           "tree_levels": "20"
         },
         "bounding_box": {
-          "type": "string",
-          "index": "no"
+          "type": "keyword",
+          "index": false
         },
         "source_id": {
-          "type": "string",
-          "index": "not_analyzed",
+          "type": "keyword",
           "doc_values": false
         },
         "category": {
-          "type": "string",
-          "index": "not_analyzed",
+          "type": "keyword",
           "doc_values": false
         },
         "population": {
@@ -7703,11 +6394,8 @@
             "path_match": "name.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
-              "analyzer": "peliasIndexOneEdgeGram",
-              "fielddata": {
-                "format": "disabled"
-              }
+              "type": "text",
+              "analyzer": "peliasIndexOneEdgeGram"
             }
           }
         },
@@ -7716,11 +6404,8 @@
             "path_match": "phrase.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
-              "analyzer": "peliasPhrase",
-              "fielddata": {
-                "format": "disabled"
-              }
+              "type": "text",
+              "analyzer": "peliasPhrase"
             }
           }
         },
@@ -7729,12 +6414,9 @@
             "path_match": "addendum.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
+              "type": "keyword",
               "index": "no",
-              "doc_values": false,
-              "fielddata" : {
-                "format": "disabled"
-              }
+              "doc_values": false
             }
           }
         }
@@ -7753,12 +6435,10 @@
     "region": {
       "properties": {
         "source": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "keyword"
         },
         "layer": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "keyword"
         },
         "name": {
           "type": "object",
@@ -7773,27 +6453,27 @@
           "dynamic": "strict",
           "properties": {
             "name": {
-              "type": "string",
+              "type": "text",
               "analyzer": "keyword"
             },
             "unit": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasUnit"
             },
             "number": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasHousenumber"
             },
             "street": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasStreet"
             },
             "cross_street": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasStreet"
             },
             "zip": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip"
             }
           }
@@ -7803,498 +6483,391 @@
           "dynamic": "strict",
           "properties": {
             "continent": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "continent_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "continent_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "ocean": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "ocean_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "ocean_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "empire": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "empire_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "empire_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "country": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "country_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "country_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "dependency": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "dependency_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "dependency_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "marinearea": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "marinearea_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "marinearea_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "macroregion": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macroregion_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macroregion_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "region": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "region_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "region_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "macrocounty": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macrocounty_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macrocounty_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "county": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "county_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "county_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "locality": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "locality_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "locality_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "borough": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "borough_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "borough_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "localadmin": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "localadmin_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "localadmin_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "neighbourhood": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "neighbourhood_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "neighbourhood_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "postalcode": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip",
               "fields": {
                 "ngram": {
-                  "type": "string",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "type": "text",
+                  "analyzer": "peliasIndexOneEdgeGram"
                 }
               }
             },
             "postalcode_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip",
               "fields": {
                 "ngram": {
-                  "type": "string",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "type": "text",
+                  "analyzer": "peliasIndexOneEdgeGram"
                 }
               }
             },
             "postalcode_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             }
           }
@@ -8308,17 +6881,15 @@
           "tree_levels": "20"
         },
         "bounding_box": {
-          "type": "string",
-          "index": "no"
+          "type": "keyword",
+          "index": false
         },
         "source_id": {
-          "type": "string",
-          "index": "not_analyzed",
+          "type": "keyword",
           "doc_values": false
         },
         "category": {
-          "type": "string",
-          "index": "not_analyzed",
+          "type": "keyword",
           "doc_values": false
         },
         "population": {
@@ -8340,11 +6911,8 @@
             "path_match": "name.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
-              "analyzer": "peliasIndexOneEdgeGram",
-              "fielddata": {
-                "format": "disabled"
-              }
+              "type": "text",
+              "analyzer": "peliasIndexOneEdgeGram"
             }
           }
         },
@@ -8353,11 +6921,8 @@
             "path_match": "phrase.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
-              "analyzer": "peliasPhrase",
-              "fielddata": {
-                "format": "disabled"
-              }
+              "type": "text",
+              "analyzer": "peliasPhrase"
             }
           }
         },
@@ -8366,12 +6931,9 @@
             "path_match": "addendum.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
+              "type": "keyword",
               "index": "no",
-              "doc_values": false,
-              "fielddata" : {
-                "format": "disabled"
-              }
+              "doc_values": false
             }
           }
         }
@@ -8390,12 +6952,10 @@
     "macroregion": {
       "properties": {
         "source": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "keyword"
         },
         "layer": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "keyword"
         },
         "name": {
           "type": "object",
@@ -8410,27 +6970,27 @@
           "dynamic": "strict",
           "properties": {
             "name": {
-              "type": "string",
+              "type": "text",
               "analyzer": "keyword"
             },
             "unit": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasUnit"
             },
             "number": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasHousenumber"
             },
             "street": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasStreet"
             },
             "cross_street": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasStreet"
             },
             "zip": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip"
             }
           }
@@ -8440,498 +7000,391 @@
           "dynamic": "strict",
           "properties": {
             "continent": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "continent_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "continent_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "ocean": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "ocean_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "ocean_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "empire": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "empire_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "empire_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "country": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "country_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "country_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "dependency": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "dependency_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "dependency_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "marinearea": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "marinearea_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "marinearea_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "macroregion": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macroregion_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macroregion_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "region": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "region_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "region_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "macrocounty": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macrocounty_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macrocounty_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "county": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "county_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "county_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "locality": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "locality_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "locality_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "borough": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "borough_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "borough_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "localadmin": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "localadmin_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "localadmin_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "neighbourhood": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "neighbourhood_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "neighbourhood_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "postalcode": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip",
               "fields": {
                 "ngram": {
-                  "type": "string",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "type": "text",
+                  "analyzer": "peliasIndexOneEdgeGram"
                 }
               }
             },
             "postalcode_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip",
               "fields": {
                 "ngram": {
-                  "type": "string",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "type": "text",
+                  "analyzer": "peliasIndexOneEdgeGram"
                 }
               }
             },
             "postalcode_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             }
           }
@@ -8945,17 +7398,15 @@
           "tree_levels": "20"
         },
         "bounding_box": {
-          "type": "string",
-          "index": "no"
+          "type": "keyword",
+          "index": false
         },
         "source_id": {
-          "type": "string",
-          "index": "not_analyzed",
+          "type": "keyword",
           "doc_values": false
         },
         "category": {
-          "type": "string",
-          "index": "not_analyzed",
+          "type": "keyword",
           "doc_values": false
         },
         "population": {
@@ -8977,11 +7428,8 @@
             "path_match": "name.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
-              "analyzer": "peliasIndexOneEdgeGram",
-              "fielddata": {
-                "format": "disabled"
-              }
+              "type": "text",
+              "analyzer": "peliasIndexOneEdgeGram"
             }
           }
         },
@@ -8990,11 +7438,8 @@
             "path_match": "phrase.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
-              "analyzer": "peliasPhrase",
-              "fielddata": {
-                "format": "disabled"
-              }
+              "type": "text",
+              "analyzer": "peliasPhrase"
             }
           }
         },
@@ -9003,12 +7448,9 @@
             "path_match": "addendum.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
+              "type": "keyword",
               "index": "no",
-              "doc_values": false,
-              "fielddata" : {
-                "format": "disabled"
-              }
+              "doc_values": false
             }
           }
         }
@@ -9027,12 +7469,10 @@
     "dependency": {
       "properties": {
         "source": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "keyword"
         },
         "layer": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "keyword"
         },
         "name": {
           "type": "object",
@@ -9047,27 +7487,27 @@
           "dynamic": "strict",
           "properties": {
             "name": {
-              "type": "string",
+              "type": "text",
               "analyzer": "keyword"
             },
             "unit": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasUnit"
             },
             "number": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasHousenumber"
             },
             "street": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasStreet"
             },
             "cross_street": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasStreet"
             },
             "zip": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip"
             }
           }
@@ -9077,498 +7517,391 @@
           "dynamic": "strict",
           "properties": {
             "continent": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "continent_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "continent_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "ocean": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "ocean_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "ocean_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "empire": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "empire_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "empire_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "country": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "country_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "country_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "dependency": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "dependency_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "dependency_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "marinearea": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "marinearea_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "marinearea_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "macroregion": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macroregion_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macroregion_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "region": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "region_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "region_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "macrocounty": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macrocounty_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macrocounty_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "county": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "county_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "county_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "locality": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "locality_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "locality_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "borough": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "borough_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "borough_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "localadmin": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "localadmin_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "localadmin_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "neighbourhood": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "neighbourhood_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "neighbourhood_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "postalcode": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip",
               "fields": {
                 "ngram": {
-                  "type": "string",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "type": "text",
+                  "analyzer": "peliasIndexOneEdgeGram"
                 }
               }
             },
             "postalcode_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip",
               "fields": {
                 "ngram": {
-                  "type": "string",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "type": "text",
+                  "analyzer": "peliasIndexOneEdgeGram"
                 }
               }
             },
             "postalcode_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             }
           }
@@ -9582,17 +7915,15 @@
           "tree_levels": "20"
         },
         "bounding_box": {
-          "type": "string",
-          "index": "no"
+          "type": "keyword",
+          "index": false
         },
         "source_id": {
-          "type": "string",
-          "index": "not_analyzed",
+          "type": "keyword",
           "doc_values": false
         },
         "category": {
-          "type": "string",
-          "index": "not_analyzed",
+          "type": "keyword",
           "doc_values": false
         },
         "population": {
@@ -9614,11 +7945,8 @@
             "path_match": "name.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
-              "analyzer": "peliasIndexOneEdgeGram",
-              "fielddata": {
-                "format": "disabled"
-              }
+              "type": "text",
+              "analyzer": "peliasIndexOneEdgeGram"
             }
           }
         },
@@ -9627,11 +7955,8 @@
             "path_match": "phrase.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
-              "analyzer": "peliasPhrase",
-              "fielddata": {
-                "format": "disabled"
-              }
+              "type": "text",
+              "analyzer": "peliasPhrase"
             }
           }
         },
@@ -9640,12 +7965,9 @@
             "path_match": "addendum.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
+              "type": "keyword",
               "index": "no",
-              "doc_values": false,
-              "fielddata" : {
-                "format": "disabled"
-              }
+              "doc_values": false
             }
           }
         }
@@ -9664,12 +7986,10 @@
     "country": {
       "properties": {
         "source": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "keyword"
         },
         "layer": {
-          "type": "string",
-          "index": "not_analyzed"
+          "type": "keyword"
         },
         "name": {
           "type": "object",
@@ -9684,27 +8004,27 @@
           "dynamic": "strict",
           "properties": {
             "name": {
-              "type": "string",
+              "type": "text",
               "analyzer": "keyword"
             },
             "unit": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasUnit"
             },
             "number": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasHousenumber"
             },
             "street": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasStreet"
             },
             "cross_street": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasStreet"
             },
             "zip": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip"
             }
           }
@@ -9714,498 +8034,391 @@
           "dynamic": "strict",
           "properties": {
             "continent": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "continent_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "continent_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "ocean": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "ocean_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "ocean_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "empire": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "empire_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "empire_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "country": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "country_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "country_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "dependency": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "dependency_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "dependency_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "marinearea": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "marinearea_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "marinearea_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "macroregion": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macroregion_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macroregion_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "region": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "region_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "region_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "macrocounty": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macrocounty_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "macrocounty_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "county": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "county_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "county_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "locality": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "locality_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "locality_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "borough": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "borough_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "borough_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "localadmin": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "localadmin_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "localadmin_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "neighbourhood": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "neighbourhood_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
-                  "type": "string",
+                  "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "doc_values": false
                 }
               }
             },
             "neighbourhood_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             },
             "postalcode": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip",
               "fields": {
                 "ngram": {
-                  "type": "string",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "type": "text",
+                  "analyzer": "peliasIndexOneEdgeGram"
                 }
               }
             },
             "postalcode_a": {
-              "type": "string",
+              "type": "text",
               "analyzer": "peliasZip",
               "fields": {
                 "ngram": {
-                  "type": "string",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "doc_values": false,
-                  "fielddata": {
-                    "format": "disabled"
-                  }
+                  "type": "text",
+                  "analyzer": "peliasIndexOneEdgeGram"
                 }
               }
             },
             "postalcode_id": {
-              "type": "string",
-              "index": "not_analyzed",
+              "type": "keyword",
               "doc_values": false
             }
           }
@@ -10219,17 +8432,15 @@
           "tree_levels": "20"
         },
         "bounding_box": {
-          "type": "string",
-          "index": "no"
+          "type": "keyword",
+          "index": false
         },
         "source_id": {
-          "type": "string",
-          "index": "not_analyzed",
+          "type": "keyword",
           "doc_values": false
         },
         "category": {
-          "type": "string",
-          "index": "not_analyzed",
+          "type": "keyword",
           "doc_values": false
         },
         "population": {
@@ -10251,11 +8462,8 @@
             "path_match": "name.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
-              "analyzer": "peliasIndexOneEdgeGram",
-              "fielddata": {
-                "format": "disabled"
-              }
+              "type": "text",
+              "analyzer": "peliasIndexOneEdgeGram"
             }
           }
         },
@@ -10264,11 +8472,8 @@
             "path_match": "phrase.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
-              "analyzer": "peliasPhrase",
-              "fielddata": {
-                "format": "disabled"
-              }
+              "type": "text",
+              "analyzer": "peliasPhrase"
             }
           }
         },
@@ -10277,12 +8482,9 @@
             "path_match": "addendum.*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
+              "type": "keyword",
               "index": "no",
-              "doc_values": false,
-              "fielddata" : {
-                "format": "disabled"
-              }
+              "doc_values": false
             }
           }
         }

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -1245,7 +1245,7 @@
             "match_mapping_type": "string",
             "mapping": {
               "type": "keyword",
-              "index": "no",
+              "index": false,
               "doc_values": false
             }
           }
@@ -1762,7 +1762,7 @@
             "match_mapping_type": "string",
             "mapping": {
               "type": "keyword",
-              "index": "no",
+              "index": false,
               "doc_values": false
             }
           }
@@ -2279,7 +2279,7 @@
             "match_mapping_type": "string",
             "mapping": {
               "type": "keyword",
-              "index": "no",
+              "index": false,
               "doc_values": false
             }
           }
@@ -2796,7 +2796,7 @@
             "match_mapping_type": "string",
             "mapping": {
               "type": "keyword",
-              "index": "no",
+              "index": false,
               "doc_values": false
             }
           }
@@ -3313,7 +3313,7 @@
             "match_mapping_type": "string",
             "mapping": {
               "type": "keyword",
-              "index": "no",
+              "index": false,
               "doc_values": false
             }
           }
@@ -3830,7 +3830,7 @@
             "match_mapping_type": "string",
             "mapping": {
               "type": "keyword",
-              "index": "no",
+              "index": false,
               "doc_values": false
             }
           }
@@ -4347,7 +4347,7 @@
             "match_mapping_type": "string",
             "mapping": {
               "type": "keyword",
-              "index": "no",
+              "index": false,
               "doc_values": false
             }
           }
@@ -4864,7 +4864,7 @@
             "match_mapping_type": "string",
             "mapping": {
               "type": "keyword",
-              "index": "no",
+              "index": false,
               "doc_values": false
             }
           }
@@ -5381,7 +5381,7 @@
             "match_mapping_type": "string",
             "mapping": {
               "type": "keyword",
-              "index": "no",
+              "index": false,
               "doc_values": false
             }
           }
@@ -5898,7 +5898,7 @@
             "match_mapping_type": "string",
             "mapping": {
               "type": "keyword",
-              "index": "no",
+              "index": false,
               "doc_values": false
             }
           }
@@ -6415,7 +6415,7 @@
             "match_mapping_type": "string",
             "mapping": {
               "type": "keyword",
-              "index": "no",
+              "index": false,
               "doc_values": false
             }
           }
@@ -6932,7 +6932,7 @@
             "match_mapping_type": "string",
             "mapping": {
               "type": "keyword",
-              "index": "no",
+              "index": false,
               "doc_values": false
             }
           }
@@ -7449,7 +7449,7 @@
             "match_mapping_type": "string",
             "mapping": {
               "type": "keyword",
-              "index": "no",
+              "index": false,
               "doc_values": false
             }
           }
@@ -7966,7 +7966,7 @@
             "match_mapping_type": "string",
             "mapping": {
               "type": "keyword",
-              "index": "no",
+              "index": false,
               "doc_values": false
             }
           }
@@ -8483,7 +8483,7 @@
             "match_mapping_type": "string",
             "mapping": {
               "type": "keyword",
-              "index": "no",
+              "index": false,
               "doc_values": false
             }
           }

--- a/test/partial-admin.js
+++ b/test/partial-admin.js
@@ -13,7 +13,7 @@ module.exports.tests.compile = function(test, common) {
 // this should never need to change
 module.exports.tests.type = function(test, common) {
   test('correct type', function(t) {
-    t.equal(schema.type, 'string', 'correct value');
+    t.equal(schema.type, 'text', 'set to text field for full text search');
     t.end();
   });
 };
@@ -34,7 +34,7 @@ module.exports.tests.index = function(test, common) {
 };
 
 // pelias analysis does not ensure that we get ['Great Britain'] instead of ['Great','Britain']
-// TODO this needs to be addressed 
+// TODO this needs to be addressed
 module.exports.tests.analysis = function(test, common) {
   test('index analysis', function(t) {
     t.equal(schema.analyzer, 'peliasAdmin', 'should be peliasAdmin');

--- a/test/partial-keyword.js
+++ b/test/partial-keyword.js
@@ -1,4 +1,4 @@
-var schema = require('../mappings/partial/literal');
+var schema = require('../mappings/partial/keyword');
 
 module.exports.tests = {};
 
@@ -13,7 +13,7 @@ module.exports.tests.compile = function(test, common) {
 // this should never need to change
 module.exports.tests.type = function(test, common) {
   test('correct type', function(t) {
-    t.equal(schema.type, 'string', 'correct value');
+    t.equal(schema.type, 'keyword', 'correct value');
     t.end();
   });
 };
@@ -28,7 +28,7 @@ module.exports.tests.store = function(test, common) {
 // do not perform analysis on categories
 module.exports.tests.analysis = function(test, common) {
   test('index analysis disabled', function(t) {
-    t.equal(schema.index, 'not_analyzed', 'should be not_analyzed');
+    t.equal(schema.index, undefined, 'should be set to default');
     t.end();
   });
 };
@@ -36,7 +36,7 @@ module.exports.tests.analysis = function(test, common) {
 module.exports.all = function (tape, common) {
 
   function test(name, testFunction) {
-    return tape('literal: ' + name, testFunction);
+    return tape('keyword: ' + name, testFunction);
   }
 
   for( var testCase in module.exports.tests ){

--- a/test/run.js
+++ b/test/run.js
@@ -13,7 +13,7 @@ var tests = [
   require('./document.js'),
   require('./partial-centroid.js'),
   require('./partial-admin.js'),
-  require('./partial-literal.js'),
+  require('./partial-keyword.js'),
   require('./partial-hash.js'),
   require('./settings.js'),
   require('./configValidation.js'),


### PR DESCRIPTION
This change makes our Elasticsearch schema compatible with Elasticsearch 5 and 6. It shouldn't have any effect on performance or operation, but it will completely drop compatibility for Elasticsearch 2.

The primary change is that Elasticsearch 5 introduces two types of text fields: `text` and `keyword`, whereas Elasticsearch 2 only had 1: `string`.

Roughly, a `text` field is for true full text search and a `keyword` field is for simple values that are primarily used for filtering or aggregation (for example, our `source` and `layer` fields). The `string` datatype previously filled both of those roles depending on how it was configured.

Fortunately, we had already roughly created a concept similar to the `keyword` datatype in our schema, but called it `literal`. This has been renamed to `keyword` to cut down on the number of terms needed

One nice effect of this change is that it removes all deprecation warnings printed by Elasticsearch 5. Notably, as discovered in https://github.com/pelias/schema/pull/337#issuecomment-444313941, these warnings were quite noisy and required special handling to work around Node.js header size restrictions. This special handling can now been removed.

Fixes pelias/whosonfirst#457
Connects pelias/pelias#719
Connects pelias/pelias#461