### PR TITLE
fix(CI): update Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
-# Once openjdk/oraclejdk dependencies are resolved, change to dist: xenial
-dist: trusty
+dist: bionic
 notifications:
   email: false
 node_js:
@@ -11,23 +10,21 @@ matrix:
   fast_finish: true
 env:
   matrix:
-    - ES_VERSION=5.6.12
+    - ES_VERSION=5.6.12 JDK_VERSION=oraclejdk8
+    - ES_VERSION=5.6.12 JDK_VERSION=oraclejdk11
+    - ES_VERSION=6.8.4 JDK_VERSION=oraclejdk8
+    - ES_VERSION=6.8.4 JDK_VERSION=oraclejdk11
 jdk:
   - oraclejdk8
+  - oraclejdk11
 install:
-  - mkdir /tmp/elasticsearch
   - ./scripts/setup_ci.sh
   - npm i
 script:
   - npm run travis
-addons:
-  apt:
-    packages:
-      - oracle-java8-installer
 before_install:
   - npm i -g npm
 before_script:
-  - sleep 10
   - curl http://127.0.0.1:9200/
   - ./bin/create_index
 branches:

--- a/scripts/elastic_wait.sh
+++ b/scripts/elastic_wait.sh
@@ -1,0 +1,23 @@
+function elastic_status(){
+  curl --output /dev/null --silent --write-out "%{http_code}" "http://${ELASTIC_HOST:-localhost:9200}" || true;
+}
+
+function elastic_wait(){
+  echo 'waiting for elasticsearch service to come up';
+  retry_count=30
+
+  i=1
+  while [[ "$i" -le "$retry_count" ]]; do
+    if [[ $(elastic_status) -eq 200 ]]; then
+      echo "Elasticsearch up!"
+      exit 0
+    fi
+    sleep 2
+    printf "."
+    i=$(($i + 1))
+  done
+
+  echo
+  echo "Elasticsearch did not come up, check configuration"
+  exit 1
+}


### PR DESCRIPTION
This PR modernizes our Travis-CI config.

I had numerous problems testing Elasticsearch6 & 7 using the existing config, I've managed to backport that code to target `master`

Highlights:
- switch to `bionic` from `trusty`
- test multiple supported versions of ES (current & future)
- test multiple JVM versions (current & future long-term releases)

Probably doesn't look like many changes but took 4 hours to get this working and numerous Travis builds ☹️ 