### PR TITLE
feat(integration): Add total hits helper

### DIFF
--- a/integration/_hits_total_helper.js
+++ b/integration/_hits_total_helper.js
@@ -1,0 +1,20 @@
+const _ = require('lodash');
+
+/**
+ * The way hits are defined in ES7 changed
+ * This helper can be used to avoid interoperability issues:
+ *
+ * expected: 1
+ * actual:
+ * { value: 1, relation: 'eq' }
+ */
+
+ function helper(hits){
+   let totalHits = 0;
+   if (_.has(hits, 'total')) {
+     totalHits = _.isPlainObject(hits.total) ? hits.total.value : hits.total;
+   }
+   return totalHits;
+ }
+
+ module.exports = helper;

--- a/integration/address_matching.js
+++ b/integration/address_matching.js
@@ -3,6 +3,7 @@
 const elastictest = require('elastictest');
 const schema = require('../schema');
 const config = require('pelias-config').generate();
+const getTotalHits = require('./_hits_total_helper');
 
 module.exports.tests = {};
 
@@ -75,7 +76,7 @@ module.exports.tests.functional = function(test, common){
         ]}}}
       }, function( err, res ){
         t.equal( err, undefined );
-        t.equal( res.hits.total, 1, 'match street number' );
+        t.equal( getTotalHits(res.hits), 1, 'match street number' );
         done();
       });
     });
@@ -90,7 +91,7 @@ module.exports.tests.functional = function(test, common){
         ]}}}
       }, function( err, res ){
         t.equal( err, undefined );
-        t.equal( res.hits.total, 2, 'match street name' );
+        t.equal( getTotalHits(res.hits), 2, 'match street name' );
         done();
       });
     });
@@ -105,7 +106,7 @@ module.exports.tests.functional = function(test, common){
         ]}}}
       }, function( err, res ){
         t.equal( err, undefined );
-        t.equal( res.hits.total, 2, 'match street name - abbr' );
+        t.equal( getTotalHits(res.hits), 2, 'match street name - abbr' );
         done();
       });
     });
@@ -120,7 +121,7 @@ module.exports.tests.functional = function(test, common){
         ]}}}
       }, function( err, res ){
         t.equal( err, undefined );
-        t.equal( res.hits.total, 3, 'match zip - numeric' );
+        t.equal( getTotalHits(res.hits), 3, 'match zip - numeric' );
         done();
       });
     });
@@ -135,7 +136,7 @@ module.exports.tests.functional = function(test, common){
         ]}}}
       }, function( err, res ){
         t.equal( err, undefined );
-        t.equal( res.hits.total, 1, 'match zip - string' );
+        t.equal( getTotalHits(res.hits), 1, 'match zip - string' );
         done();
       });
     });
@@ -150,7 +151,7 @@ module.exports.tests.functional = function(test, common){
         ]}}}
       }, function( err, res ){
         t.equal( err, undefined );
-        t.equal( res.hits.total, 3, 'match zip - numeric - punct' );
+        t.equal( getTotalHits(res.hits), 3, 'match zip - numeric - punct' );
         done();
       });
     });
@@ -165,7 +166,7 @@ module.exports.tests.functional = function(test, common){
         ]}}}
       }, function( err, res ){
         t.equal( err, undefined );
-        t.equal( res.hits.total, 3, 'match zip - numeric - whitespace' );
+        t.equal( getTotalHits(res.hits), 3, 'match zip - numeric - whitespace' );
         done();
       });
     });
@@ -180,7 +181,7 @@ module.exports.tests.functional = function(test, common){
         ]}}}
       }, function( err, res ){
         t.equal( err, undefined );
-        t.equal( res.hits.total, 1, 'match zip - string - punct' );
+        t.equal( getTotalHits(res.hits), 1, 'match zip - string - punct' );
         done();
       });
     });
@@ -195,7 +196,7 @@ module.exports.tests.functional = function(test, common){
         ]}}}
       }, function( err, res ){
         t.equal( err, undefined );
-        t.equal( res.hits.total, 1, 'match zip - string - whitespace' );
+        t.equal( getTotalHits(res.hits), 1, 'match zip - string - whitespace' );
         done();
       });
     });
