### PR TITLE
feat(ES5): Drop support for Elasticsearch 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ matrix:
   fast_finish: true
 env:
   matrix:
-    - ES_VERSION=5.6.12 ES_TYPE=doc JDK_VERSION=oraclejdk8
-    - ES_VERSION=5.6.12 ES_TYPE=doc JDK_VERSION=oraclejdk11
     - ES_VERSION=6.8.5 ES_TYPE=doc JDK_VERSION=oraclejdk8
     - ES_VERSION=6.8.5 ES_TYPE=doc JDK_VERSION=oraclejdk11
     - ES_VERSION=6.8.5 ES_TYPE=_doc JDK_VERSION=oraclejdk8


### PR DESCRIPTION
BREAKING CHANGE: This drops Elasticsearch 5 from the test matrix for this repo. While it makes no other changes, it's a breaking change as it marks the point where we stop supporting ES5.

This allows us to make changes that support only ES6/7 as we add support for Elasticsearch 7.

Connects https://github.com/pelias/pelias/issues/831