### PR TITLE
test multiple type names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,18 @@ dist: bionic
 notifications:
   email: false
 node_js:
-  - 8
   - 10
   - 12
 matrix:
   fast_finish: true
 env:
   matrix:
-    - ES_VERSION=5.6.12 JDK_VERSION=oraclejdk8
-    - ES_VERSION=5.6.12 JDK_VERSION=oraclejdk11
-    - ES_VERSION=6.8.4 JDK_VERSION=oraclejdk8
-    - ES_VERSION=6.8.4 JDK_VERSION=oraclejdk11
+    - ES_VERSION=5.6.12 ES_TYPE=doc JDK_VERSION=oraclejdk8
+    - ES_VERSION=5.6.12 ES_TYPE=doc JDK_VERSION=oraclejdk11
+    - ES_VERSION=6.8.4 ES_TYPE=doc JDK_VERSION=oraclejdk8
+    - ES_VERSION=6.8.4 ES_TYPE=doc JDK_VERSION=oraclejdk11
+    - ES_VERSION=6.8.4 ES_TYPE=_doc JDK_VERSION=oraclejdk8
+    - ES_VERSION=6.8.4 ES_TYPE=_doc JDK_VERSION=oraclejdk11
 jdk:
   - oraclejdk8
   - oraclejdk11

--- a/integration/address_matching.js
+++ b/integration/address_matching.js
@@ -1,9 +1,8 @@
 // validate analyzer is behaving as expected
 
-var tape = require('tape'),
-    elastictest = require('elastictest'),
-    schema = require('../schema'),
-    punctuation = require('../punctuation');
+const elastictest = require('elastictest');
+const schema = require('../schema');
+const config = require('pelias-config').generate();
 
 module.exports.tests = {};
 