@@ -307,7 +308,7 @@ module.exports.tests.venue_vs_address = function(test, common){
         }
       }, function( err, res ){
         t.equal( err, undefined );
-        t.equal( res.hits.total, TOTAL_ADDRESS_DOCS+1, 'matched all docs' );
+        t.equal( getTotalHits(res.hits), TOTAL_ADDRESS_DOCS+1, 'matched all docs' );
         t.equal( res.hits.hits[TOTAL_ADDRESS_DOCS]._id, '1', 'exact name match first' );
         done();
       });

--- a/integration/admin_matching.js
+++ b/integration/admin_matching.js
@@ -3,6 +3,7 @@
 const elastictest = require('elastictest');
 const schema = require('../schema');
 const config = require('pelias-config').generate();
+const getTotalHits = require('./_hits_total_helper');
 
 module.exports.tests = {};
 
@@ -50,7 +51,7 @@ module.exports.tests.functional = function(test, common){
         body: { query: { match: { 'parent.country': 'Test Country' } } }
       }, function( err, res ){
         t.equal( err, undefined );
-        t.equal( res.hits.total, 1, 'document found' );
+        t.equal( getTotalHits(res.hits), 1, 'document found' );
         done();
       });
     });
@@ -63,7 +64,7 @@ module.exports.tests.functional = function(test, common){
         body: { query: { match: { 'parent.country_a': 'TestCountry' } } }
       }, function( err, res ){
         t.equal( err, undefined );
-        t.equal( res.hits.total, 1, 'document found' );
+        t.equal( getTotalHits(res.hits), 1, 'document found' );
         done();
       });
     });
@@ -76,7 +77,7 @@ module.exports.tests.functional = function(test, common){
         body: { query: { match: { 'parent.country_id': '100' } } }
       }, function( err, res ){
         t.equal( err, undefined );
-        t.equal( res.hits.total, 1, 'document found' );
+        t.equal( getTotalHits(res.hits), 1, 'document found' );
         done();
       });
     });

--- a/integration/analyzer_peliasPhrase.js
+++ b/integration/analyzer_peliasPhrase.js
@@ -4,6 +4,7 @@ const elastictest = require('elastictest');
 const schema = require('../schema');
 const punctuation = require('../punctuation');
 const config = require('pelias-config').generate();
+const getTotalHits = require('./_hits_total_helper');
 
 module.exports.tests = {};
 
@@ -215,7 +216,7 @@ module.exports.tests.slop_query = function(test, common){
         searchType: 'dfs_query_then_fetch',
         body: buildQuery('Lake Cayuga')
       }, function( err, res ){
-        t.equal( res.hits.total, 3 );
+        t.equal( getTotalHits(res.hits), 3 );
         var hits = res.hits.hits;
 
         t.equal( hits[0]._source.name.default, 'Lake Cayuga' );
@@ -273,7 +274,7 @@ module.exports.tests.slop = function(test, common){
         }}}
       }, function( err, res ){
         t.equal( err, undefined );
-        t.equal( res.hits.total, 1, 'document found' );
+        t.equal( getTotalHits(res.hits), 1, 'document found' );
         done();
       });
     });

--- a/integration/autocomplete_abbreviated_street_names.js
+++ b/integration/autocomplete_abbreviated_street_names.js
@@ -7,6 +7,7 @@
 const elastictest = require('elastictest');
 const schema = require('../schema');
 const config = require('pelias-config').generate();
+const getTotalHits = require('./_hits_total_helper');
 
 module.exports.tests = {};
 
@@ -40,7 +41,7 @@ module.exports.tests.index_expanded_form_search_contracted = function(test, comm
         }}}
       }, function( err, res ){
         t.equal( err, undefined );
-        t.equal( res.hits.total, 1, 'document found' );
+        t.equal( getTotalHits(res.hits), 1, 'document found' );
         done();
       });
     });
