### PR TITLE
Add "tce" as a synonym of terrace

### DIFF
--- a/synonyms/street_suffix.txt
+++ b/synonyms/street_suffix.txt
@@ -109,7 +109,7 @@ springs, spgs
 square, sq
 street, st
 suite, ste
-terrace, terr
+terrace, terr, tce
 trail, trl, tr
 trafficway, trfy
 tunnel, tunl

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -643,7 +643,7 @@
             "square,sq",
             "street,st",
             "suite,ste",
-            "terrace,terr",
+            "terrace,terr,tce",
             "trail,trl,tr",
             "trafficway,trfy",
             "tunnel,tunl",


### PR DESCRIPTION
:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

---
#### Here's the reason for this change :rocket:
I came across an example yesterday "39 Bellavista tce, Paddington, Queensland 4064, Australia"
It seems only "terrace" and "terr" are currently synonyms so tce doesn't match and causes a bad geocode.
https://pelias.github.io/compare/#/v1/search%3Ftext=39%20Bellavista%20tce,%20Paddington,%20Queensland%204064,%20Australia

Checking my database of 5 million real world (mostly Australian) addresses I have:
- 47133 ending with "terrace"
- 6333 ending with "tce"
- 6 ending with "terr"
---
#### Here's what actually got changed :clap:
Added tce as a synonym of terrace.
