### PR TITLE
enforce strict checking of token positions

### DIFF
--- a/integration/analyzer_peliasAdmin.js
+++ b/integration/analyzer_peliasAdmin.js
@@ -78,19 +78,19 @@ module.exports.tests.synonyms = function(test, common){
 
     assertAnalysis( 'place', 'Saint-Louis-du-Ha! Ha!', [
       '0:saint', '0:st', '1:louis', '2:du', '3:ha', '4:ha'
-    ], true);
+    ]);
 
     assertAnalysis( 'place', 'Sainte-Chapelle', [
       '0:sainte', '0:ste', '1:chapelle'
-    ], true);
+    ]);
 
     assertAnalysis( 'place', 'Mount Everest', [
       '0:mount', '0:mt', '1:everest'
-    ], true);
+    ]);
 
     assertAnalysis( 'place', 'Mont Blanc', [
       '0:mont', '0:mt', '1:blanc'
-    ], true);
+    ]);
 
     suite.run( t.end );
   });
@@ -103,19 +103,21 @@ module.exports.tests.tokenizer = function(test, common){
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasAdmin' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
+    const expected = ['0:trinidad', '1:tobago'];
+
     // specify 2 parts with a delimeter
-    assertAnalysis( 'forward slash', 'Trinidad/Tobago',   [ 'trinidad', 'tobago' ]);
-    assertAnalysis( 'forward slash', 'Trinidad /Tobago',  [ 'trinidad', 'tobago' ]);
-    assertAnalysis( 'forward slash', 'Trinidad/ Tobago',  [ 'trinidad', 'tobago' ]);
-    assertAnalysis( 'back slash',    'Trinidad\\Tobago',  [ 'trinidad', 'tobago' ]);
-    assertAnalysis( 'back slash',    'Trinidad \\Tobago', [ 'trinidad', 'tobago' ]);
-    assertAnalysis( 'back slash',    'Trinidad\\ Tobago', [ 'trinidad', 'tobago' ]);
-    assertAnalysis( 'comma',         'Trinidad,Tobago',   [ 'trinidad', 'tobago' ]);
-    assertAnalysis( 'comma',         'Trinidad ,Tobago',  [ 'trinidad', 'tobago' ]);
-    assertAnalysis( 'comma',         'Trinidad, Tobago',  [ 'trinidad', 'tobago' ]);
-    assertAnalysis( 'space',         'Trinidad,Tobago',   [ 'trinidad', 'tobago' ]);
-    assertAnalysis( 'space',         'Trinidad ,Tobago',  [ 'trinidad', 'tobago' ]);
-    assertAnalysis( 'space',         'Trinidad, Tobago',  [ 'trinidad', 'tobago' ]);
+    assertAnalysis( 'forward slash', 'Trinidad/Tobago',   expected);
+    assertAnalysis( 'forward slash', 'Trinidad /Tobago',  expected);
+    assertAnalysis( 'forward slash', 'Trinidad/ Tobago',  expected);
+    assertAnalysis( 'back slash',    'Trinidad\\Tobago',  expected);
+    assertAnalysis( 'back slash',    'Trinidad \\Tobago', expected);
+    assertAnalysis( 'back slash',    'Trinidad\\ Tobago', expected);
+    assertAnalysis( 'comma',         'Trinidad,Tobago',   expected);
+    assertAnalysis( 'comma',         'Trinidad ,Tobago',  expected);
+    assertAnalysis( 'comma',         'Trinidad, Tobago',  expected);
+    assertAnalysis( 'space',         'Trinidad,Tobago',   expected);
+    assertAnalysis( 'space',         'Trinidad ,Tobago',  expected);
+    assertAnalysis( 'space',         'Trinidad, Tobago',  expected);
 
     suite.run( t.end );
   });

