### PR TITLE
update elastic_wait command usage

### DIFF
--- a/scripts/elastic_wait.sh
+++ b/scripts/elastic_wait.sh
@@ -1,5 +1,11 @@
+set -e
+
 function elastic_status(){
-  curl --output /dev/null --silent --write-out "%{http_code}" "http://${ELASTIC_HOST:-localhost:9200}" || true;
+  curl \
+    --output /dev/null \
+    --silent \
+    --write-out "%{http_code}" \
+    "http://${ELASTIC_HOST:-localhost:9200}" || true;
 }
 
 function elastic_wait(){
@@ -9,7 +15,7 @@ function elastic_wait(){
   i=1
   while [[ "$i" -le "$retry_count" ]]; do
     if [[ $(elastic_status) -eq 200 ]]; then
-      echo "Elasticsearch up!"
+      echo
       exit 0
     fi
     sleep 2

--- a/scripts/setup_ci.sh
+++ b/scripts/setup_ci.sh
@@ -37,7 +37,7 @@ fi
 # wait for server to boot up
 # logs show that on travis-ci it can take ~17s to boot an ES6 server
 source "${BASH_SOURCE%/*}/elastic_wait.sh"
-elastic_wait
+(elastic_wait)
 
 # set the correct esclient.apiVersion in pelias.json
 v=( ${ES_VERSION//./ } ) # split version number on '.'


### PR DESCRIPTION
I think my previous PR was using `elastic_wait` incorrectly.

The script exits 0 or 1, which was preventing the rest of the `setup_ci` script from running after the `elastic_wait` command ended