### PR TITLE
Explicitly set analyzers

### DIFF
--- a/mappings/document.js
+++ b/mappings/document.js
@@ -26,26 +26,32 @@ var schema = {
         name: {
           type: 'text',
           analyzer: 'keyword',
+          search_analyzer: 'keyword'
         },
         unit: {
           type: 'text',
           analyzer: 'peliasUnit',
+          search_analyzer: 'peliasUnit'
         },
         number: {
           type: 'text',
           analyzer: 'peliasHousenumber',
+          search_analyzer: 'peliasHousenumber'
         },
         street: {
           type: 'text',
           analyzer: 'peliasStreet',
+          search_analyzer: 'peliasStreet'
         },
         cross_street: {
           type: 'text',
           analyzer: 'peliasStreet',
+          search_analyzer: 'peliasStreet'
         },
         zip: {
           type: 'text',
           analyzer: 'peliasZip',
+          search_analyzer: 'peliasZip'
         },
       }
     },
@@ -152,7 +158,8 @@ var schema = {
       match_mapping_type: 'string',
       mapping: {
         type: 'text',
-        analyzer: 'peliasIndexOneEdgeGram'
+        analyzer: 'peliasIndexOneEdgeGram',
+        search_analyzer: 'peliasQuery'
       }
     },
   },{
@@ -161,7 +168,8 @@ var schema = {
       match_mapping_type: 'string',
       mapping: {
         type: 'text',
-        analyzer: 'peliasPhrase'
+        analyzer: 'peliasPhrase',
+        search_analyzer: 'peliasQuery'
       }
     }
   },{

--- a/mappings/partial/admin.json
+++ b/mappings/partial/admin.json
@@ -1,10 +1,12 @@
 {
   "type": "text",
   "analyzer": "peliasAdmin",
+  "search_analyzer": "peliasAdmin",
   "fields": {
     "ngram": {
       "type": "text",
       "analyzer": "peliasIndexOneEdgeGram",
+      "search_analyzer": "peliasAdmin",
       "doc_values": false
     }
   }

--- a/mappings/partial/postalcode.json
+++ b/mappings/partial/postalcode.json
@@ -1,10 +1,12 @@
 {
   "type": "text",
   "analyzer": "peliasZip",
+  "search_analyzer": "peliasZip",
   "fields": {
     "ngram": {
       "type": "text",
-      "analyzer": "peliasIndexOneEdgeGram"
+      "analyzer": "peliasIndexOneEdgeGram",
+      "search_analyzer": "peliasZip"
     }
   }
 }

--- a/test/compile.js
+++ b/test/compile.js
@@ -1,7 +1,16 @@
+const _ = require('lodash');
 const path = require('path');
 const schema = require('../');
 const fixture = require('./fixtures/expected.json');
 const config = require('pelias-config').generate();
+
+const forEachDeep = (obj, cb) =>
+  _.forEach(obj, (val, key) => {
+    cb(val, key);
+    if (_.isPlainObject(val) || _.isArray(val)){
+      forEachDeep(val, cb);
+    }
+  });
 
 module.exports.tests = {};
 
@@ -13,11 +22,11 @@ module.exports.tests.compile = function(test, common) {
   });
 };
 
-// admin indeces are explicitly specified in order to specify a custom
+// admin indices are explicitly specified in order to specify a custom
 // dynamic_template and to avoid 'type not found' errors when deploying
 // the api codebase against an index without admin data
