### PR TITLE
integration tests: rewrite match phrase queries

### DIFF
--- a/integration/address_matching.js
+++ b/integration/address_matching.js
@@ -266,10 +266,9 @@ module.exports.tests.venue_vs_address = function(test, common){
             'bool': {
               'must': [
                 {
-                  'match': {
+                  'match_phrase': {
                     'name.default': {
                       'analyzer': 'peliasQueryFullToken',
-                      'type': 'phrase',
                       'boost': 1,
                       'slop': 3,
                       'query': 'union square'
@@ -288,10 +287,9 @@ module.exports.tests.venue_vs_address = function(test, common){
                   }
                 },
                 {
-                  'match': {
+                  'match_phrase': {
                     'phrase.default': {
                       'analyzer': 'peliasPhrase',
-                      'type': 'phrase',
                       'boost': 1,
                       'slop': 3,
                       'query': 'union square'

--- a/integration/analyzer_peliasPhrase.js
+++ b/integration/analyzer_peliasPhrase.js
@@ -195,10 +195,9 @@ module.exports.tests.slop_query = function(test, common){
             ],
             'should': [
               {
-                'match': {
+                'match_phrase': {
                   'phrase.default': {
                     'query': i,
-                    'type': 'phrase',
                     'slop': 2
                   }
                 }
@@ -265,11 +264,10 @@ module.exports.tests.slop = function(test, common){
         index: suite.props.index,
         type: 'doc',
         searchType: 'dfs_query_then_fetch',
-        body: { query: { match: {
+        body: { query: { match_phrase: {
           'name.default': {
             'analyzer': 'peliasPhrase',
             'query': 'Görlitzer Straße 52',
-            'type': 'phrase',
             'slop': 3,
           }
         }}}

--- a/integration/analyzer_peliasQueryFullToken.js
+++ b/integration/analyzer_peliasQueryFullToken.js
@@ -165,11 +165,10 @@ module.exports.tests.slop = function(test, common){
       suite.client.search({
         index: suite.props.index,
         type: 'doc',
-        body: { query: { match: {
+        body: { query: { match_phrase: {
           'name.default': {
             'analyzer': 'peliasQueryFullToken',
             'query': 'Görlitzer Straße 52',
-            'type': 'phrase',
             'slop': 3,
           }
         }}}


### PR DESCRIPTION
this is a simple no-op refactor which changes the `match+type:phrase` queries in the integration tests to use `match_phrase` instead.

tested and working on both ES5 & ES6

Connects https://github.com/pelias/pelias/issues/719