### PR TITLE
feat(Node.js): Drop support for Node.js 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/pelias/schema/issues"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "dependencies": {
     "@hapi/joi": "^16.1.8",


### PR DESCRIPTION
Node.js 8 is no longer supported as it will reach [end of life](https://github.com/nodejs/Release#release-schedule) at the end of 2019.

Unlike the other PRs to drop Node.js 8 support, this one was not made a breaking change since we just dropped ES5 support, also as a breaking change.

Connects https://github.com/pelias/pelias/issues/837