-module.exports.tests.indeces = function(test, common) {
-  test('explicitly specify some admin indeces and their analyzer', function(t) {
+module.exports.tests.indices = function(test, common) {
+  test('explicitly specify some admin indices and their analyzer', function(t) {
     const _type = config.schema.typeName;
     t.equal(typeof schema.mappings[_type], 'object', 'mappings present');
     t.equal(schema.mappings[_type].dynamic_templates[0].nameGram.mapping.analyzer, 'peliasIndexOneEdgeGram');
@@ -35,8 +44,57 @@ module.exports.tests.dynamic_templates = function(test, common) {
     t.equal(template.match_mapping_type, 'string');
     t.deepEqual(template.mapping, {
       type: 'text',
-      analyzer: 'peliasIndexOneEdgeGram'
+      analyzer: 'peliasIndexOneEdgeGram',
+      search_analyzer: 'peliasQuery'
     });
+    t.end();
+  });
+  test('dynamic_templates: phrase', function (t) {
+    const _type = config.schema.typeName;
+    t.equal(typeof schema.mappings[_type].dynamic_templates[1].phrase, 'object', 'phrase template specified');
+    var template = schema.mappings[_type].dynamic_templates[1].phrase;
+    t.equal(template.path_match, 'phrase.*');
+    t.equal(template.match_mapping_type, 'string');
+    t.deepEqual(template.mapping, {
+      type: 'text',
+      analyzer: 'peliasPhrase',
+      search_analyzer: 'peliasQuery'
+    });
+    t.end();
+  });
+  test('dynamic_templates: addendum', function (t) {
+    const _type = config.schema.typeName;
+    t.equal(typeof schema.mappings[_type].dynamic_templates[2].addendum, 'object', 'addendum template specified');
+    var template = schema.mappings[_type].dynamic_templates[2].addendum;
+    t.equal(template.path_match, 'addendum.*');
+    t.equal(template.match_mapping_type, 'string');
+    t.deepEqual(template.mapping, {
+      type: 'keyword',
+      index: false,
+      doc_values: false
+    });
+    t.end();
+  });
+};
+
+// ensure both "analyzer" and "search_analyzer" are set for stringy fields
+module.exports.tests.analyzers = function (test, common) {
+  test('analyzers: ensure "analyzer" and "search_analyzer" are set', function (t) {
+
+    const stringyTypes = ['string', 'text'];
+    const stringyFields = [];
+
+    forEachDeep(schema, (value, key) => {
+      if (!_.isPlainObject(value)) { return; }
+      if (!stringyTypes.includes(_.get(value, 'type', ''))) { return; }
+      stringyFields.push({ key: key, value: value });
+    });
+
+    stringyFields.forEach(field => {
+      t.true(_.has(field.value, 'analyzer'), `analyzer not set on ${field.key}`)
+      t.true(_.has(field.value, 'search_analyzer'), `search_analyzer not set on ${field.key}`)
+    })
+
     t.end();
   });
 };
@@ -69,8 +127,8 @@ module.exports.tests.current_schema = function(test, common) {
     // console.error( JSON.stringify( schemaCopy, null, 2 ) );
 
     // code to write expected output to the fixture
-    //const fs = require('fs');
-    //fs.writeFileSync(path.resolve( __dirname + '/fixtures/expected.json' ), JSON.stringify(schemaCopy, null, 2));
+    // const fs = require('fs');
+    // fs.writeFileSync(path.resolve( __dirname + '/fixtures/expected.json' ), JSON.stringify(schemaCopy, null, 2));
 
     t.deepEqual(schemaCopy, fixture);
     t.end();

--- a/test/document.js
+++ b/test/document.js
@@ -49,6 +49,7 @@ module.exports.tests.address_analysis = function(test, common) {
   test('name', function(t) {
     t.equal(prop.name.type, 'text');
     t.equal(prop.name.analyzer, 'keyword');
+    t.equal(prop.name.search_analyzer, 'keyword');
     t.end();
   });
 
@@ -56,6 +57,7 @@ module.exports.tests.address_analysis = function(test, common) {
   test('unit', function(t) {
     t.equal(prop.unit.type, 'text', 'unit has full text type');
     t.equal(prop.unit.analyzer, 'peliasUnit', 'unit analyzer is peliasUnit');
+    t.equal(prop.unit.search_analyzer, 'peliasUnit', 'unit search_analyzer is peliasUnit');
     t.end();
   });
 
@@ -63,6 +65,7 @@ module.exports.tests.address_analysis = function(test, common) {
   test('number', function(t) {
     t.equal(prop.number.type, 'text');
     t.equal(prop.number.analyzer, 'peliasHousenumber');
+    t.equal(prop.number.search_analyzer, 'peliasHousenumber');
     t.end();
   });
 
@@ -70,6 +73,7 @@ module.exports.tests.address_analysis = function(test, common) {
   test('street', function(t) {
     t.equal(prop.street.type, 'text');
     t.equal(prop.street.analyzer, 'peliasStreet');
+    t.equal(prop.street.search_analyzer, 'peliasStreet');
     t.end();
   });
 
@@ -79,6 +83,7 @@ module.exports.tests.address_analysis = function(test, common) {
   test('zip', function(t) {
     t.equal(prop.zip.type, 'text');
     t.equal(prop.zip.analyzer, 'peliasZip');
+    t.equal(prop.zip.search_analyzer, 'peliasZip');
     t.end();
   });
 };
@@ -125,12 +130,14 @@ module.exports.tests.parent_analysis = function(test, common) {
       t.equal(prop[field].analyzer, 'peliasAdmin', `${field} analyzer is peliasAdmin`);
       t.equal(prop[field+'_a'].type, 'text', `${field}_a type is text`);
       t.equal(prop[field+'_a'].analyzer, 'peliasAdmin', `${field}_a analyzer is peliasAdmin`);
+      t.equal(prop[field+'_a'].search_analyzer, 'peliasAdmin', `${field}_a analyzer is peliasAdmin`);
       t.equal(prop[field+'_id'].type, 'keyword', `${field}_id type is keyword`);
       t.equal(prop[field+'_id'].index, undefined, `${field}_id index left at default`);
 
       // subfields
       t.equal(prop[field].fields.ngram.type, 'text', `${field}.ngram type is full text`);
       t.equal(prop[field].fields.ngram.analyzer, 'peliasIndexOneEdgeGram', `${field}.ngram analyzer is peliasIndexOneEdgeGram`);
+      t.equal(prop[field].fields.ngram.search_analyzer, 'peliasAdmin', `${field}.ngram analyzer is peliasIndexOneEdgeGram`);
 
       t.end();
     });
@@ -139,8 +146,10 @@ module.exports.tests.parent_analysis = function(test, common) {
   test('postalcode', function(t) {
     t.equal(prop['postalcode'].type, 'text', 'postalcode is full text field');
     t.equal(prop['postalcode'].analyzer, 'peliasZip', 'postalcode analyzer is peliasZip');
+    t.equal(prop['postalcode'].search_analyzer, 'peliasZip', 'postalcode analyzer is peliasZip');
     t.equal(prop['postalcode'+'_a'].type, 'text', 'postalcode_a is full text field');
     t.equal(prop['postalcode'+'_a'].analyzer, 'peliasZip', 'postalcode_a analyzer is peliasZip');
+    t.equal(prop['postalcode'+'_a'].search_analyzer, 'peliasZip', 'postalcode_a analyzer is peliasZip');
     t.equal(prop['postalcode'+'_id'].type, 'keyword', 'postalcode_id field is keyword type');
     t.equal(prop['postalcode'+'_id'].index, undefined, 'postalcode_id index left at default');
 
@@ -157,6 +166,7 @@ module.exports.tests.dynamic_templates = function(test, common) {
     t.equal(template.mapping.type, 'text', 'set to full text type');
     t.equal(template.mapping.fielddata, undefined, 'fielddata is left to default (disabled)');
     t.equal(template.mapping.analyzer, 'peliasIndexOneEdgeGram', 'analyzer set');
+    t.equal(template.mapping.search_analyzer, 'peliasQuery', 'search_analyzer set');
     t.end();
   });
   test('dynamic_templates: phrase', function(t) {
@@ -167,6 +177,7 @@ module.exports.tests.dynamic_templates = function(test, common) {
     t.equal(template.mapping.type, 'text', 'set to full text type');
     t.equal(template.mapping.fielddata, undefined, 'fielddata is left to default (disabled)');
     t.equal(template.mapping.analyzer, 'peliasPhrase', 'analyzer set');
+    t.equal(template.mapping.search_analyzer, 'peliasQuery', 'search_analyzer set');
     t.end();
   });
 };

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -594,27 +594,33 @@
           "properties": {
             "name": {
               "type": "text",
-              "analyzer": "keyword"
+              "analyzer": "keyword",
+              "search_analyzer": "keyword"
             },
             "unit": {
               "type": "text",
-              "analyzer": "peliasUnit"
+              "analyzer": "peliasUnit",
+              "search_analyzer": "peliasUnit"
             },
             "number": {
               "type": "text",
-              "analyzer": "peliasHousenumber"
+              "analyzer": "peliasHousenumber",
+              "search_analyzer": "peliasHousenumber"
             },
             "street": {
               "type": "text",
-              "analyzer": "peliasStreet"
+              "analyzer": "peliasStreet",
+              "search_analyzer": "peliasStreet"
             },
             "cross_street": {
               "type": "text",
-              "analyzer": "peliasStreet"
+              "analyzer": "peliasStreet",
+              "search_analyzer": "peliasStreet"
             },
             "zip": {
               "type": "text",
-              "analyzer": "peliasZip"
+              "analyzer": "peliasZip",
+              "search_analyzer": "peliasZip"
             }
           }
         },
@@ -625,10 +631,12 @@
             "continent": {
               "type": "text",
               "analyzer": "peliasAdmin",
+              "search_analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
                   "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
+                  "search_analyzer": "peliasAdmin",
                   "doc_values": false
                 }
               }
@@ -636,10 +644,12 @@
             "continent_a": {
               "type": "text",
               "analyzer": "peliasAdmin",
+              "search_analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
                   "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
+                  "search_analyzer": "peliasAdmin",
                   "doc_values": false
                 }
               }
@@ -651,10 +661,12 @@
             "ocean": {
               "type": "text",
               "analyzer": "peliasAdmin",
+              "search_analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
                   "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
+                  "search_analyzer": "peliasAdmin",
                   "doc_values": false
                 }
               }
@@ -662,10 +674,12 @@
             "ocean_a": {
               "type": "text",
               "analyzer": "peliasAdmin",
+              "search_analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
                   "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
+                  "search_analyzer": "peliasAdmin",
                   "doc_values": false
                 }
               }
@@ -677,10 +691,12 @@
             "empire": {
               "type": "text",
               "analyzer": "peliasAdmin",
+              "search_analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
                   "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
+                  "search_analyzer": "peliasAdmin",
                   "doc_values": false
                 }
               }
@@ -688,10 +704,12 @@
             "empire_a": {
               "type": "text",
               "analyzer": "peliasAdmin",
+              "search_analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
                   "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
+                  "search_analyzer": "peliasAdmin",
                   "doc_values": false
                 }
               }
@@ -703,10 +721,12 @@
             "country": {
               "type": "text",
               "analyzer": "peliasAdmin",
+              "search_analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
                   "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
+                  "search_analyzer": "peliasAdmin",
                   "doc_values": false
                 }
               }
@@ -714,10 +734,12 @@
             "country_a": {
               "type": "text",
               "analyzer": "peliasAdmin",
+              "search_analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
                   "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
+                  "search_analyzer": "peliasAdmin",
                   "doc_values": false
                 }
               }
@@ -729,10 +751,12 @@
             "dependency": {
               "type": "text",
               "analyzer": "peliasAdmin",
+              "search_analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
                   "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
+                  "search_analyzer": "peliasAdmin",
                   "doc_values": false
                 }
               }
