### PR TITLE
update preferred ES version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ env:
   matrix:
     - ES_VERSION=5.6.12 ES_TYPE=doc JDK_VERSION=oraclejdk8
     - ES_VERSION=5.6.12 ES_TYPE=doc JDK_VERSION=oraclejdk11
-    - ES_VERSION=6.8.4 ES_TYPE=doc JDK_VERSION=oraclejdk8
-    - ES_VERSION=6.8.4 ES_TYPE=doc JDK_VERSION=oraclejdk11
-    - ES_VERSION=6.8.4 ES_TYPE=_doc JDK_VERSION=oraclejdk8
-    - ES_VERSION=6.8.4 ES_TYPE=_doc JDK_VERSION=oraclejdk11
+    - ES_VERSION=6.8.5 ES_TYPE=doc JDK_VERSION=oraclejdk8
+    - ES_VERSION=6.8.5 ES_TYPE=doc JDK_VERSION=oraclejdk11
+    - ES_VERSION=6.8.5 ES_TYPE=_doc JDK_VERSION=oraclejdk8
+    - ES_VERSION=6.8.5 ES_TYPE=_doc JDK_VERSION=oraclejdk11
 jdk:
   - oraclejdk8
   - oraclejdk11

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ $ npm run integration
 Download the image and start an elasticsearch docker container:
 
 ```bash
-$ docker run --rm --name elastic-test -p 9200:9200 pelias/elasticsearch:5.6.12
+$ docker run --rm --name elastic-test -p 9200:9200 pelias/elasticsearch:6.8.5
 ```
 
 ### Continuous Integration

--- a/scripts/setup_ci.sh
+++ b/scripts/setup_ci.sh
@@ -23,15 +23,22 @@ if [[ "${ES_VERSION}" == "2.4"* ]]; then
   /tmp/elasticsearch/bin/elasticsearch --daemonize --path.data /tmp
 else
   FILENAME="elasticsearch-${ES_VERSION}-linux-x86_64.tar.gz"
+  STRIP_COMPONENTS=1
 
   # prior to ES7 the architecture was not included in the filename
   if [[ "${ES_VERSION}" == "5"* || "${ES_VERSION}" == "6"* ]]; then
     FILENAME="elasticsearch-${ES_VERSION}.tar.gz"
   fi
 
+  # the 6.8.5 release is inconsisent with the others
+  # https://github.com/elastic/elasticsearch/issues/49599
+  if [[ "${ES_VERSION}" == "6.8.5" ]]; then
+    STRIP_COMPONENTS=2
+  fi
+
   # download from new host
   wget -O - "https://artifacts.elastic.co/downloads/elasticsearch/${FILENAME}" \
-    | tar xz --directory=/tmp/elasticsearch --strip-components=1
+    | tar xz --directory=/tmp/elasticsearch --strip-components="${STRIP_COMPONENTS}"
 
   # install ICU plugin
   /tmp/elasticsearch/bin/elasticsearch-plugin install analysis-icu


### PR DESCRIPTION
minor README edit to update the preferred ES version for testing

[edit] I got the version wrong, the most up-to-date version is `6.8.5` so I've also updated Travis to reflect that.
[edit] includes fix for ES bug in `6.8.5` release.