@@ -16,7 +15,8 @@ module.exports.tests.functional = function(test, common){
     // index some docs
     suite.action( function( done ){
       suite.client.index({
-        index: suite.props.index, type: 'doc',
+        index: suite.props.index,
+        type: config.schema.typeName,
         id: '1', body: { address_parts: {
           name: 'Mapzen HQ',
           number: 30,
@@ -28,7 +28,8 @@ module.exports.tests.functional = function(test, common){
 
     suite.action( function( done ){
       suite.client.index({
-        index: suite.props.index, type: 'doc',
+        index: suite.props.index,
+        type: config.schema.typeName,
         id: '2', body: { address_parts: {
           name: 'Fake Venue',
           number: 300,
@@ -40,7 +41,8 @@ module.exports.tests.functional = function(test, common){
 
     suite.action( function( done ){
       suite.client.index({
-        index: suite.props.index, type: 'doc',
+        index: suite.props.index,
+        type: config.schema.typeName,
         id: '3', body: { address_parts: {
           name: 'Mock British Address',
           number: 3000,
@@ -52,7 +54,8 @@ module.exports.tests.functional = function(test, common){
 
     suite.action( function( done ){
       suite.client.index({
-        index: suite.props.index, type: 'doc',
+        index: suite.props.index,
+        type: config.schema.typeName,
         id: '4', body: { address_parts: {
           name: 'Mystery Location',
           number: 300,
@@ -66,7 +69,7 @@ module.exports.tests.functional = function(test, common){
     suite.assert( function( done ){
       suite.client.search({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         body: { query: { bool: { must: [
           { match: { 'address_parts.number': 30 } }
         ]}}}
@@ -81,7 +84,7 @@ module.exports.tests.functional = function(test, common){
     suite.assert( function( done ){
       suite.client.search({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         body: { query: { bool: { must: [
           { match_phrase: { 'address_parts.street': 'west 26th street' } }
         ]}}}
@@ -96,7 +99,7 @@ module.exports.tests.functional = function(test, common){
     suite.assert( function( done ){
       suite.client.search({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         body: { query: { bool: { must: [
           { match_phrase: { 'address_parts.street': 'W 26th ST' } }
         ]}}}
@@ -111,7 +114,7 @@ module.exports.tests.functional = function(test, common){
     suite.assert( function( done ){
       suite.client.search({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         body: { query: { bool: { must: [
           { match: { 'address_parts.zip': '10010' } }
         ]}}}
@@ -126,7 +129,7 @@ module.exports.tests.functional = function(test, common){
     suite.assert( function( done ){
       suite.client.search({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         body: { query: { bool: { must: [
           { match: { 'address_parts.zip': 'e24dn' } }
         ]}}}
@@ -141,7 +144,7 @@ module.exports.tests.functional = function(test, common){
     suite.assert( function( done ){
       suite.client.search({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         body: { query: { bool: { must: [
           { match: { 'address_parts.zip': '100-10' } }
         ]}}}
@@ -156,7 +159,7 @@ module.exports.tests.functional = function(test, common){
     suite.assert( function( done ){
       suite.client.search({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         body: { query: { bool: { must: [
           { match: { 'address_parts.zip': '10 0 10' } }
         ]}}}
@@ -171,7 +174,7 @@ module.exports.tests.functional = function(test, common){
     suite.assert( function( done ){
       suite.client.search({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         body: { query: { bool: { must: [
           { match: { 'address_parts.zip': 'E2-4DN' } }
         ]}}}
@@ -186,7 +189,7 @@ module.exports.tests.functional = function(test, common){
     suite.assert( function( done ){
       suite.client.search({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         body: { query: { bool: { must: [
           { match: { 'address_parts.zip': 'E2  4DN' } }
         ]}}}
@@ -220,7 +223,8 @@ module.exports.tests.venue_vs_address = function(test, common){
     // index a venue
     suite.action( function( done ){
       suite.client.index({
-        index: suite.props.index, type: 'doc',
+        index: suite.props.index,
+        type: config.schema.typeName,
         id: '1', body: {
           name: { default: 'Union Square' },
           phrase: { default: 'Union Square' }
@@ -234,7 +238,8 @@ module.exports.tests.venue_vs_address = function(test, common){
       return function( done ){
         let id = i + 100; // id offset
         suite.client.index({
-          index: suite.props.index, type: 'doc',
+          index: suite.props.index,
+          type: config.schema.typeName,
           id: String(id),
           body: {
             name: { default: `${id} Union Square` },
@@ -258,7 +263,7 @@ module.exports.tests.venue_vs_address = function(test, common){
     suite.assert( function( done ){
       suite.client.search({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         searchType: 'dfs_query_then_fetch',
         size: TOTAL_ADDRESS_DOCS+1,
         body: {

--- a/integration/admin_matching.js
+++ b/integration/admin_matching.js
@@ -1,9 +1,8 @@
 // validate analyzer is behaving as expected
 
-var tape = require('tape'),
-    elastictest = require('elastictest'),
-    schema = require('../schema'),
-    punctuation = require('../punctuation');
+const elastictest = require('elastictest');
+const schema = require('../schema');
+const config = require('pelias-config').generate();
 
 module.exports.tests = {};
 
@@ -16,7 +15,8 @@ module.exports.tests.functional = function(test, common){
     // index a document with all admin values
     suite.action( function( done ){
       suite.client.index({
-        index: suite.props.index, type: 'doc',
+        index: suite.props.index,
+        type: config.schema.typeName,
         id: '1', body: {
           parent: {
             country: 'Test Country',
@@ -46,7 +46,7 @@ module.exports.tests.functional = function(test, common){
     suite.assert( function( done ){
       suite.client.search({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         body: { query: { match: { 'parent.country': 'Test Country' } } }
       }, function( err, res ){
         t.equal( err, undefined );
@@ -59,7 +59,7 @@ module.exports.tests.functional = function(test, common){
     suite.assert( function( done ){
       suite.client.search({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         body: { query: { match: { 'parent.country_a': 'TestCountry' } } }
       }, function( err, res ){
         t.equal( err, undefined );
@@ -72,7 +72,7 @@ module.exports.tests.functional = function(test, common){
     suite.assert( function( done ){
       suite.client.search({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         body: { query: { match: { 'parent.country_id': '100' } } }
       }, function( err, res ){
         t.equal( err, undefined );

--- a/integration/analyzer_peliasPhrase.js
+++ b/integration/analyzer_peliasPhrase.js
@@ -1,9 +1,9 @@
 // validate analyzer is behaving as expected
 
-var tape = require('tape'),
-    elastictest = require('elastictest'),
-    schema = require('../schema'),
-    punctuation = require('../punctuation');
+const elastictest = require('elastictest');
+const schema = require('../schema');
+const punctuation = require('../punctuation');
+const config = require('pelias-config').generate();
 
 module.exports.tests = {};
 
@@ -154,7 +154,7 @@ module.exports.tests.slop_query = function(test, common){
     suite.action( function( done ){
       suite.client.index({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         id: '1',
         body: { name: { default: 'Lake Cayuga' }, phrase: { default: 'Lake Cayuga' } }
       }, done );
@@ -164,7 +164,7 @@ module.exports.tests.slop_query = function(test, common){
     suite.action( function( done ){
       suite.client.index({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         id: '2',
         body: { name: { default: 'Cayuga Lake' }, phrase: { default: 'Cayuga Lake' } }
       }, done );
@@ -174,7 +174,7 @@ module.exports.tests.slop_query = function(test, common){
     suite.action( function( done ){
       suite.client.index({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         id: '3',
         body: { name: { default: '7991 Lake Cayuga Dr' }, phrase: { default: '7991 Lake Cayuga Dr' } }
       }, done );
@@ -211,7 +211,7 @@ module.exports.tests.slop_query = function(test, common){
     suite.assert( function( done ){
       suite.client.search({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         searchType: 'dfs_query_then_fetch',
         body: buildQuery('Lake Cayuga')
       }, function( err, res ){
@@ -249,7 +249,7 @@ module.exports.tests.slop = function(test, common){
     suite.action( function( done ){
       suite.client.index({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         id: '1',
         body: { name: { default: '52 Görlitzer Straße' } }
       }, done);
@@ -262,7 +262,7 @@ module.exports.tests.slop = function(test, common){
     suite.assert( function( done ){
       suite.client.search({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         searchType: 'dfs_query_then_fetch',
         body: { query: { match_phrase: {
           'name.default': {

--- a/integration/analyzer_peliasQueryFullToken.js
+++ b/integration/analyzer_peliasQueryFullToken.js
@@ -1,9 +1,9 @@
 // validate analyzer is behaving as expected
 
-var tape = require('tape'),
-    elastictest = require('elastictest'),
-    schema = require('../schema'),
-    punctuation = require('../punctuation');
+const elastictest = require('elastictest');
+const schema = require('../schema');
+const punctuation = require('../punctuation');
+const config = require('pelias-config').generate();
 
 module.exports.tests = {};
 
@@ -151,7 +151,7 @@ module.exports.tests.slop = function(test, common){
     suite.action( function( done ){
       suite.client.index({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         id: '1',
         body: { name: { default: '52 Görlitzer Straße' } }
       }, done);
@@ -164,7 +164,7 @@ module.exports.tests.slop = function(test, common){
     suite.assert( function( done ){
       suite.client.search({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         body: { query: { match_phrase: {
           'name.default': {
             'analyzer': 'peliasQueryFullToken',

--- a/integration/autocomplete_abbreviated_street_names.js
+++ b/integration/autocomplete_abbreviated_street_names.js
@@ -4,10 +4,9 @@
 // The greater issue is descriped in: https://github.com/pelias/pelias/issues/211
 // The cases tested here are described in: https://github.com/pelias/schema/issues/105
 
-var tape = require('tape'),
-    elastictest = require('elastictest'),
-    schema = require('../schema'),
-    punctuation = require('../punctuation');
+const elastictest = require('elastictest');
+const schema = require('../schema');
+const config = require('pelias-config').generate();
 
 module.exports.tests = {};
 
@@ -22,7 +21,7 @@ module.exports.tests.index_expanded_form_search_contracted = function(test, comm
     suite.action( function( done ){
       suite.client.index({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         id: '1',
         body: { name: { default: 'Grolmanstraße' } }
       }, done);
@@ -32,7 +31,7 @@ module.exports.tests.index_expanded_form_search_contracted = function(test, comm
     suite.assert( function( done ){
       suite.client.search({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         body: { query: { match: {
           'name.default': {
             'analyzer': 'peliasQueryPartialToken',
@@ -50,7 +49,7 @@ module.exports.tests.index_expanded_form_search_contracted = function(test, comm
     suite.assert( function( done ){
       suite.client.search({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         body: { query: { match: {
           'name.default': {
             'analyzer': 'peliasQueryFullToken',
@@ -81,7 +80,7 @@ module.exports.tests.index_expanded_form_search_contracted = function(test, comm
 //     suite.action( function( done ){
 //       suite.client.index({
 //         index: suite.props.index,
-//         type: 'doc',
+//         type: config.schema.typeName,
 //         id: '1',
 //         body: { name: { default: 'Grolmanstr.' } }
 //       }, done);
@@ -94,7 +93,7 @@ module.exports.tests.index_expanded_form_search_contracted = function(test, comm
 //     suite.assert( function( done ){
 //       suite.client.search({
 //         index: suite.props.index,
-//         type: 'doc',
+//         type: config.schema.typeName,
 //         body: { query: { match: {
 //           'name.default': {
 //             'analyzer': 'peliasQueryPartialToken',
@@ -115,7 +114,7 @@ module.exports.tests.index_expanded_form_search_contracted = function(test, comm
 //     suite.assert( function( done ){
 //       suite.client.search({
 //         index: suite.props.index,
-//         type: 'doc',
+//         type: config.schema.typeName,
 //         body: { query: { match: {
 //           'name.default': {
 //             'analyzer': 'peliasQueryFullToken',

--- a/integration/autocomplete_directional_synonym_expansion.js
+++ b/integration/autocomplete_directional_synonym_expansion.js
@@ -4,10 +4,9 @@
 // The greater issue is descriped in: https://github.com/pelias/pelias/issues/211
 // The cases tested here are described in: https://github.com/pelias/schema/issues/105
 
-var tape = require('tape'),
-    elastictest = require('elastictest'),
-    schema = require('../schema'),
-    punctuation = require('../punctuation');
+const elastictest = require('elastictest');
+const schema = require('../schema');
+const config = require('pelias-config').generate();
 
 module.exports.tests = {};
 
@@ -22,7 +21,7 @@ module.exports.tests.index_and_retrieve_expanded_form = function(test, common){
     suite.action( function( done ){
       suite.client.index({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         id: '1',
         body: { name: { default: 'north' } }
       }, done);
@@ -32,7 +31,7 @@ module.exports.tests.index_and_retrieve_expanded_form = function(test, common){
     suite.assert( function( done ){
       suite.client.search({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         body: { query: { match: {
           'name.default': {
             'analyzer': 'peliasQueryPartialToken',
@@ -50,7 +49,7 @@ module.exports.tests.index_and_retrieve_expanded_form = function(test, common){
     suite.assert( function( done ){
       suite.client.search({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         body: { query: { match: {
           'name.default': {
             'analyzer': 'peliasQueryFullToken',
@@ -79,7 +78,7 @@ module.exports.tests.index_and_retrieve_contracted_form = function(test, common)
     suite.action( function( done ){
       suite.client.index({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         id: '1',
         body: { name: { default: 'n' } }
       }, done);
@@ -89,7 +88,7 @@ module.exports.tests.index_and_retrieve_contracted_form = function(test, common)
     suite.assert( function( done ){
       suite.client.search({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         body: { query: { match: {
           'name.default': {
             'analyzer': 'peliasQueryPartialToken',
@@ -107,7 +106,7 @@ module.exports.tests.index_and_retrieve_contracted_form = function(test, common)
     suite.assert( function( done ){
       suite.client.search({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         body: { query: { match: {
           'name.default': {
             'analyzer': 'peliasQueryFullToken',
@@ -136,7 +135,7 @@ module.exports.tests.index_and_retrieve_mixed_form_1 = function(test, common){
     suite.action( function( done ){
       suite.client.index({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         id: '1',
         body: { name: { default: 'n' } }
       }, done);
@@ -146,7 +145,7 @@ module.exports.tests.index_and_retrieve_mixed_form_1 = function(test, common){
     suite.assert( function( done ){
       suite.client.search({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         body: { query: { match: {
           'name.default': {
             'analyzer': 'peliasQueryPartialToken',
@@ -164,7 +163,7 @@ module.exports.tests.index_and_retrieve_mixed_form_1 = function(test, common){
     suite.assert( function( done ){
       suite.client.search({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         body: { query: { match: {
           'name.default': {
             'analyzer': 'peliasQueryFullToken',
@@ -193,7 +192,7 @@ module.exports.tests.index_and_retrieve_mixed_form_2 = function(test, common){
     suite.action( function( done ){
       suite.client.index({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         id: '1',
         body: { name: { default: 'north' } }
       }, done);
@@ -203,7 +202,7 @@ module.exports.tests.index_and_retrieve_mixed_form_2 = function(test, common){
     suite.assert( function( done ){
       suite.client.search({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         body: { query: { match: {
           'name.default': {
             'analyzer': 'peliasQueryPartialToken',
@@ -221,7 +220,7 @@ module.exports.tests.index_and_retrieve_mixed_form_2 = function(test, common){
     suite.assert( function( done ){
       suite.client.search({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         body: { query: { match: {
           'name.default': {
             'analyzer': 'peliasQueryFullToken',

--- a/integration/autocomplete_street_synonym_expansion.js
+++ b/integration/autocomplete_street_synonym_expansion.js
@@ -4,10 +4,9 @@
 // The greater issue is descriped in: https://github.com/pelias/pelias/issues/211
 // The cases tested here are described in: https://github.com/pelias/schema/issues/105
 
-var tape = require('tape'),
-    elastictest = require('elastictest'),
-    schema = require('../schema'),
-    punctuation = require('../punctuation');
+const elastictest = require('elastictest');
+const schema = require('../schema');
+const config = require('pelias-config').generate();
 
 module.exports.tests = {};
 
@@ -22,7 +21,7 @@ module.exports.tests.index_and_retrieve_expanded_form = function(test, common){
     suite.action( function( done ){
       suite.client.index({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         id: '1',
         body: { name: { default: 'center' } }
       }, done);
@@ -32,7 +31,7 @@ module.exports.tests.index_and_retrieve_expanded_form = function(test, common){
     suite.assert( function( done ){
       suite.client.search({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         body: { query: { match: {
           'name.default': {
             'analyzer': 'peliasQueryPartialToken',
@@ -50,7 +49,7 @@ module.exports.tests.index_and_retrieve_expanded_form = function(test, common){
     suite.assert( function( done ){
       suite.client.search({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         body: { query: { match: {
           'name.default': {
             'analyzer': 'peliasQueryFullToken',
@@ -79,7 +78,7 @@ module.exports.tests.index_and_retrieve_contracted_form = function(test, common)
     suite.action( function( done ){
       suite.client.index({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         id: '1',
         body: { name: { default: 'ctr' } }
       }, done);
@@ -89,7 +88,7 @@ module.exports.tests.index_and_retrieve_contracted_form = function(test, common)
     suite.assert( function( done ){
       suite.client.search({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         body: { query: { match: {
           'name.default': {
             'analyzer': 'peliasQueryPartialToken',
@@ -107,7 +106,7 @@ module.exports.tests.index_and_retrieve_contracted_form = function(test, common)
     suite.assert( function( done ){
       suite.client.search({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         body: { query: { match: {
           'name.default': {
             'analyzer': 'peliasQueryFullToken',
@@ -136,7 +135,7 @@ module.exports.tests.index_and_retrieve_mixed_form_1 = function(test, common){
     suite.action( function( done ){
       suite.client.index({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         id: '1',
         body: { name: { default: 'ctr' } }
       }, done);
@@ -146,7 +145,7 @@ module.exports.tests.index_and_retrieve_mixed_form_1 = function(test, common){
     suite.assert( function( done ){
       suite.client.search({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         body: { query: { match: {
           'name.default': {
             'analyzer': 'peliasQueryPartialToken',
@@ -164,7 +163,7 @@ module.exports.tests.index_and_retrieve_mixed_form_1 = function(test, common){
     suite.assert( function( done ){
       suite.client.search({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         body: { query: { match: {
           'name.default': {
             'analyzer': 'peliasQueryFullToken',
@@ -193,7 +192,7 @@ module.exports.tests.index_and_retrieve_mixed_form_2 = function(test, common){
     suite.action( function( done ){
       suite.client.index({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         id: '1',
         body: { name: { default: 'center' } }
       }, done);
@@ -203,7 +202,7 @@ module.exports.tests.index_and_retrieve_mixed_form_2 = function(test, common){
     suite.assert( function( done ){
       suite.client.search({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         body: { query: { match: {
           'name.default': {
             'analyzer': 'peliasQueryPartialToken',
@@ -221,7 +220,7 @@ module.exports.tests.index_and_retrieve_mixed_form_2 = function(test, common){
     suite.assert( function( done ){
       suite.client.search({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         body: { query: { match: {
           'name.default': {
             'analyzer': 'peliasQueryFullToken',

--- a/integration/bounding_box.js
+++ b/integration/bounding_box.js
@@ -1,9 +1,8 @@
 // validate bounding box behaves as expected
 
-var tape = require('tape'),
-    elastictest = require('elastictest'),
-    schema = require('../schema'),
-    punctuation = require('../punctuation');
+const elastictest = require('elastictest');
+const schema = require('../schema');
+const config = require('pelias-config').generate();
 
 module.exports.tests = {};
 
@@ -17,7 +16,7 @@ module.exports.tests.index_and_retrieve = function(test, common){
     suite.action( function( done ){
       suite.client.index({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         id: '1',
         body: {
           bounding_box: '{"min_lat":-47.75,"max_lat":-33.9,"min_lon":163.82,"max_lon":179.42}'
@@ -30,7 +29,7 @@ module.exports.tests.index_and_retrieve = function(test, common){
       suite.client.get(
         {
           index: suite.props.index,
-          type: 'doc',
+          type: config.schema.typeName,
           id: '1'
         },
         function (err, res) {

--- a/integration/dynamic_templates.js
+++ b/integration/dynamic_templates.js
@@ -1,8 +1,8 @@
 // http://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-root-object-type.html#_dynamic_templates
 
-var tape = require('tape'),
-    elastictest = require('elastictest'),
-    schema = require('../schema');
+const elastictest = require('elastictest');
+const schema = require('../schema');
+const config = require('pelias-config').generate();
 
 module.exports.tests = {};
 
@@ -33,14 +33,13 @@ function nameAssertion( analyzer, common ){
   return function(t){
 
     var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
-
-    const type = 'doc';
+    const _type = config.schema.typeName;
 
     // index a document from a normal document layer
-    suite.action( function( done ){
+    suite.action( done => {
       suite.client.index({
         index: suite.props.index,
-        type: type,
+        type: _type,
         id: '1',
         body: { name: { default: 'foo', alt: 'bar' } }
       }, done );
@@ -48,13 +47,17 @@ function nameAssertion( analyzer, common ){
 
     // check dynamically created mapping has
     // inherited from the dynamic_template
-    suite.assert( function( done ){
-      suite.client.indices.getMapping({ index: suite.props.index, type: type }, function( err, res ){
+    suite.assert( done => {
 
-        var properties = res[suite.props.index].mappings[type].properties;
+      suite.client.indices.getMapping({
+        index: suite.props.index,
+        type: _type
+      }, (err, res) => {
+
+        const properties = res[suite.props.index].mappings[_type].properties;
         t.equal( properties.name.dynamic, 'true' );
 
-        var nameProperties = properties.name.properties;
+        const nameProperties = properties.name.properties;
         t.equal( nameProperties.default.analyzer, analyzer );
         t.equal( nameProperties.alt.analyzer, analyzer );
         done();
@@ -68,15 +71,14 @@ function nameAssertion( analyzer, common ){
 function phraseAssertion( analyzer, common ){
   return function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
-
-    const type = 'doc';
+    const suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    const _type = config.schema.typeName;
 
     // index a document from a normal document layer
-    suite.action( function( done ){
+    suite.action( done => {
       suite.client.index({
         index: suite.props.index,
-        type: type,
+        type: _type,
         id: '1',
         body: { phrase: { default: 'foo', alt: 'bar' } }
       }, done );
@@ -84,13 +86,17 @@ function phraseAssertion( analyzer, common ){
 
     // check dynamically created mapping has
     // inherited from the dynamic_template
-    suite.assert( function( done ){
-      suite.client.indices.getMapping({ index: suite.props.index, type: type }, function( err, res ){
+    suite.assert( done => {
 
-        var properties = res[suite.props.index].mappings[type].properties;
+      suite.client.indices.getMapping({
+        index: suite.props.index,
+        type: _type
+      }, ( err, res ) => {
+
+        const properties = res[suite.props.index].mappings[_type].properties;
         t.equal( properties.phrase.dynamic, 'true' );
 
-        var phraseProperties = properties.phrase.properties;
+        const phraseProperties = properties.phrase.properties;
         t.equal( phraseProperties.default.analyzer, analyzer );
         t.equal( phraseProperties.alt.analyzer, analyzer );
         done();
@@ -104,15 +110,14 @@ function phraseAssertion( analyzer, common ){
 function addendumAssertion( namespace, value, common ){
   return function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
-
-    const type = 'doc';
+    const suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    const _type = config.schema.typeName;
 
     // index a document including the addendum
-    suite.action( function( done ){
+    suite.action( done => {
       suite.client.index({
         index: suite.props.index,
-        type: type,
+        type: _type,
         id: '1',
         body: { addendum: { [namespace]: value } },
       }, done );
@@ -120,13 +125,16 @@ function addendumAssertion( namespace, value, common ){
 
     // check dynamically created mapping has
     // inherited from the dynamic_template
-    suite.assert( function( done ){
-      suite.client.indices.getMapping({ index: suite.props.index, type: type }, function( err, res ){
+    suite.assert( done => {
+      suite.client.indices.getMapping({
+        index: suite.props.index,
+        type: _type
+      }, ( err, res ) => {
 
-        var properties = res[suite.props.index].mappings[type].properties;
+        const properties = res[suite.props.index].mappings[_type].properties;
         t.equal( properties.addendum.dynamic, 'true' );
 
-        var addendumProperties = properties.addendum.properties;
+        const addendumProperties = properties.addendum.properties;
 
         t.true([
           'keyword' // elasticsearch 5.6
@@ -146,12 +154,12 @@ function addendumAssertion( namespace, value, common ){
     });
 
     // retrieve document and check addendum was stored verbatim
-    suite.assert( function( done ){
+    suite.assert( done => {
       suite.client.get({
         index: suite.props.index,
-        type: type,
+        type: _type,
         id: 1
-      }, function( err, res ){
+      }, ( err, res ) => {
         t.false( err );
         t.equal( res._source.addendum[namespace], value );
         done();

--- a/integration/multi_token_synonyms.js
+++ b/integration/multi_token_synonyms.js
@@ -2,6 +2,7 @@
 
 const elastictest = require('elastictest');
 const schema = require('../schema');
+const config = require('pelias-config').generate();
 
 module.exports.tests = {};
 
@@ -18,7 +19,8 @@ module.exports.tests.functional = function (test, common) {
     // not supported on ES6+
     suite.action(function (done) {
       suite.client.index({
-        index: suite.props.index, type: 'doc',
+        index: suite.props.index,
+        type: config.schema.typeName,
         id: '1', body: {
           name: { default: 'set' },
           phrase: { default: 'set' },

--- a/integration/source_layer_sourceid_filtering.js
+++ b/integration/source_layer_sourceid_filtering.js
@@ -1,9 +1,8 @@
 // validate analyzer is behaving as expected
 
-var tape = require('tape'),
-    elastictest = require('elastictest'),
-    schema = require('../schema'),
-    punctuation = require('../punctuation');
+const elastictest = require('elastictest');
+const schema = require('../schema');
+const config = require('pelias-config').generate();
 
 module.exports.tests = {};
 
@@ -16,28 +15,28 @@ module.exports.tests.source_filter = function(test, common){
     // index some docs
     suite.action( function( done ){
       suite.client.index({
-        index: suite.props.index, type: 'doc',
+        index: suite.props.index, type: config.schema.typeName,
         id: '1', body: { source: 'osm', layer: 'node', source_id: 'dataset/1' }
       }, done );
     });
 
     suite.action( function( done ){
       suite.client.index({
-        index: suite.props.index, type: 'doc',
+        index: suite.props.index, type: config.schema.typeName,
         id: '2', body: { source: 'osm', layer: 'address', source_id: 'dataset/2' }
       }, done );
     });
 
     suite.action( function( done ){
       suite.client.index({
-        index: suite.props.index, type: 'doc',
+        index: suite.props.index, type: config.schema.typeName,
         id: '3', body: { source: 'geonames', layer: 'address', source_id: 'dataset/1' }
       }, done );
     });
 
     suite.action( function( done ){
       suite.client.index({
-        index: suite.props.index, type: 'doc',
+        index: suite.props.index, type: config.schema.typeName,
         id: '4', body: { source: 'foo bar baz' }
       }, done );
     });
@@ -46,7 +45,7 @@ module.exports.tests.source_filter = function(test, common){
     suite.assert( function( done ){
       suite.client.search({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         body: { query: {
           term: {
             source: 'osm'
@@ -62,7 +61,7 @@ module.exports.tests.source_filter = function(test, common){
     suite.assert( function( done ){
       suite.client.search({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         body: { query: {
           term: {
             layer: 'address'
@@ -78,7 +77,7 @@ module.exports.tests.source_filter = function(test, common){
     suite.assert( function( done ){
       suite.client.search({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         body: { query: {
           term: {
             source_id: 'dataset/1'
@@ -94,7 +93,7 @@ module.exports.tests.source_filter = function(test, common){
     suite.assert( function( done ){
       suite.client.search({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         body: { query: { bool: { must: [
           { term: { source: 'osm' } },
           { term: { source_id: 'dataset/1' } }
@@ -109,7 +108,7 @@ module.exports.tests.source_filter = function(test, common){
     suite.assert( function( done ){
       suite.client.search({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         body: { query: {
           term: {
             source: 'OSM'
@@ -125,7 +124,7 @@ module.exports.tests.source_filter = function(test, common){
     suite.assert( function( done ){
       suite.client.search({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         body: { query: {
           term: {
             source: 'foo'
@@ -141,7 +140,7 @@ module.exports.tests.source_filter = function(test, common){
     suite.assert( function( done ){
       suite.client.search({
         index: suite.props.index,
-        type: 'doc',
+        type: config.schema.typeName,
         body: { query: {
           term: {
             source: 'foo bar baz'

--- a/integration/validate.js
+++ b/integration/validate.js
@@ -1,19 +1,18 @@
 // simply validate that the schema doesn't error when inserted in to
 // your local elasticsearch server, useful to sanity check version upgrades.
 
-var tape = require('tape'),
-    elastictest = require('elastictest'),
-    schema = require('../schema');
+const elastictest = require('elastictest');
+const schema = require('../schema');
 
 module.exports.tests = {};
 
 module.exports.tests.validate = function(test, common){
-  test( 'schema', function(t){
+  test( 'schema', t => {
 
     var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
 
-    suite.assert( function( done ){
-      suite.client.info({}, function( err, res, status ){
+    suite.assert( done => {
+      suite.client.info({}, ( err, res, status ) => {
         t.equal( status, 200 );
         done();
       });

--- a/scripts/setup_ci.sh
+++ b/scripts/setup_ci.sh
@@ -41,7 +41,24 @@ source "${BASH_SOURCE%/*}/elastic_wait.sh"
 
 # set the correct esclient.apiVersion in pelias.json
 v=( ${ES_VERSION//./ } ) # split version number on '.'
-echo "{\"esclient\":{\"apiVersion\":\"${v[0]}.${v[1]}\"}}" > ~/pelias.json
+
+# generate a pelias.json config
+PELIAS_CONFIG=$(
+  jq -n \
+    --arg apiVersion "${v[0]}.${v[1]}" \
+    --arg typeName "${ES_TYPE}" \
+    '{
+      esclient: {
+        apiVersion: $apiVersion
+      },
+      schema: {
+        typeName: $typeName
+      }
+    } | del(.. | select(. == ""))'
+);
+
+# write to filesystem
+echo "${PELIAS_CONFIG}" > ~/pelias.json
 
 # debugging
 echo "--- pelias.json ---"

--- a/test/compile.js
+++ b/test/compile.js
@@ -1,6 +1,7 @@
-var path = require('path'),
-    schema = require('../'),
-    fixture = require('./fixtures/expected.json');
+const path = require('path');
+const schema = require('../');
+const fixture = require('./fixtures/expected.json');
+const config = require('pelias-config').generate();
 
 module.exports.tests = {};
 
@@ -17,8 +18,9 @@ module.exports.tests.compile = function(test, common) {
 // the api codebase against an index without admin data
 module.exports.tests.indeces = function(test, common) {
   test('explicitly specify some admin indeces and their analyzer', function(t) {
-    t.equal(typeof schema.mappings.doc, 'object', 'mappings present');
-    t.equal(schema.mappings.doc.dynamic_templates[0].nameGram.mapping.analyzer, 'peliasIndexOneEdgeGram');
+    const _type = config.schema.typeName;
+    t.equal(typeof schema.mappings[_type], 'object', 'mappings present');
+    t.equal(schema.mappings[_type].dynamic_templates[0].nameGram.mapping.analyzer, 'peliasIndexOneEdgeGram');
     t.end();
   });
 };
@@ -26,8 +28,9 @@ module.exports.tests.indeces = function(test, common) {
 // some 'admin' types allow single edgeNGrams and so have a different dynamic_template
 module.exports.tests.dynamic_templates = function(test, common) {
   test('dynamic_templates: nameGram', function(t) {
-    t.equal(typeof schema.mappings.doc.dynamic_templates[0].nameGram, 'object', 'nameGram template specified');
-    var template = schema.mappings.doc.dynamic_templates[0].nameGram;
+    const _type = config.schema.typeName;
+    t.equal(typeof schema.mappings[_type].dynamic_templates[0].nameGram, 'object', 'nameGram template specified');
+    var template = schema.mappings[_type].dynamic_templates[0].nameGram;
     t.equal(template.path_match, 'name.*');
     t.equal(template.match_mapping_type, 'string');
     t.deepEqual(template.mapping, {
@@ -45,6 +48,16 @@ module.exports.tests.current_schema = function(test, common) {
 
     // copy schema
     var schemaCopy = JSON.parse( JSON.stringify( schema ) );
+
+    // the fixture contains a _type named 'doc'.
+    // this code allows the generated schema to match the fixture if the
+    // type name is defined named differently in pelias.json, the rest of
+    // the settings still apply verbatim.
+    const _type = config.schema.typeName;
+    if(_type && _type !== 'doc'){
+      schemaCopy.mappings.doc = schemaCopy.mappings[_type];
+      delete schemaCopy.mappings[_type];
+    }
 
     // use the pelias config fixture instead of the local config
     process.env.PELIAS_CONFIG = path.resolve( __dirname + '/fixtures/config.json' );


### PR DESCRIPTION
this PR updates our CI config to test multiple `schema.typeName` values so that we will know when a PR which breaks backwards compatibility with ES5 is opened.

I ended up modernizing a bunch of this code and also dropping node8 from the build matrix since it got very large!