@@ -740,10 +764,12 @@
             "dependency_a": {
               "type": "text",
               "analyzer": "peliasAdmin",
+              "search_analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
                   "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
+                  "search_analyzer": "peliasAdmin",
                   "doc_values": false
                 }
               }
@@ -755,10 +781,12 @@
             "marinearea": {
               "type": "text",
               "analyzer": "peliasAdmin",
+              "search_analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
                   "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
+                  "search_analyzer": "peliasAdmin",
                   "doc_values": false
                 }
               }
@@ -766,10 +794,12 @@
             "marinearea_a": {
               "type": "text",
               "analyzer": "peliasAdmin",
+              "search_analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
                   "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
+                  "search_analyzer": "peliasAdmin",
                   "doc_values": false
                 }
               }
@@ -781,10 +811,12 @@
             "macroregion": {
               "type": "text",
               "analyzer": "peliasAdmin",
+              "search_analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
                   "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
+                  "search_analyzer": "peliasAdmin",
                   "doc_values": false
                 }
               }
@@ -792,10 +824,12 @@
             "macroregion_a": {
               "type": "text",
               "analyzer": "peliasAdmin",
+              "search_analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
                   "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
+                  "search_analyzer": "peliasAdmin",
                   "doc_values": false
                 }
               }