@@ -84,7 +85,7 @@ module.exports.tests.index_expanded_form_search_contracted = function(test, comm
 //         }}}
 //       }, function( err, res ){
 //         t.equal( err, undefined );
-//         t.equal( res.hits.total, 1, 'document found' );
+//         t.equal( getTotalHits(res.hits), 1, 'document found' );
 //         done();
 //       });
 //     });
@@ -105,7 +106,7 @@ module.exports.tests.index_expanded_form_search_contracted = function(test, comm
 //         }}}
 //       }, function( err, res ){
 //         t.equal( err, undefined );
-//         t.equal( res.hits.total, 1, 'document found' );
+//         t.equal( getTotalHits(res.hits), 1, 'document found' );
 //         done();
 //       });
 //     });

--- a/integration/autocomplete_directional_synonym_expansion.js
+++ b/integration/autocomplete_directional_synonym_expansion.js
@@ -7,6 +7,7 @@
 const elastictest = require('elastictest');
 const schema = require('../schema');
 const config = require('pelias-config').generate();
+const getTotalHits = require('./_hits_total_helper');
 
 module.exports.tests = {};
 
@@ -40,7 +41,7 @@ module.exports.tests.index_and_retrieve_expanded_form = function(test, common){
         }}}
       }, function( err, res ){
         t.equal( err, undefined );
-        t.equal( res.hits.total, 1, 'document found' );
+        t.equal( getTotalHits(res.hits), 1, 'document found' );
         done();
       });
     });
@@ -58,7 +59,7 @@ module.exports.tests.index_and_retrieve_expanded_form = function(test, common){
         }}}
       }, function( err, res ){
         t.equal( err, undefined );
-        t.equal( res.hits.total, 1, 'document found' );
+        t.equal( getTotalHits(res.hits), 1, 'document found' );
         done();
       });
     });
@@ -97,7 +98,7 @@ module.exports.tests.index_and_retrieve_contracted_form = function(test, common)
         }}}
       }, function( err, res ){
         t.equal( err, undefined );
-        t.equal( res.hits.total, 1, 'document found' );
+        t.equal( getTotalHits(res.hits), 1, 'document found' );
         done();
       });
     });
@@ -136,7 +137,7 @@ module.exports.tests.index_and_retrieve_mixed_form_1 = function(test, common){
         }}}
       }, function( err, res ){
         t.equal( err, undefined );
-        t.equal( res.hits.total, 1, 'document found' );
+        t.equal( getTotalHits(res.hits), 1, 'document found' );
         done();
       });
     });
@@ -154,7 +155,7 @@ module.exports.tests.index_and_retrieve_mixed_form_1 = function(test, common){
         }}}
       }, function( err, res ){
         t.equal( err, undefined );
-        t.equal( res.hits.total, 1, 'document found' );
+        t.equal( getTotalHits(res.hits), 1, 'document found' );
         done();
       });
     });
@@ -193,7 +194,7 @@ module.exports.tests.index_and_retrieve_mixed_form_2 = function(test, common){
         }}}
       }, function( err, res ){
         t.equal( err, undefined );
-        t.equal( res.hits.total, 1, 'document found' );
+        t.equal( getTotalHits(res.hits), 1, 'document found' );
         done();
       });
     });

--- a/integration/autocomplete_street_synonym_expansion.js
+++ b/integration/autocomplete_street_synonym_expansion.js
@@ -7,6 +7,7 @@
 const elastictest = require('elastictest');
 const schema = require('../schema');
 const config = require('pelias-config').generate();
+const getTotalHits = require('./_hits_total_helper');
 
 module.exports.tests = {};
 
@@ -40,7 +41,7 @@ module.exports.tests.index_and_retrieve_expanded_form = function(test, common){
         }}}
       }, function( err, res ){
         t.equal( err, undefined );
-        t.equal( res.hits.total, 1, 'document found' );
+        t.equal( getTotalHits(res.hits), 1, 'document found' );
         done();
       });
     });
@@ -58,7 +59,7 @@ module.exports.tests.index_and_retrieve_expanded_form = function(test, common){
         }}}
       }, function( err, res ){
         t.equal( err, undefined );
-        t.equal( res.hits.total, 1, 'document found' );
+        t.equal( getTotalHits(res.hits), 1, 'document found' );
         done();
       });
     });
