### PR TITLE
feat(peliasAdmin): Remove word delimiter filter

### DIFF
--- a/integration/analyzer_peliasAdmin.js
+++ b/integration/analyzer_peliasAdmin.js
@@ -24,7 +24,7 @@ module.exports.tests.analyze = function(test, common){
     assertAnalysis( 'notnull', ' ^ ', [] );
 
     // remove punctuation (handled by the char_filter)
-    assertAnalysis( 'punctuation', punctuation.all.join(''), [] );
+    assertAnalysis( 'punctuation', punctuation.all.join(''), ['0:&'] );
 
     suite.run( t.end );
   });


### PR DESCRIPTION
The first error seen when trying to use our current schema with Elasticsearch 7 is:

```
[illegal_argument_exception] Token filter [word_delimiter] cannot be used to parse synonyms
```

The [word delimiter](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-word-delimiter-tokenfilter.html) token filter is only used in one place: the `peliasAdmin` analyzer.

Looking at the documentation, this token filter does _a lot_: splitting words, handling punctuation, and even some basic stemming.

It really feels like an extremely convoluted tool and at this point I have a suspicion it is something that Elasticsearch would deprecate in the future.

Furthermore, according to our integration tests, it seems one of the key reasons we used it was to tokenize on hyphens, which we have done using the `peliasNameTokenizer` since https://github.com/pelias/schema/pull/375.

Considering how complicated this token filter is, and how it's now being used with relatively little effect, it seems like something we should remove.

Connects https://github.com/pelias/pelias/issues/831