@@ -807,10 +841,12 @@
             "region": {
               "type": "text",
               "analyzer": "peliasAdmin",
+              "search_analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
                   "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
+                  "search_analyzer": "peliasAdmin",
                   "doc_values": false
                 }
               }
@@ -818,10 +854,12 @@
             "region_a": {
               "type": "text",
               "analyzer": "peliasAdmin",
+              "search_analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
                   "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
+                  "search_analyzer": "peliasAdmin",
                   "doc_values": false
                 }
               }
@@ -833,10 +871,12 @@
             "macrocounty": {
               "type": "text",
               "analyzer": "peliasAdmin",
+              "search_analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
                   "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
+                  "search_analyzer": "peliasAdmin",
                   "doc_values": false
                 }
               }
@@ -844,10 +884,12 @@
             "macrocounty_a": {
               "type": "text",
               "analyzer": "peliasAdmin",
+              "search_analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
                   "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
+                  "search_analyzer": "peliasAdmin",
                   "doc_values": false
                 }
               }
@@ -859,10 +901,12 @@
             "county": {
               "type": "text",
               "analyzer": "peliasAdmin",
+              "search_analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
                   "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
+                  "search_analyzer": "peliasAdmin",
                   "doc_values": false
                 }
               }
@@ -870,10 +914,12 @@
             "county_a": {
               "type": "text",
               "analyzer": "peliasAdmin",
+              "search_analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
                   "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
+                  "search_analyzer": "peliasAdmin",
                   "doc_values": false
                 }
               }
