### PR TITLE
WIP: Use `synonym_graph` filter

### DIFF
--- a/integration/address_matching.js
+++ b/integration/address_matching.js
@@ -266,10 +266,9 @@ module.exports.tests.venue_vs_address = function(test, common){
             'bool': {
               'must': [
                 {
-                  'match': {
+                  'match_phrase': {
                     'name.default': {
                       'analyzer': 'peliasQueryFullToken',
-                      'type': 'phrase',
                       'boost': 1,
                       'slop': 3,
                       'query': 'union square'
@@ -288,10 +287,9 @@ module.exports.tests.venue_vs_address = function(test, common){
                   }
                 },
                 {
-                  'match': {
+                  'match_phrase': {
                     'phrase.default': {
                       'analyzer': 'peliasPhrase',
-                      'type': 'phrase',
                       'boost': 1,
                       'slop': 3,
                       'query': 'union square'

--- a/integration/analyzer_peliasPhrase.js
+++ b/integration/analyzer_peliasPhrase.js
@@ -72,28 +72,24 @@ module.exports.tests.functional = function(test, common){
     ]);
 
     // both terms should map to same tokens
-    var expected1 = [ '0:325', '1:n', '1:north', '2:12', '3:st', '3:street' ];
-    var expected2 = [ '0:325', '1:north', '1:n', '2:12', '3:street', '3:st' ];
-    assertAnalysis( 'address', '325 N 12th St', expected1 );
-    assertAnalysis( 'address', '325 North 12th Street', expected2 );
+    var expected1 = ['0:325', '1:n', '1:north', '2:12', '3:st', '3:street'];
+    assertAnalysis('address', '325 N 12th St', expected1);
+    assertAnalysis('address', '325 North 12th Street', expected1);
 
     // both terms should map to same tokens
-    var expected3 = [ '0:13509', '1:colfax', '2:ave', '2:avenue', '2:av', '3:s', '3:south', '3:see' ];
-    var expected4 = [ '0:13509', '1:colfax', '2:avenue', '2:ave', '2:av', '3:south', '3:s' ];
-    assertAnalysis( 'address', '13509 Colfax Ave S', expected3 );
-    assertAnalysis( 'address', '13509 Colfax Avenue South', expected4 );
+    var expected2 = [ '0:13509', '1:colfax', '2:ave', '2:avenue', '2:av', '3:s', '3:south', '3:see' ];
+    assertAnalysis('address', '13509 Colfax Ave S', expected2 );
+    assertAnalysis('address', '13509 Colfax Avenue South', expected2 );
 
     // both terms should map to same tokens
-    var expected5 = [ '0:100', '1:s', '1:south', '1:see', '2:lake', '2:lk', '3:dr', '3:drive' ];
-    var expected6 = [ '0:100', '1:south', '1:s', '2:lake', '2:lk', '3:drive', '3:dr' ];
-    assertAnalysis( 'address', '100 S Lake Dr', expected5 );
-    assertAnalysis( 'address', '100 South Lake Drive', expected6 );
+    var expected3 = ['0:100', '1:s', '1:south', '1:see', '2:lake', '2:lk', '3:dr', '3:drive'];
+    assertAnalysis('address', '100 S Lake Dr', expected3 );
+    assertAnalysis('address', '100 South Lake Drive', expected3 );
 
     // both terms should map to same tokens
-    var expected7 = [ '0:100', '1:northwest', '1:nw', '2:highway', '2:hwy' ];
-    var expected8 = [ '0:100', '1:nw', '1:northwest', '2:hwy', '2:highway' ];
-    assertAnalysis( 'address', '100 northwest highway', expected7 );
-    assertAnalysis( 'address', '100 nw hwy', expected8 );
+    var expected4 = ['0:100', '1:northwest', '1:nw', '2:highway', '2:hwy'];
+    assertAnalysis('address', '100 northwest highway', expected4 );
+    assertAnalysis('address', '100 nw hwy', expected4 );
 
     suite.run( t.end );
   });
@@ -195,10 +191,9 @@ module.exports.tests.slop_query = function(test, common){
             ],
             'should': [
               {
-                'match': {
+                'match_phrase': {
                   'phrase.default': {
                     'query': i,
-                    'type': 'phrase',
                     'slop': 2
                   }
                 }
@@ -265,11 +260,10 @@ module.exports.tests.slop = function(test, common){
         index: suite.props.index,
         type: 'doc',
         searchType: 'dfs_query_then_fetch',
-        body: { query: { match: {
+        body: { query: { match_phrase: {
           'name.default': {
             'analyzer': 'peliasPhrase',
             'query': 'Görlitzer Straße 52',
-            'type': 'phrase',
             'slop': 3,
           }
         }}}

--- a/integration/analyzer_peliasQueryFullToken.js
+++ b/integration/analyzer_peliasQueryFullToken.js
@@ -165,11 +165,10 @@ module.exports.tests.slop = function(test, common){
       suite.client.search({
         index: suite.props.index,
         type: 'doc',
-        body: { query: { match: {
+        body: { query: { match_phrase: {
           'name.default': {
             'analyzer': 'peliasQueryFullToken',
             'query': 'Görlitzer Straße 52',
-            'type': 'phrase',
             'slop': 3,
           }
         }}}

--- a/settings.js
+++ b/settings.js
@@ -280,7 +280,7 @@ function generate(){
   // each filter is given the same name as the file, minus the extension.
   for( var key in synonyms ){
     settings.analysis.filter[key] = {
-      "type": "synonym",
+      "type": "synonym_graph",
       "synonyms": !!synonyms[key].length ? synonyms[key] : ['']
     };
   }

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -247,14 +247,14 @@
           "replacement": "$1"
         },
         "ampersand": {
-          "type": "synonym",
+          "type": "synonym_graph",
           "synonyms": [
             "&,and",
             "&,und"
           ]
         },
         "custom_admin": {
-          "type": "synonym",
+          "type": "synonym_graph",
           "synonyms": [
             "saint,st",
             "sainte,ste",
@@ -264,7 +264,7 @@
           ]
         },
         "custom_name": {
-          "type": "synonym",
+          "type": "synonym_graph",
           "synonyms": [
             "brothers,bros",
             "cape,cpe,cp",
@@ -410,13 +410,13 @@
           ]
         },
         "custom_street": {
-          "type": "synonym",
+          "type": "synonym_graph",
           "synonyms": [
             ""
           ]
         },
         "directionals": {
-          "type": "synonym",
+          "type": "synonym_graph",
           "synonyms": [
             "southwest,sw",
             "southeast,se",
@@ -429,7 +429,7 @@
           ]
         },
         "partial_token_address_suffix_expansion": {
-          "type": "synonym",
+          "type": "synonym_graph",
           "synonyms": [
             "aly => alley",
             "anx => annex",
@@ -530,7 +530,7 @@
           ]
         },
         "street_suffix": {
-          "type": "synonym",
+          "type": "synonym_graph",
           "synonyms": [
             "alley,aly",
             "annex,anx",

--- a/test/settings.js
+++ b/test/settings.js
@@ -348,7 +348,7 @@ module.exports.tests.ampersandFilter = function(test, common) {
     var s = settings();
     t.equal(typeof s.analysis.filter.ampersand, 'object', 'there is a ampersand filter');
     var filter = s.analysis.filter.ampersand;
-    t.equal(filter.type, 'synonym');
+    t.equal(filter.type, 'synonym_graph');
     t.deepEqual(filter.synonyms, [
       "&,and",
       "&,und"
@@ -403,7 +403,7 @@ module.exports.tests.streetSynonymFilter = function(test, common) {
     var s = settings();
     t.equal(typeof s.analysis.filter.street_suffix, 'object', 'there is an street_suffix filter');
     var filter = s.analysis.filter.street_suffix;
-    t.equal(filter.type, 'synonym');
+    t.equal(filter.type, 'synonym_graph');
     t.true(Array.isArray(filter.synonyms));
     t.equal(filter.synonyms.length, 127);
     t.end();
@@ -417,7 +417,7 @@ module.exports.tests.directionSynonymFilter = function(test, common) {
     var s = settings();
     t.equal(typeof s.analysis.filter.directionals, 'object', 'there is an directionals filter');
     var filter = s.analysis.filter.directionals;
-    t.equal(filter.type, 'synonym');
+    t.equal(filter.type, 'synonym_graph');
     t.true(Array.isArray(filter.synonyms));
     t.equal(filter.synonyms.length, 8);
     t.end();


### PR DESCRIPTION
This is an exploration of using the `synonym_graph` filter instead of
the `synonym` filter. Quite a few integration tests fail, but they all
look to be simple order changes of otherwise identical tokens.

I didn't bother to fix them all because I'd first like to explore
whether or not this change actually has any effect on query results or
ES6 compatibility.

Connects https://github.com/pelias/schema/issues/381