--- a/integration/analyzer_peliasIndexOneEdgeGram.js
+++ b/integration/analyzer_peliasIndexOneEdgeGram.js
@@ -16,62 +16,72 @@ module.exports.tests.analyze = function(test, common){
 
     assertAnalysis( 'lowercase', 'F', ['f']);
     assertAnalysis( 'asciifolding', 'á', ['a']);
-    assertAnalysis( 'asciifolding', 'ß', ['s','ss']);
-    assertAnalysis( 'asciifolding', 'æ', ['a','ae']);
+    assertAnalysis( 'asciifolding', 'ß', ['0:s','0:ss']);
+    assertAnalysis( 'asciifolding', 'æ', ['0:a','0:ae']);
     assertAnalysis( 'asciifolding', 'ł', ['l']);
     assertAnalysis( 'asciifolding', 'ɰ', ['m']);
     assertAnalysis( 'trim', ' f ', ['f'] );
-    assertAnalysis( 'ampersand', 'a and b', [
+    assertAnalysis('ampersand', 'a and b', [
       '0:a',
       '1:a', '1:an', '1:and', '1:&',
       '2:b'
-    ], true );
-    assertAnalysis( 'ampersand', 'a & b', [
+    ]);
+    assertAnalysis('ampersand', 'a & b', [
       '0:a',
       '1:&', '1:a', '1:an', '1:and', '1:u', '1:un', '1:und',
       '2:b'
-    ], true );
-    assertAnalysis( 'ampersand', 'a and & and b', [
+    ]);
+    assertAnalysis('ampersand', 'a and & and b', [
       '0:a',
       '1:a', '1:an', '1:and', '1:&',
       '2:&', '2:a', '2:an', '2:and', '2:u', '2:un', '2:und',
       '3:a', '3:an', '3:and', '3:&',
       '4:b'
-    ], true );
-    assertAnalysis( 'ampersand', 'land', ['l','la','lan','land'] ); // should not replace inside tokens
+    ]);
+    assertAnalysis( 'ampersand', 'land', ['0:l','0:la','0:lan','0:land'] ); // should not replace inside tokens
 
     // keyword_street_suffix
-    assertAnalysis( 'keyword_street_suffix', 'rd', ['r','rd','ro','roa','road'] );
-    assertAnalysis( 'keyword_street_suffix', 'ctr', ['c', 'ct', 'ctr', 'ce', 'cen', 'cent', 'cente', 'center'] );
+    assertAnalysis( 'keyword_street_suffix', 'rd', ['0:r','0:rd','0:ro','0:roa','0:road'] );
+    assertAnalysis( 'keyword_street_suffix', 'ctr', ['0:c', '0:ct', '0:ctr', '0:ce', '0:cen', '0:cent', '0:cente', '0:center'] );
 
     assertAnalysis( 'peliasIndexOneEdgeGramFilter', '1 a ab abc abcdefghij', [
-      '1', 'a', 'a', 'ab', 'a', 'ab', 'abc', 'a', 'ab', 'abc',
-      'abcd', 'abcde', 'abcdef', 'abcdefg', 'abcdefgh', 'abcdefghi', 'abcdefghij'
+      '0:1',
+      '1:a',
+      '2:a', '2:ab',
+      '3:a', '3:ab', '3:abc',
+      '4:a', '4:ab', '4:abc', '4:abcd', '4:abcde', '4:abcdef', 
+      '4:abcdefg', '4:abcdefgh', '4:abcdefghi', '4:abcdefghij'
     ] );
     assertAnalysis( 'removeAllZeroNumericPrefix', '00001', ['1'] );
 
     assertAnalysis( 'unique', '1 1 1', ['1','1','1'] );
     assertAnalysis( 'notnull', ' / / ', [] );
 
-    assertAnalysis( 'no kstem', 'mcdonalds', ['m', 'mc', 'mcd', 'mcdo', 'mcdon', 'mcdona', 'mcdonal', 'mcdonald', 'mcdonalds'] );
-    assertAnalysis( 'no kstem', 'McDonald\'s', ['m', 'mc', 'mcd', 'mcdo', 'mcdon', 'mcdona', 'mcdonal', 'mcdonald', 'mcdonalds'] );
-    assertAnalysis( 'no kstem', 'peoples', ['p', 'pe', 'peo', 'peop', 'peopl', 'people', 'peoples'] );
+    assertAnalysis( 'no kstem', 'mcdonalds', [
+      '0:m', '0:mc', '0:mcd', '0:mcdo', '0:mcdon', '0:mcdona', '0:mcdonal', '0:mcdonald', '0:mcdonalds'
+    ]);
+    assertAnalysis( 'no kstem', 'McDonald\'s', [
+      '0:m', '0:mc', '0:mcd', '0:mcdo', '0:mcdon', '0:mcdona', '0:mcdonal', '0:mcdonald', '0:mcdonalds'
+    ]);
+    assertAnalysis( 'no kstem', 'peoples', [
+      '0:p', '0:pe', '0:peo', '0:peop', '0:peopl', '0:people', '0:peoples'
+    ]);
 
     // remove punctuation (handled by the char_filter)
-    assertAnalysis( 'punctuation', punctuation.all.join(''), ['&', 'a', 'an', 'and', 'u', 'un', 'und'] );
-    assertAnalysis( 'punctuation', 'Hawai‘i', ['h', 'ha', 'haw', 'hawa', 'hawai', 'hawaii'] );
+    assertAnalysis('punctuation', punctuation.all.join(''), ['0:&', '0:a', '0:an', '0:and', '0:u', '0:un', '0:und'] );
+    assertAnalysis( 'punctuation', 'Hawai‘i', ['0:h', '0:ha', '0:haw', '0:hawa', '0:hawai', '0:hawaii'] );
 
     // ensure that very large grams are created
     assertAnalysis( 'largeGrams', 'grolmanstrasse', [
-      'g','gr','gro','grol','grolm','grolma','grolman','grolmans','grolmanst',
-      'grolmanstr','grolmanstra','grolmanstras','grolmanstrass',
-      'grolmanstrasse'
+      '0:g', '0:gr', '0:gro', '0:grol', '0:grolm', '0:grolma', '0:grolman', '0:grolmans',
+      '0:grolmanst', '0:grolmanstr', '0:grolmanstra', '0:grolmanstras', '0:grolmanstrass',
+      '0:grolmanstrasse'
     ]);
-    assertAnalysis( 'largeGrams2', 'Flughafeninformation', [ 'f', 'fl', 'flu',
-      'flug', 'flugh', 'flugha', 'flughaf', 'flughafe', 'flughafen', 'flughafeni',
-      'flughafenin', 'flughafeninf', 'flughafeninfo', 'flughafeninfor',
-      'flughafeninform', 'flughafeninforma', 'flughafeninformat', 'flughafeninformati',
-      'flughafeninformatio', 'flughafeninformation'
+    assertAnalysis( 'largeGrams2', 'Flughafeninformation', [ '0:f', '0:fl', '0:flu',
+      '0:flug', '0:flugh', '0:flugha', '0:flughaf', '0:flughafe', '0:flughafen', '0:flughafeni',
+      '0:flughafenin', '0:flughafeninf', '0:flughafeninfo', '0:flughafeninfor', '0:flughafeninform',
+      '0:flughafeninforma', '0:flughafeninformat', '0:flughafeninformati',
+      '0:flughafeninformatio', '0:flughafeninformation'
     ]);
 
     suite.run( t.end );
@@ -88,19 +98,21 @@ module.exports.tests.address_suffix_expansions = function(test, common){
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     assertAnalysis( 'safe expansions', 'aly', [
-      'a', 'al', 'aly', 'all', 'alle', 'alley'
+      '0:a', '0:al', '0:aly', '0:all', '0:alle', '0:alley'
     ]);
 
     assertAnalysis( 'safe expansions', 'xing', [
-      'x', 'xi', 'xin', 'xing', 'c', 'cr', 'cro', 'cros', 'cross', 'crossi', 'crossin', 'crossing'
+      '0:x', '0:xi', '0:xin', '0:xing',
+      '0:c', '0:cr', '0:cro', '0:cros', '0:cross', '0:crossi', '0:crossin', '0:crossing'
     ]);
 
     assertAnalysis( 'safe expansions', 'rd', [
-      'r', 'rd', 'ro', 'roa', 'road'
+      '0:r', '0:rd', '0:ro', '0:roa', '0:road'
     ]);
 
     assertAnalysis( 'unsafe expansion', 'ct st', [
-      'c', 'ct', 'co', 'cou', 'cour', 'court', 's', 'st', 'str', 'stre', 'stree', 'street'
+      '0:c', '0:ct', '0:co', '0:cou', '0:cour', '0:court',
+      '1:s', '1:st', '1:str', '1:stre', '1:stree', '1:street'
     ]);
 
     suite.run( t.end );
@@ -116,11 +128,13 @@ module.exports.tests.stop_words = function(test, common){
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     assertAnalysis( 'street suffix', 'AB street', [
-      'a', 'ab', 's', 'st', 'str', 'stre', 'stree', 'street'
+      '0:a', '0:ab',
+      '1:s', '1:st', '1:str', '1:stre', '1:stree', '1:street'
     ]);
 
     assertAnalysis( 'street suffix (abbreviation)', 'AB st', [
-      'a', 'ab', 's', 'st', 'str', 'stre', 'stree', 'street'
+      '0:a', '0:ab',
+      '1:s', '1:st', '1:str', '1:stre', '1:stree', '1:street'
     ]);
 
     suite.run( t.end );
@@ -134,18 +148,18 @@ module.exports.tests.functional = function(test, common){
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasIndexOneEdgeGram' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
-    assertAnalysis( 'country', 'Trinidad and Tobago', [
-      't', 'tr', 'tri', 'trin', 'trini', 'trinid', 'trinida', 'trinidad',
-      'a', 'an', 'and', '&',
-      't', 'to', 'tob', 'toba', 'tobag', 'tobago'
+    assertAnalysis('country', 'Trinidad and Tobago', [
+      '0:t', '0:tr', '0:tri', '0:trin', '0:trini', '0:trinid', '0:trinida', '0:trinidad',
+      '1:a', '1:an', '1:and', '1:&',
+      '2:t', '2:to', '2:tob', '2:toba', '2:tobag', '2:tobago'
     ]);
 
-    assertAnalysis( 'place', 'Toys "R" Us!', [
-      't', 'to', 'toy', 'toys', 'r', 'u', 'us'
+    assertAnalysis('place', 'Toys "R" Us!', [
+      '0:t', '0:to', '0:toy', '0:toys', '1:r', '2:u', '2:us'
     ]);
 
-    assertAnalysis( 'address', '101 mapzen place', [
-      '101', 'm', 'ma', 'map', 'mapz', 'mapze', 'mapzen', 'p', 'pl', 'pla', 'plac', 'place'
+    assertAnalysis('address', '101 mapzen place', [
+      '0:101', '1:m', '1:ma', '1:map', '1:mapz', '1:mapze', '1:mapzen', '2:p', '2:pl', '2:pla', '2:plac', '2:place'
     ]);
 
     suite.run( t.end );
@@ -161,7 +175,7 @@ module.exports.tests.unique = function(test, common){
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     // if 'only_on_same_position' is not used the '1:a' token is erroneously removed
-    assertAnalysis( 'unique', 'a ab', [ '0:a', '1:a', '1:ab' ], true);
+    assertAnalysis( 'unique', 'a ab', [ '0:a', '1:a', '1:ab' ]);
 
     suite.run( t.end );
   });
@@ -175,15 +189,23 @@ module.exports.tests.address = function(test, common){
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     assertAnalysis( 'address', '101 mapzen place', [
-      '101', 'm', 'ma', 'map', 'mapz', 'mapze', 'mapzen', 'p', 'pl', 'pla', 'plac', 'place'
+      '0:101',
+      '1:m', '1:ma', '1:map', '1:mapz', '1:mapze', '1:mapzen',
+      '2:p', '2:pl', '2:pla', '2:plac', '2:place'
     ]);
 
     assertAnalysis( 'address', '30 w 26 st', [
-      '30', 'w', 'we', 'wes', 'west', '26', 's', 'st', 'str', 'stre', 'stree', 'street'
+      '0:30',
+      '1:w', '1:we', '1:wes', '1:west',
+      '2:26',
+      '3:s', '3:st', '3:str', '3:stre', '3:stree', '3:street'
     ]);
 
     assertAnalysis( 'address', '4B 921 83 st', [
-      '4b', '921', '83', 's', 'st', 'str', 'stre', 'stree', 'street'
+      '0:4b',
+      '2:921', // @todo: this token position is incorrect
+      '3:83',
+      '4:s', '4:st', '4:str', '4:stre', '4:stree', '4:street'
     ]);
 
     suite.run( t.end );
@@ -208,15 +230,19 @@ module.exports.tests.unicode = function(test, common){
     var composed = "Chamb" + latin_small_letter_e_with_acute + "ry";
     var decomposed = "Chamb" + combining_acute_accent + latin_small_letter_e + "ry"
 
-    assertAnalysis( 'composed', composed, ['c', 'ch', 'cha', 'cham', 'chamb', 'chambe', 'chamber', 'chambery'] );
-    assertAnalysis( 'decomposed', decomposed, ['c', 'ch', 'cha', 'cham', 'chamb', 'chambe', 'chamber', 'chambery'] );
+    assertAnalysis( 'composed', composed, [
+      '0:c', '0:ch', '0:cha', '0:cham', '0:chamb', '0:chambe', '0:chamber', '0:chambery'
+    ] );
+    assertAnalysis( 'decomposed', decomposed, [
+      '0:c', '0:ch', '0:cha', '0:cham', '0:chamb', '0:chambe', '0:chamber', '0:chambery'
+    ] );
 
     // Één (both forms appear the same)
     var composed = latin_large_letter_e_with_acute + latin_small_letter_e_with_acute + "n";
     var decomposed = combining_acute_accent + latin_large_letter_e + combining_acute_accent + latin_small_letter_e + "n"
 
-    assertAnalysis( 'composed', composed, ['e','ee','een'] );
-    assertAnalysis( 'decomposed', decomposed, ['e','ee','een'] );
+    assertAnalysis('composed', composed, ['0:e', '0:ee', '0:een']);
+    assertAnalysis('decomposed', decomposed, ['0:e', '0:ee', '0:een']);
 
     suite.run( t.end );
   });

--- a/integration/analyzer_peliasPhrase.js
+++ b/integration/analyzer_peliasPhrase.js
@@ -21,10 +21,10 @@ module.exports.tests.analyze = function(test, common){
     assertAnalysis( 'asciifolding', 'ł', ['l']);
     assertAnalysis( 'asciifolding', 'ɰ', ['m']);
     assertAnalysis( 'trim', ' f ', ['f'] );
-    assertAnalysis( 'stop_words (disabled)', 'a st b ave c', ['0:a', '1:st', '1:street', '2:b', '3:ave', '3:avenue', '3:av', '4:c'], true );
-    assertAnalysis( 'ampersand', 'a and b', ['a', 'and', '&', 'b']);
-    assertAnalysis( 'ampersand', 'a & b', ['a', '&', 'and', 'und', 'b']);
-    assertAnalysis( 'ampersand', 'a and & and b', ['a', 'and', '&', '&', 'and', 'und', 'and', '&', 'b']);
+    assertAnalysis( 'stop_words (disabled)', 'a st b ave c', ['0:a', '1:st', '1:street', '2:b', '3:ave', '3:avenue', '3:av', '4:c'] );
+    assertAnalysis( 'ampersand', 'a and b', ['0:a', '1:and', '1:&', '2:b']);
+    assertAnalysis( 'ampersand', 'a & b', ['0:a', '1:&', '1:and', '1:und', '2:b']);
+    assertAnalysis( 'ampersand', 'a and & and b', ['0:a', '1:and', '1:&', '2:&', '2:and', '2:und', '3:and', '3:&', '4:b']);
     assertAnalysis( 'ampersand', 'land', ['land'] ); // should not replace inside tokens
 
     // @todo: handle multiple consecutive 'and'
@@ -38,14 +38,14 @@ module.exports.tests.analyze = function(test, common){
     assertAnalysis( 'unique', '1 1 1', ['1','1','1'] );
     assertAnalysis( 'notnull', ' ^ ', [] );
 
-    assertAnalysis( 'stem street suffixes', 'streets avenue', ['0:streets', '1:avenue', '1:ave', '1:av'], true );
-    assertAnalysis( 'stem street suffixes', 'boulevard roads', ['0:boulevard', '0:blvd', '1:roads'], true );
+    assertAnalysis( 'stem street suffixes', 'streets avenue', ['0:streets', '1:avenue', '1:ave', '1:av'] );
+    assertAnalysis( 'stem street suffixes', 'boulevard roads', ['0:boulevard', '0:blvd', '1:roads'] );
 
-    assertAnalysis( 'stem direction synonyms', 'south by southwest', ['0:south', '0:s', '1:by', '2:southwest', '2:sw'], true );
-    assertAnalysis( 'stem direction synonyms', '20 bear road northeast', ['0:20', '1:bear', '2:road', '2:rd', '3:northeast', '3:ne'], true );
+    assertAnalysis( 'stem direction synonyms', 'south by southwest', ['0:south', '0:s', '1:by', '2:southwest', '2:sw'] );
+    assertAnalysis( 'stem direction synonyms', '20 bear road northeast', ['0:20', '1:bear', '2:road', '2:rd', '3:northeast', '3:ne'] );
 
     // remove punctuation (handled by the char_filter)
-    assertAnalysis( 'punctuation', punctuation.all.join(''), ['&', 'and', 'und'] );
+    assertAnalysis( 'punctuation', punctuation.all.join(''), ['0:&', '0:and', '0:und'] );
     assertAnalysis( 'punctuation', 'Hawai‘i', ['hawaii'] );
 
     suite.run( t.end );
@@ -61,7 +61,7 @@ module.exports.tests.functional = function(test, common){
 
     assertAnalysis( 'country', 'Trinidad and Tobago', [
       '0:trinidad', '1:and', '1:&', '2:tobago'
-    ], true);
+    ]);
 
     assertAnalysis( 'place', 'Toys "R" Us!', [
       'toys', 'r', 'us'
@@ -69,31 +69,31 @@ module.exports.tests.functional = function(test, common){
 
     assertAnalysis( 'address', '101 geocode pl', [
       '0:101', '1:geocode', '2:pl', '2:place', '2:platz'
-    ], true);
+    ]);
 
     // both terms should map to same tokens
     var expected1 = [ '0:325', '1:n', '1:north', '2:12', '3:st', '3:street' ];
     var expected2 = [ '0:325', '1:north', '1:n', '2:12', '3:street', '3:st' ];
-    assertAnalysis( 'address', '325 N 12th St', expected1, true );
-    assertAnalysis( 'address', '325 North 12th Street', expected2, true );
+    assertAnalysis( 'address', '325 N 12th St', expected1 );
+    assertAnalysis( 'address', '325 North 12th Street', expected2 );
 
     // both terms should map to same tokens
     var expected3 = [ '0:13509', '1:colfax', '2:ave', '2:avenue', '2:av', '3:s', '3:south', '3:see' ];
     var expected4 = [ '0:13509', '1:colfax', '2:avenue', '2:ave', '2:av', '3:south', '3:s' ];
-    assertAnalysis( 'address', '13509 Colfax Ave S', expected3, true );
-    assertAnalysis( 'address', '13509 Colfax Avenue South', expected4, true );
+    assertAnalysis( 'address', '13509 Colfax Ave S', expected3 );
+    assertAnalysis( 'address', '13509 Colfax Avenue South', expected4 );
 
     // both terms should map to same tokens
     var expected5 = [ '0:100', '1:s', '1:south', '1:see', '2:lake', '2:lk', '3:dr', '3:drive' ];
     var expected6 = [ '0:100', '1:south', '1:s', '2:lake', '2:lk', '3:drive', '3:dr' ];
-    assertAnalysis( 'address', '100 S Lake Dr', expected5, true );
-    assertAnalysis( 'address', '100 South Lake Drive', expected6, true );
+    assertAnalysis( 'address', '100 S Lake Dr', expected5 );
+    assertAnalysis( 'address', '100 South Lake Drive', expected6 );
 
     // both terms should map to same tokens
     var expected7 = [ '0:100', '1:northwest', '1:nw', '2:highway', '2:hwy' ];
     var expected8 = [ '0:100', '1:nw', '1:northwest', '2:hwy', '2:highway' ];
-    assertAnalysis( 'address', '100 northwest highway', expected7, true );
-    assertAnalysis( 'address', '100 nw hwy', expected8, true );
+    assertAnalysis( 'address', '100 northwest highway', expected7 );
+    assertAnalysis( 'address', '100 nw hwy', expected8 );
 
     suite.run( t.end );
   });
@@ -106,19 +106,18 @@ module.exports.tests.tokenizer = function(test, common){
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasPhrase' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
-    var expected1 = [ '0:bedell', '1:street', '1:st', '2:133', '3:avenue', '3:ave', '3:av' ];
-    var expected2 = [ '0:bedell', '1:street', '1:st', '102:133', '103:avenue', '103:ave', '103:av' ];
+    var expected = [ '0:bedell', '1:street', '1:st', '2:133', '3:avenue', '3:ave', '3:av' ];
 
     // specify 2 streets with a delimeter
-    assertAnalysis( 'forward slash', 'Bedell Street/133rd Avenue',   expected1, true );
-    assertAnalysis( 'forward slash', 'Bedell Street /133rd Avenue',  expected1, true );
-    assertAnalysis( 'forward slash', 'Bedell Street/ 133rd Avenue',  expected1, true );
-    assertAnalysis( 'back slash',    'Bedell Street\\133rd Avenue',  expected1, true );
-    assertAnalysis( 'back slash',    'Bedell Street \\133rd Avenue', expected1, true );
-    assertAnalysis( 'back slash',    'Bedell Street\\ 133rd Avenue', expected1, true );
-    assertAnalysis( 'comma',         'Bedell Street,133rd Avenue',   expected2, true );
-    assertAnalysis( 'comma',         'Bedell Street ,133rd Avenue',  expected2, true );
-    assertAnalysis( 'comma',         'Bedell Street, 133rd Avenue',  expected2, true );
+    assertAnalysis( 'forward slash', 'Bedell Street/133rd Avenue',   expected );
+    assertAnalysis( 'forward slash', 'Bedell Street /133rd Avenue',  expected );
+    assertAnalysis( 'forward slash', 'Bedell Street/ 133rd Avenue',  expected );
+    assertAnalysis( 'back slash',    'Bedell Street\\133rd Avenue',  expected );
+    assertAnalysis( 'back slash',    'Bedell Street \\133rd Avenue', expected );
+    assertAnalysis( 'back slash',    'Bedell Street\\ 133rd Avenue', expected );
+    assertAnalysis( 'comma',         'Bedell Street,133rd Avenue',   expected );
+    assertAnalysis( 'comma',         'Bedell Street ,133rd Avenue',  expected );
+    assertAnalysis( 'comma',         'Bedell Street, 133rd Avenue',  expected );
 
     suite.run( t.end );
   });

--- a/integration/analyzer_peliasQueryFullToken.js
+++ b/integration/analyzer_peliasQueryFullToken.js
@@ -21,17 +21,23 @@ module.exports.tests.analyze = function(test, common){
     assertAnalysis( 'asciifolding', 'ł', ['l']);
     assertAnalysis( 'asciifolding', 'ɰ', ['m']);
     assertAnalysis( 'trim', ' f ', ['f'] );
-    assertAnalysis('ampersand', 'a and b', ['a', 'and', '&', 'b']);
-    assertAnalysis('ampersand', 'a & b', ['a', '&', 'and', 'und', 'b']);
-    assertAnalysis('ampersand', 'a and & and b', ['a', 'and', '&', '&', 'and', 'und', 'and', '&', 'b']);
-    assertAnalysis( 'ampersand', 'land', ['land'] ); // should not replace inside tokens
+    assertAnalysis('ampersand', 'a and b', ['0:a', '1:and', '1:&', '2:b']);
+    assertAnalysis('ampersand', 'a & b', ['0:a', '1:&', '1:and', '1:und', '2:b']);
+    assertAnalysis('ampersand', 'a and & and b', [
+      '0:a',
+      '1:and', '1:&',
+      '2:&', '2:and', '2:und',
+      '3:and', '3:&',
+      '4:b'
+    ]);
+    assertAnalysis('ampersand', 'land', ['land'] ); // should not replace inside tokens
 
-    assertAnalysis( 'keyword_street_suffix', 'foo Street', ['foo', 'street', 'st'] );
-    assertAnalysis( 'keyword_street_suffix', 'foo Road', ['foo', 'road', 'rd'] );
-    assertAnalysis( 'keyword_street_suffix', 'foo Crescent', ['foo', 'crescent', 'cres'] );
-    assertAnalysis( 'keyword_compass', 'north foo', ['north', 'n', 'foo'] );
-    assertAnalysis( 'keyword_compass', 'SouthWest foo', ['southwest', 'sw', 'foo'] );
-    assertAnalysis( 'keyword_compass', 'foo SouthWest', ['foo', 'southwest', 'sw'] );
+    assertAnalysis('keyword_street_suffix', 'foo Street', ['0:foo', '1:street', '1:st'] );
+    assertAnalysis('keyword_street_suffix', 'foo Road', ['0:foo', '1:road', '1:rd'] );
+    assertAnalysis('keyword_street_suffix', 'foo Crescent', ['0:foo', '1:crescent', '1:cres'] );
+    assertAnalysis('keyword_compass', 'north foo', ['0:north', '0:n', '1:foo'] );
+    assertAnalysis('keyword_compass', 'SouthWest foo', ['0:southwest', '0:sw', '1:foo'] );
+    assertAnalysis('keyword_compass', 'foo SouthWest', ['0:foo', '1:southwest', '1:sw'] );
 
     assertAnalysis( 'peliasQueryFullTokenFilter', '1 a ab abc abcdefghij', ['1','a','ab','abc','abcdefghij'] );
     assertAnalysis( 'removeAllZeroNumericPrefix', '00001', ['1'] );
@@ -43,7 +49,7 @@ module.exports.tests.analyze = function(test, common){
     assertAnalysis( 'no kstem', 'peoples', ['peoples'] );
 
     // remove punctuation (handled by the char_filter)
-    assertAnalysis( 'punctuation', punctuation.all.join(''), ['&', 'and', 'und'] );
+    assertAnalysis( 'punctuation', punctuation.all.join(''), ['0:&', '0:and', '0:und'] );
 
     // ensure that very large tokens are created
     assertAnalysis( 'largeGrams', 'grolmanstrasse', [ 'grolmanstrasse' ]);
@@ -59,13 +65,13 @@ module.exports.tests.address_suffix_expansions = function(test, common){
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasQueryFullToken' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
-    assertAnalysis( 'safe expansions', 'aly', [ 'aly', 'alley' ]);
+    assertAnalysis('safe expansions', 'aly', ['0:aly', '0:alley' ]);
 
-    assertAnalysis( 'safe expansions', 'xing', [ 'xing', 'crossing' ]);
+    assertAnalysis('safe expansions', 'xing', ['0:xing', '0:crossing' ]);
 
-    assertAnalysis( 'safe expansions', 'rd', [ 'rd', 'road' ]);
+    assertAnalysis('safe expansions', 'rd', ['0:rd', '0:road' ]);
 
-    assertAnalysis( 'safe expansion', 'ct st', [ 'ct', 'court', 'st', 'street' ]);
+    assertAnalysis('safe expansion', 'ct st', ['0:ct', '0:court', '1:st', '1:street' ]);
 
     suite.run( t.end );
   });
@@ -79,9 +85,9 @@ module.exports.tests.stop_words = function(test, common){
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasQueryFullToken' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
-    assertAnalysis( 'street suffix', 'AB street', [ 'ab', 'street', 'st' ]);
+    assertAnalysis( 'street suffix', 'AB street', [ '0:ab', '1:street', '1:st' ]);
 
-    assertAnalysis( 'street suffix (abbreviation)', 'AB st', [ 'ab', 'st', 'street' ]);
+    assertAnalysis( 'street suffix (abbreviation)', 'AB st', [ '0:ab', '1:st', '1:street' ]);
 
     suite.run( t.end );
   });
@@ -96,14 +102,14 @@ module.exports.tests.functional = function(test, common){
 
     assertAnalysis( 'country', 'Trinidad and Tobago', [
       '0:trinidad', '1:and', '1:&', '2:tobago'
-    ], true);
+    ]);
 
     assertAnalysis( 'place', 'Toys "R" Us!', [
-      'toys', 'r', 'us'
+      '0:toys', '1:r', '2:us'
     ]);
 
     assertAnalysis( 'address', '101 mapzen place', [
-      '101', 'mapzen', 'place', 'pl'
+      '0:101', '1:mapzen', '2:place', '2:pl'
     ]);
 
     suite.run( t.end );
@@ -117,16 +123,18 @@ module.exports.tests.tokenizer = function(test, common){
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasQueryFullToken' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
+    const expected = ['0:bedell', '1:street', '1:st', '2:133', '3:avenue', '3:ave', '3:av'];
+
     // specify 2 streets with a delimeter
-    assertAnalysis( 'forward slash', 'Bedell Street/133rd Avenue',   [ 'bedell', 'street', 'st', '133', 'avenue', 'ave', 'av' ]);
-    assertAnalysis( 'forward slash', 'Bedell Street /133rd Avenue',  [ 'bedell', 'street', 'st', '133', 'avenue', 'ave', 'av' ]);
-    assertAnalysis( 'forward slash', 'Bedell Street/ 133rd Avenue',  [ 'bedell', 'street', 'st', '133', 'avenue', 'ave', 'av' ]);
-    assertAnalysis( 'back slash',    'Bedell Street\\133rd Avenue',  [ 'bedell', 'street', 'st', '133', 'avenue', 'ave', 'av' ]);
-    assertAnalysis( 'back slash',    'Bedell Street \\133rd Avenue', [ 'bedell', 'street', 'st', '133', 'avenue', 'ave', 'av' ]);
-    assertAnalysis( 'back slash',    'Bedell Street\\ 133rd Avenue', [ 'bedell', 'street', 'st', '133', 'avenue', 'ave', 'av' ]);
-    assertAnalysis( 'comma',         'Bedell Street,133rd Avenue',   [ 'bedell', 'street', 'st', '133', 'avenue', 'ave', 'av' ]);
-    assertAnalysis( 'comma',         'Bedell Street ,133rd Avenue',  [ 'bedell', 'street', 'st', '133', 'avenue', 'ave', 'av' ]);
-    assertAnalysis( 'comma',         'Bedell Street, 133rd Avenue',  [ 'bedell', 'street', 'st', '133', 'avenue', 'ave', 'av' ]);
+    assertAnalysis( 'forward slash', 'Bedell Street/133rd Avenue',   expected);
+    assertAnalysis( 'forward slash', 'Bedell Street /133rd Avenue',  expected);
+    assertAnalysis( 'forward slash', 'Bedell Street/ 133rd Avenue',  expected);
+    assertAnalysis( 'back slash',    'Bedell Street\\133rd Avenue',  expected);
+    assertAnalysis( 'back slash',    'Bedell Street \\133rd Avenue', expected);
+    assertAnalysis( 'back slash',    'Bedell Street\\ 133rd Avenue', expected);
+    assertAnalysis( 'comma',         'Bedell Street,133rd Avenue',   expected);
+    assertAnalysis( 'comma',         'Bedell Street ,133rd Avenue',  expected);
+    assertAnalysis( 'comma',         'Bedell Street, 133rd Avenue',  expected);
 
     suite.run( t.end );
   });
@@ -184,15 +192,15 @@ module.exports.tests.address = function(test, common){
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     assertAnalysis( 'address', '101 mapzen place', [
-      '101', 'mapzen', 'place', 'pl'
+      '0:101', '1:mapzen', '2:place', '2:pl'
     ]);
 
     assertAnalysis( 'address', '30 w 26 st', [
-      '30', 'w', 'west', '26', 'st', 'street'
+      '0:30', '1:w', '1:west', '2:26', '3:st', '3:street'
     ]);
 
     assertAnalysis( 'address', '4B 921 83 st', [
-      '4b', '921', '83', 'st', 'street'
+      '0:4b', '1:921', '2:83', '3:st', '3:street'
     ]);
 
     suite.run( t.end );

--- a/integration/analyzer_peliasQueryPartialToken.js
+++ b/integration/analyzer_peliasQueryPartialToken.js
@@ -21,9 +21,23 @@ module.exports.tests.analyze = function(test, common){
     assertAnalysis( 'asciifolding', 'ł', ['l']);
     assertAnalysis( 'asciifolding', 'ɰ', ['m']);
     assertAnalysis( 'trim', ' f ', ['f'] );
-    assertAnalysis( 'ampersand', 'a and b', ['a','and','&','b'] );
-    assertAnalysis( 'ampersand', 'a & b', ['a','&','and','und','b'] );
-    assertAnalysis( 'ampersand', 'a and & and b', ['a','and','&','&','and','und','and','&','b'] );
+    assertAnalysis('ampersand', 'a and b', [
+      '0:a',
+      '1:and', '1:&',
+      '2:b'
+    ]);
+    assertAnalysis('ampersand', 'a & b', [
+      '0:a',
+      '1:&', '1:and', '1:und',
+      '2:b'
+    ]);
+    assertAnalysis('ampersand', 'a and & and b', [
+      '0:a',
+      '1:and', '1:&',
+      '2:&', '2:and', '2:und',
+      '3:and', '3:&',
+      '4:b'
+    ]);
     assertAnalysis( 'ampersand', 'land', ['land'] ); // should not replace inside tokens
 
     // partial_token_address_suffix_expansion
@@ -40,7 +54,7 @@ module.exports.tests.analyze = function(test, common){
     assertAnalysis( 'no kstem', 'peoples', ['peoples'] );
 
     // remove punctuation (handled by the char_filter)
-    assertAnalysis( 'punctuation', punctuation.all.join(''), ['&', 'and', 'und'] );
+    assertAnalysis( 'punctuation', punctuation.all.join(''), ['0:&', '0:and', '0:und'] );
 
     // ensure that very large grams are created
     assertAnalysis( 'largeGrams', 'grolmanstrasse', ['grolmanstrasse']);
@@ -90,7 +104,7 @@ module.exports.tests.functional = function(test, common){
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasQueryPartialToken' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
-    assertAnalysis( 'country', 'Trinidad and Tobago', [ '0:trinidad', '1:and', '1:&', '2:tobago' ], true);
+    assertAnalysis( 'country', 'Trinidad and Tobago', [ '0:trinidad', '1:and', '1:&', '2:tobago' ]);
     assertAnalysis( 'place', 'Toys "R" Us!', [ 'toys', 'r', 'us' ]);
     assertAnalysis( 'address', '101 mapzen place', [ '101', 'mapzen', 'place' ]);
 

--- a/integration/analyzer_peliasStreet.js
+++ b/integration/analyzer_peliasStreet.js
@@ -15,14 +15,14 @@ module.exports.tests.analyze = function(test, common){
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     assertAnalysis( 'lowercase', 'F', ['f']);
-    assertAnalysis( 'asciifolding', 'Max-Beer-Straße', ['max', 'beer', 'strasse', 'str']);
+    assertAnalysis( 'asciifolding', 'Max-Beer-Straße', ['0:max', '1:beer', '2:strasse', '2:str']);
     assertAnalysis( 'trim', ' f ', ['f'] );
-    assertAnalysis( 'keyword_street_suffix', 'foo Street', ['0:foo', '1:street', '1:st'], true );
-    assertAnalysis( 'keyword_street_suffix', 'foo Road', ['0:foo', '1:road', '1:rd'], true );
-    assertAnalysis( 'keyword_street_suffix', 'foo Crescent', ['0:foo', '1:crescent', '1:cres'], true );
-    assertAnalysis( 'keyword_compass', 'north foo', ['0:north', '0:n', '1:foo'], true );
-    assertAnalysis( 'keyword_compass', 'SouthWest foo', ['0:southwest', '0:sw', '1:foo'], true );
-    assertAnalysis( 'keyword_compass', 'foo SouthWest', ['0:foo', '1:southwest', '1:sw'], true );
+    assertAnalysis( 'keyword_street_suffix', 'foo Street', ['0:foo', '1:street', '1:st'] );
+    assertAnalysis( 'keyword_street_suffix', 'foo Road', ['0:foo', '1:road', '1:rd'] );
+    assertAnalysis( 'keyword_street_suffix', 'foo Crescent', ['0:foo', '1:crescent', '1:cres'] );
+    assertAnalysis( 'keyword_compass', 'north foo', ['0:north', '0:n', '1:foo'] );
+    assertAnalysis( 'keyword_compass', 'SouthWest foo', ['0:southwest', '0:sw', '1:foo'] );
+    assertAnalysis( 'keyword_compass', 'foo SouthWest', ['0:foo', '1:southwest', '1:sw'] );
     assertAnalysis( 'remove_ordinals', '1st 2nd 3rd 4th 5th', ['1','2','3','4','5'] );
     assertAnalysis( 'remove_ordinals', 'Ast th 101st', ['ast','th','101'] );
 
@@ -37,11 +37,11 @@ module.exports.tests.functional = function(test, common){
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasStreet' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
-    assertAnalysis( 'USA address', 'west 26th street', [ '0:west', '0:w', '1:26', '2:street', '2:st' ], true);
-    assertAnalysis( 'USA address', 'West 26th Street', [ '0:west', '0:w', '1:26', '2:street', '2:st' ], true);
-    assertAnalysis( 'USA address', 'w 26th st', [ '0:w', '0:west', '1:26', '2:st', '2:street' ], true);
-    assertAnalysis( 'USA address', 'WEST 26th STREET', [ '0:west', '0:w', '1:26', '2:street', '2:st' ], true);
-    assertAnalysis( 'USA address', 'WEST 26th ST', [ '0:west', '0:w', '1:26', '2:st', '2:street' ], true);
+    assertAnalysis( 'USA address', 'west 26th street', [ '0:west', '0:w', '1:26', '2:street', '2:st' ]);
+    assertAnalysis( 'USA address', 'West 26th Street', [ '0:west', '0:w', '1:26', '2:street', '2:st' ]);
+    assertAnalysis( 'USA address', 'w 26th st', [ '0:w', '0:west', '1:26', '2:st', '2:street' ]);
+    assertAnalysis( 'USA address', 'WEST 26th STREET', [ '0:west', '0:w', '1:26', '2:street', '2:st' ]);
+    assertAnalysis( 'USA address', 'WEST 26th ST', [ '0:west', '0:w', '1:26', '2:st', '2:street' ]);
 
     suite.run( t.end );
   });
@@ -56,10 +56,10 @@ module.exports.tests.normalize_punctuation = function(test, common){
 
     var expected = [ '0:chapala', '1:street', '1:st' ];
 
-    assertAnalysis( 'single space', 'Chapala Street',    expected, true );
-    assertAnalysis( 'double space', 'Chapala  Street',   expected, true );
-    assertAnalysis( 'triple space', 'Chapala   Street',  expected, true );
-    assertAnalysis( 'quad space',   'Chapala    Street', expected, true );
+    assertAnalysis( 'single space', 'Chapala Street',    expected );
+    assertAnalysis( 'double space', 'Chapala  Street',   expected );
+    assertAnalysis( 'triple space', 'Chapala   Street',  expected );
+    assertAnalysis( 'quad space',   'Chapala    Street', expected );
 
     suite.run( t.end );
   });
@@ -146,19 +146,18 @@ module.exports.tests.tokenizer = function(test, common){
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasStreet' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
-    var expected1 = [ '0:bedell', '1:street', '1:st', '2:133', '3:avenue', '3:ave', '3:av' ];
-    var expected2 = [ '0:bedell', '1:street', '1:st', '102:133', '103:avenue', '103:ave', '103:av' ];
+    var expected = [ '0:bedell', '1:street', '1:st', '2:133', '3:avenue', '3:ave', '3:av' ];
 
     // specify 2 streets with a delimeter
-    assertAnalysis( 'forward slash', 'Bedell Street/133rd Avenue',   expected1, true );
-    assertAnalysis( 'forward slash', 'Bedell Street /133rd Avenue',  expected1, true );
-    assertAnalysis( 'forward slash', 'Bedell Street/ 133rd Avenue',  expected1, true );
-    assertAnalysis( 'back slash',    'Bedell Street\\133rd Avenue',  expected1, true );
-    assertAnalysis( 'back slash',    'Bedell Street \\133rd Avenue', expected1, true );
-    assertAnalysis( 'back slash',    'Bedell Street\\ 133rd Avenue', expected1, true );
-    assertAnalysis( 'comma',         'Bedell Street,133rd Avenue',   expected2, true );
-    assertAnalysis( 'comma',         'Bedell Street ,133rd Avenue',  expected2, true );
-    assertAnalysis( 'comma',         'Bedell Street, 133rd Avenue',  expected2, true );
+    assertAnalysis( 'forward slash', 'Bedell Street/133rd Avenue',   expected );
+    assertAnalysis( 'forward slash', 'Bedell Street /133rd Avenue',  expected );
+    assertAnalysis( 'forward slash', 'Bedell Street/ 133rd Avenue',  expected );
+    assertAnalysis( 'back slash',    'Bedell Street\\133rd Avenue',  expected );
+    assertAnalysis( 'back slash',    'Bedell Street \\133rd Avenue', expected );
+    assertAnalysis( 'back slash',    'Bedell Street\\ 133rd Avenue', expected );
+    assertAnalysis( 'comma',         'Bedell Street,133rd Avenue',   expected );
+    assertAnalysis( 'comma',         'Bedell Street ,133rd Avenue',  expected );
+    assertAnalysis( 'comma',         'Bedell Street, 133rd Avenue',  expected );
 
     suite.run( t.end );
   });
@@ -204,15 +203,15 @@ module.exports.tests.germanic_street_suffixes = function (test, common) {
     suite.action(function (done) { setTimeout(done, 500); }); // wait for es to bring some shards up
 
     // Germanic street suffixes
-    assertAnalysis('straße', 'straße', ['0:strasse', '0:str'], true);
-    assertAnalysis('strasse', 'strasse', ['0:strasse', '0:str'], true);
-    assertAnalysis('str.', 'str.', ['0:str', '0:strasse'], true);
-    assertAnalysis('str', 'str', ['0:str', '0:strasse'], true);
-    assertAnalysis('brücke', 'brücke', [ '0:bruecke', '0:brucke', '0:br' ], true);
-    assertAnalysis('bruecke', 'bruecke', [ '0:bruecke', '0:brucke', '0:br' ], true);
-    assertAnalysis('brucke', 'brucke', ['0:brucke', '0:bruecke', '0:br'], true);
-    assertAnalysis('br.', 'br.', ['0:br', '0:branch', '0:bruecke', '0:brucke'], true);
-    assertAnalysis('br', 'br', ['0:br', '0:branch', '0:bruecke', '0:brucke'], true);
+    assertAnalysis('straße', 'straße', ['0:strasse', '0:str']);
+    assertAnalysis('strasse', 'strasse', ['0:strasse', '0:str']);
+    assertAnalysis('str.', 'str.', ['0:str', '0:strasse']);
+    assertAnalysis('str', 'str', ['0:str', '0:strasse']);
+    assertAnalysis('brücke', 'brücke', [ '0:bruecke', '0:brucke', '0:br' ]);
+    assertAnalysis('bruecke', 'bruecke', [ '0:bruecke', '0:brucke', '0:br' ]);
+    assertAnalysis('brucke', 'brucke', ['0:brucke', '0:bruecke', '0:br']);
+    assertAnalysis('br.', 'br.', ['0:br', '0:branch', '0:bruecke', '0:brucke']);
+    assertAnalysis('br', 'br', ['0:br', '0:branch', '0:bruecke', '0:brucke']);
 
     suite.run(t.end);
   });

--- a/package.json
+++ b/package.json
@@ -32,11 +32,10 @@
     "elasticsearch": ">=1.1.1"
   },
   "dependencies": {
+    "@hapi/joi": "^15.1.1",
     "colors": "^1.1.2",
     "elasticsearch": "^16.0.0",
-    "@hapi/joi": "^15.1.1",
-    "lodash.has": "^4.5.2",
-    "lodash.merge": "^4.6.0",
+    "lodash": "^4.17.15",
     "pelias-config": "^4.0.0",
     "pelias-logger": "^1.3.0"
   },

--- a/settings.js
+++ b/settings.js
@@ -1,12 +1,12 @@
-var fs = require('fs');
-var path = require('path');
-var merge = require('lodash.merge');
-var peliasConfig = require('pelias-config');
-var punctuation = require('./punctuation');
-var synonymFile = require('./synonyms/parser');
+const _ = require('lodash');
+const fs = require('fs');
+const path = require('path');
+const peliasConfig = require('pelias-config');
+const punctuation = require('./punctuation');
+const synonymFile = require('./synonyms/parser');
 
 // load synonyms from disk
-var synonyms = fs.readdirSync(path.join(__dirname, 'synonyms'))
+const synonyms = fs.readdirSync(path.join(__dirname, 'synonyms'))
                  .sort()
                  .filter( f => f.match(/\.txt$/) )
                  .reduce(( acc, cur ) => {
@@ -289,7 +289,7 @@ function generate(){
   if( 'object' === typeof config &&
       'object' === typeof config.elasticsearch &&
       'object' === typeof config.elasticsearch.settings ){
-    return merge({}, settings, config.elasticsearch.settings);
+    return _.merge({}, settings, config.elasticsearch.settings);
   }
 
   return settings;

--- a/test/document.js
+++ b/test/document.js
@@ -1,5 +1,5 @@
+const _ = require('lodash');
 const schema = require('../mappings/document');
-const has = require('lodash.has');
 
 module.exports.tests = {};
 
@@ -104,7 +104,7 @@ module.exports.tests.parent_fields = function(test, common) {
   ];
   test('parent fields specified', function(t) {
     fields.forEach( expected => {
-      t.true( has( schema.properties.parent.properties, expected ), expected );
+      t.true( _.has( schema.properties.parent.properties, expected ), expected );
     });
     t.end();
   });


### PR DESCRIPTION
okay, so there are a bunch of changes in here but it should be a no-op refactor ;)

this PR enforces strict checking of token positions for the `integration` test suite.

the motivation for this is:
- the order in which tokens are generated by elasticsearch changed in elasticsearch@6 making all the tests break
- not specifying token positions in the test meant they were not checked, meaning nasty bugs could slip through unnoticed.

you can provide the 'expected' tokens in two forms:

```
// no explicit token positions
[ 'A', 'ABC' ]

or...

// with explicit token positions
[ '0:A', '1:ABC' ]
```

prior to this PR if you used the 'no explicit token positions' form then we simply checked that all the tokens were present and there were no extra ones being generated.

what it's doing now is assigning a token position equal to the array offset, so 'A' is being seen as '0:A' internally now, and all token positions are being checked.

the use of the other form goes unchanged but the requirement to add `, true` to indicate this style is now removed and no longer required.

I think this is a better approach going-forward as it prevents bugs, it does add some verbosity to testing ngrams and synonyms analysis but that's totally worth it in order to ensure it's working as expected :)

Oh and you can also specify the expected tokens out-of-order or in any order as long as the positions are correct.