@@ -885,10 +931,12 @@
             "locality": {
               "type": "text",
               "analyzer": "peliasAdmin",
+              "search_analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
                   "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
+                  "search_analyzer": "peliasAdmin",
                   "doc_values": false
                 }
               }
@@ -896,10 +944,12 @@
             "locality_a": {
               "type": "text",
               "analyzer": "peliasAdmin",
+              "search_analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
                   "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
+                  "search_analyzer": "peliasAdmin",
                   "doc_values": false
                 }
               }
@@ -911,10 +961,12 @@
             "borough": {
               "type": "text",
               "analyzer": "peliasAdmin",
+              "search_analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
                   "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
+                  "search_analyzer": "peliasAdmin",
                   "doc_values": false
                 }
               }
@@ -922,10 +974,12 @@
             "borough_a": {
               "type": "text",
               "analyzer": "peliasAdmin",
+              "search_analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
                   "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
+                  "search_analyzer": "peliasAdmin",
                   "doc_values": false
                 }
               }
@@ -937,10 +991,12 @@
             "localadmin": {
               "type": "text",
               "analyzer": "peliasAdmin",
+              "search_analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
                   "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
+                  "search_analyzer": "peliasAdmin",
                   "doc_values": false
                 }
               }
@@ -948,10 +1004,12 @@
             "localadmin_a": {
               "type": "text",
               "analyzer": "peliasAdmin",
+              "search_analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
                   "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
+                  "search_analyzer": "peliasAdmin",
                   "doc_values": false
                 }
               }
