### PR TITLE
fix mandatory token filter test

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -45,6 +45,7 @@ function generate(){
             "trim",
             "word_delimiter",
             "custom_admin",
+            "unique_only_same_position",
             "notnull"
           ]
         },
@@ -144,7 +145,10 @@ function generate(){
           "char_filter" : ["alphanumeric"],
           "filter": [
             "lowercase",
-            "trim"
+            "icu_folding",
+            "trim",
+            "unique_only_same_position",
+            "notnull"
           ]
         },
         "peliasUnit": {
@@ -153,7 +157,10 @@ function generate(){
           "char_filter" : ["alphanumeric"],
           "filter": [
             "lowercase",
-            "trim"
+            "icu_folding",
+            "trim",
+            "unique_only_same_position",
+            "notnull"
           ]
         },
         "peliasHousenumber": {
@@ -174,7 +181,9 @@ function generate(){
             "directionals",
             "icu_folding",
             "remove_ordinals",
-            "trim"
+            "trim",
+            "unique_only_same_position",
+            "notnull"
           ]
         }
       },

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -25,6 +25,7 @@
             "trim",
             "word_delimiter",
             "custom_admin",
+            "unique_only_same_position",
             "notnull"
           ]
         },
@@ -141,7 +142,10 @@
           ],
           "filter": [
             "lowercase",
-            "trim"
+            "icu_folding",
+            "trim",
+            "unique_only_same_position",
+            "notnull"
           ]
         },
         "peliasUnit": {
@@ -152,7 +156,10 @@
           ],
           "filter": [
             "lowercase",
-            "trim"
+            "icu_folding",
+            "trim",
+            "unique_only_same_position",
+            "notnull"
           ]
         },
         "peliasHousenumber": {
@@ -178,7 +185,9 @@
             "directionals",
             "icu_folding",
             "remove_ordinals",
-            "trim"
+            "trim",
+            "unique_only_same_position",
+            "notnull"
           ]
         }
       },


### PR DESCRIPTION
fix mandatory token filter test and refactor schema to enforce original intent.

there is an acceptance test which was supposed to ensure that *every* analyzer contains all of the mandatory token filters such as `lowercase` `unique` etc.

looking at this code today it was all messed up and not testing what it should have been, as a result, some of the analyzers were missing some of these very basic but very essential components (although I doubt the effect was noticeable).

In the process of fixing the test I've also refactored the token filters in order to achieve the original intent of the test.