@@ -97,7 +98,7 @@ module.exports.tests.index_and_retrieve_contracted_form = function(test, common)
         }}}
       }, function( err, res ){
         t.equal( err, undefined );
-        t.equal( res.hits.total, 1, 'document found' );
+        t.equal( getTotalHits(res.hits), 1, 'document found' );
         done();
       });
     });
@@ -136,7 +137,7 @@ module.exports.tests.index_and_retrieve_mixed_form_1 = function(test, common){
         }}}
       }, function( err, res ){
         t.equal( err, undefined );
-        t.equal( res.hits.total, 1, 'document found' );
+        t.equal( getTotalHits(res.hits), 1, 'document found' );
         done();
       });
     });
@@ -154,7 +155,7 @@ module.exports.tests.index_and_retrieve_mixed_form_1 = function(test, common){
         }}}
       }, function( err, res ){
         t.equal( err, undefined );
-        t.equal( res.hits.total, 1, 'document found' );
+        t.equal( getTotalHits(res.hits), 1, 'document found' );
         done();
       });
     });
@@ -193,7 +194,7 @@ module.exports.tests.index_and_retrieve_mixed_form_2 = function(test, common){
         }}}
       }, function( err, res ){
         t.equal( err, undefined );
-        t.equal( res.hits.total, 1, 'document found' );
+        t.equal( getTotalHits(res.hits), 1, 'document found' );
         done();
       });
     });

--- a/integration/source_layer_sourceid_filtering.js
+++ b/integration/source_layer_sourceid_filtering.js
@@ -3,6 +3,7 @@
 const elastictest = require('elastictest');
 const schema = require('../schema');
 const config = require('pelias-config').generate();
+const getTotalHits = require('./_hits_total_helper');
 
 module.exports.tests = {};
 
@@ -52,7 +53,7 @@ module.exports.tests.source_filter = function(test, common){
           }
         }}
       }, function( err, res ){
-        t.equal( res.hits.total, 2 );
+        t.equal( getTotalHits(res.hits), 2 );
         done();
       });
     });
@@ -68,7 +69,7 @@ module.exports.tests.source_filter = function(test, common){
           }
         }}
       }, function( err, res ){
-        t.equal( res.hits.total, 2 );
+        t.equal( getTotalHits(res.hits), 2 );
         done();
       });
     });
@@ -84,7 +85,7 @@ module.exports.tests.source_filter = function(test, common){
           }
         }}
       }, function( err, res ){
-        t.equal( res.hits.total, 2 );
+        t.equal( getTotalHits(res.hits), 2 );
         done();
       });
     });
@@ -99,7 +100,7 @@ module.exports.tests.source_filter = function(test, common){
           { term: { source_id: 'dataset/1' } }
         ]}}}
       }, function( err, res ){
-        t.equal( res.hits.total, 1 );
+        t.equal( getTotalHits(res.hits), 1 );
         done();
       });
     });
@@ -115,7 +116,7 @@ module.exports.tests.source_filter = function(test, common){
           }
         }}
       }, function( err, res ){
-        t.equal( res.hits.total, 0 );
+        t.equal( getTotalHits(res.hits), 0 );
         done();
       });
     });
@@ -131,7 +132,7 @@ module.exports.tests.source_filter = function(test, common){
           }
         }}
       }, function( err, res ){
-        t.equal( res.hits.total, 0 );
+        t.equal( getTotalHits(res.hits), 0 );
         done();
       });
     });
@@ -147,7 +148,7 @@ module.exports.tests.source_filter = function(test, common){
           }
         }}
       }, function( err, res ){
-        t.equal( res.hits.total, 1 );
+        t.equal( getTotalHits(res.hits), 1 );
         done();
       });
     });


### PR DESCRIPTION
In Elasticsearch 7+, the [hits count is now an object](https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html#hits-total-now-object-search-response).

This was needed because Elasticsearch now includes a performance improvement that allows non-exact hit counts to be used when the exact count isn't needed.

This PR adds a helper to wrap around the breaking change and support either the old or new format.

Extracted from https://github.com/pelias/schema/pull/394
Connects https://github.com/pelias/pelias/issues/831