### PR TITLE
backport some features from the ES7 branch which may be ok to use now

### DIFF
--- a/mappings/partial/shape.json
+++ b/mappings/partial/shape.json
@@ -1,5 +1,3 @@
 {
-  "type": "geo_shape",
-  "tree": "quadtree",
-  "tree_levels": "20"
+  "type": "geo_shape"
 }

--- a/scripts/setup_ci.sh
+++ b/scripts/setup_ci.sh
@@ -22,9 +22,15 @@ if [[ "${ES_VERSION}" == "2.4"* ]]; then
   # start elasticsearch server
   /tmp/elasticsearch/bin/elasticsearch --daemonize --path.data /tmp
 else
+  FILENAME="elasticsearch-${ES_VERSION}-linux-x86_64.tar.gz"
+
+  # prior to ES7 the architecture was not included in the filename
+  if [[ "${ES_VERSION}" == "5"* || "${ES_VERSION}" == "6"* ]]; then
+    FILENAME="elasticsearch-${ES_VERSION}.tar.gz"
+  fi
 
   # download from new host
-  wget -O - https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz \
+  wget -O - "https://artifacts.elastic.co/downloads/elasticsearch/${FILENAME}" \
     | tar xz --directory=/tmp/elasticsearch --strip-components=1
 
   # install ICU plugin

--- a/settings.js
+++ b/settings.js
@@ -43,8 +43,8 @@ function generate(){
             "lowercase",
             "icu_folding",
             "trim",
-            "word_delimiter",
             "custom_admin",
+            "word_delimiter",
             "unique_only_same_position",
             "notnull",
             "flatten_graph"

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -23,8 +23,8 @@
             "lowercase",
             "icu_folding",
             "trim",
-            "word_delimiter",
             "custom_admin",
+            "word_delimiter",
             "unique_only_same_position",
             "notnull",
             "flatten_graph"
@@ -1156,9 +1156,7 @@
           "type": "geo_point"
         },
         "shape": {
-          "type": "geo_shape",
-          "tree": "quadtree",
-          "tree_levels": "20"
+          "type": "geo_shape"
         },
         "bounding_box": {
           "type": "keyword",


### PR DESCRIPTION
backport some features from the ES7 branch which may be ok to use now

note: this includes the code which moves `word_delimiter` down one place, I'm not against removing that line as suggested in the draft PR https://github.com/pelias/schema/pull/392, I just wanted to keep this as close to a no-op as possible for now.

merging this will ensure that indices built on ES6 are more compatible with future versions, hopefully avoiding breaking changes down the line.

our new epic build matrix will catch any bugs ;)