@@ -963,10 +1021,12 @@
             "neighbourhood": {
               "type": "text",
               "analyzer": "peliasAdmin",
+              "search_analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
                   "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
+                  "search_analyzer": "peliasAdmin",
                   "doc_values": false
                 }
               }
@@ -974,10 +1034,12 @@
             "neighbourhood_a": {
               "type": "text",
               "analyzer": "peliasAdmin",
+              "search_analyzer": "peliasAdmin",
               "fields": {
                 "ngram": {
                   "type": "text",
                   "analyzer": "peliasIndexOneEdgeGram",
+                  "search_analyzer": "peliasAdmin",
                   "doc_values": false
                 }
               }
@@ -989,20 +1051,24 @@
             "postalcode": {
               "type": "text",
               "analyzer": "peliasZip",
+              "search_analyzer": "peliasZip",
               "fields": {
                 "ngram": {
                   "type": "text",
-                  "analyzer": "peliasIndexOneEdgeGram"
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "search_analyzer": "peliasZip"
                 }
               }
             },
             "postalcode_a": {
               "type": "text",
               "analyzer": "peliasZip",
+              "search_analyzer": "peliasZip",
               "fields": {
                 "ngram": {
                   "type": "text",
-                  "analyzer": "peliasIndexOneEdgeGram"
+                  "analyzer": "peliasIndexOneEdgeGram",
+                  "search_analyzer": "peliasZip"
                 }
               }
             },
@@ -1050,7 +1116,8 @@
             "match_mapping_type": "string",
             "mapping": {
               "type": "text",
-              "analyzer": "peliasIndexOneEdgeGram"
+              "analyzer": "peliasIndexOneEdgeGram",
+              "search_analyzer": "peliasQuery"
             }
           }
         },
@@ -1060,7 +1127,8 @@
             "match_mapping_type": "string",
             "mapping": {
               "type": "text",
-              "analyzer": "peliasPhrase"
+              "analyzer": "peliasPhrase",
+              "search_analyzer": "peliasQuery"
             }
           }
         },


### PR DESCRIPTION
cherry-picked from https://github.com/pelias/schema/pull/412 and based on https://github.com/pelias/schema/pull/413. [view diff](https://github.com/pelias/schema/compare/list_analyzers...explicitly_set_analyzers)

This is something I've been wanting to do for a while, it explicitly sets the `analyzer` and `search_analyzer` property for all `text` fields.

The default behaviour of elasticsearch is to default all analyzers to `standard` when not otherwise defined..
... and to default the `search_analyzer` property to equal `analyzer`.

So while it's not totally necessary to define an explicit `search_analyzer` when it's equal to the `analyzer` I have made this mandatory and covered it with tests, this ensures that it is considered when adding new fields or adapting existing ones.

This is hopefully a no-op refactor (basing the `search_analyzer` settings on what's in the `defaults` for `pelias/api`).
It will benefit any queries where the `analyzer` was not set on the query for whatever reason.

```diff
 field                            type                             analyzer                  search_analyzer           normalizer
< name.*                           text                             peliasIndexOneEdgeGram    peliasIndexOneEdgeGram    n/a
< phrase.*                         text                             peliasPhrase              peliasPhrase              n/a
---
> name.*                           text                             peliasIndexOneEdgeGram    peliasQuery               n/a
> phrase.*                         text                             peliasPhrase              peliasQuery               n/a
```