### PR TITLE
chore(integration): Move schema creation options to common config

### DIFF
--- a/integration/address_matching.js
+++ b/integration/address_matching.js
@@ -1,7 +1,6 @@
 // validate analyzer is behaving as expected
 
 const elastictest = require('elastictest');
-const schema = require('../schema');
 const config = require('pelias-config').generate();
 const getTotalHits = require('./_hits_total_helper');
 
@@ -10,7 +9,7 @@ module.exports.tests = {};
 module.exports.tests.functional = function(test, common){
   test( 'functional', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     // index some docs
@@ -218,7 +217,7 @@ module.exports.tests.venue_vs_address = function(test, common){
     // Unfortunately there seems to be no easy way of fixing this, it's an artifact of us
     // storing the street names in the name.default field.
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     // index a venue

--- a/integration/admin_matching.js
+++ b/integration/admin_matching.js
@@ -1,7 +1,6 @@
 // validate analyzer is behaving as expected
 
 const elastictest = require('elastictest');
-const schema = require('../schema');
 const config = require('pelias-config').generate();
 const getTotalHits = require('./_hits_total_helper');
 
@@ -10,7 +9,7 @@ module.exports.tests = {};
 module.exports.tests.functional = function(test, common){
   test( 'functional', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     // index a document with all admin values

--- a/integration/analyzer_peliasAdmin.js
+++ b/integration/analyzer_peliasAdmin.js
@@ -2,7 +2,6 @@
 
 var tape = require('tape'),
     elastictest = require('elastictest'),
-    schema = require('../schema'),
     punctuation = require('../punctuation');
 
 module.exports.tests = {};
@@ -10,7 +9,7 @@ module.exports.tests = {};
 module.exports.tests.analyze = function(test, common){
   test( 'analyze', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasAdmin' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -34,7 +33,7 @@ module.exports.tests.analyze = function(test, common){
 module.exports.tests.functional = function(test, common){
   test( 'functional', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasAdmin' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -72,7 +71,7 @@ module.exports.tests.functional = function(test, common){
 module.exports.tests.synonyms = function(test, common){
   test( 'synonyms', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasAdmin' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -99,7 +98,7 @@ module.exports.tests.synonyms = function(test, common){
 module.exports.tests.tokenizer = function(test, common){
   test( 'tokenizer', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasAdmin' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -127,7 +126,7 @@ module.exports.tests.tokenizer = function(test, common){
 module.exports.tests.unicode = function(test, common){
   test( 'normalization', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasAdmin' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 

--- a/integration/analyzer_peliasHousenumber.js
+++ b/integration/analyzer_peliasHousenumber.js
@@ -2,7 +2,6 @@
 
 var tape = require('tape'),
     elastictest = require('elastictest'),
-    schema = require('../schema'),
     punctuation = require('../punctuation');
 
 module.exports.tests = {};
@@ -10,7 +9,7 @@ module.exports.tests = {};
 module.exports.tests.analyze = function(test, common){
   test( 'analyze', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasHousenumber' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -24,7 +23,7 @@ module.exports.tests.analyze = function(test, common){
 module.exports.tests.functional = function(test, common){
   test( 'functional', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasHousenumber' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 

--- a/integration/analyzer_peliasIndexOneEdgeGram.js
+++ b/integration/analyzer_peliasIndexOneEdgeGram.js
@@ -2,7 +2,6 @@
 
 var tape = require('tape'),
     elastictest = require('elastictest'),
-    schema = require('../schema'),
     punctuation = require('../punctuation');
 
 module.exports.tests = {};
@@ -10,7 +9,7 @@ module.exports.tests = {};
 module.exports.tests.analyze = function(test, common){
   test( 'analyze', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasIndexOneEdgeGram' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -93,7 +92,7 @@ module.exports.tests.analyze = function(test, common){
 module.exports.tests.address_suffix_expansions = function(test, common){
   test( 'address suffix expansions', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasIndexOneEdgeGram' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -123,7 +122,7 @@ module.exports.tests.address_suffix_expansions = function(test, common){
 module.exports.tests.stop_words = function(test, common){
   test( 'stop words', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasIndexOneEdgeGram' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -144,7 +143,7 @@ module.exports.tests.stop_words = function(test, common){
 module.exports.tests.functional = function(test, common){
   test( 'functional', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasIndexOneEdgeGram' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -170,7 +169,7 @@ module.exports.tests.functional = function(test, common){
 module.exports.tests.unique = function(test, common){
   test( 'unique', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasIndexOneEdgeGram' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -184,7 +183,7 @@ module.exports.tests.unique = function(test, common){
 module.exports.tests.address = function(test, common){
   test( 'address', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasIndexOneEdgeGram' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -216,7 +215,7 @@ module.exports.tests.address = function(test, common){
 module.exports.tests.unicode = function(test, common){
   test( 'normalization', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasIndexOneEdgeGram' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 

--- a/integration/analyzer_peliasPhrase.js
+++ b/integration/analyzer_peliasPhrase.js
@@ -1,7 +1,6 @@
 // validate analyzer is behaving as expected
 
 const elastictest = require('elastictest');
-const schema = require('../schema');
 const punctuation = require('../punctuation');
 const config = require('pelias-config').generate();
 const getTotalHits = require('./_hits_total_helper');
@@ -11,7 +10,7 @@ module.exports.tests = {};
 module.exports.tests.analyze = function(test, common){
   test( 'analyze', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasPhrase' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -56,7 +55,7 @@ module.exports.tests.analyze = function(test, common){
 module.exports.tests.functional = function(test, common){
   test( 'functional', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasPhrase' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -103,7 +102,7 @@ module.exports.tests.functional = function(test, common){
 module.exports.tests.tokenizer = function(test, common){
   test( 'tokenizer', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasPhrase' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -129,7 +128,7 @@ module.exports.tests.tokenizer = function(test, common){
 module.exports.tests.slop = function(test, common){
   test( 'slop', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasPhrase' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -147,7 +146,7 @@ module.exports.tests.slop = function(test, common){
 module.exports.tests.slop_query = function(test, common){
   test( 'slop query', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasPhrase' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -243,7 +242,7 @@ module.exports.tests.slop_query = function(test, common){
 module.exports.tests.slop = function(test, common){
   test( 'slop', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     // index a document
@@ -287,7 +286,7 @@ module.exports.tests.slop = function(test, common){
 module.exports.tests.unicode = function(test, common){
   test( 'normalization', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasPhrase' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 

--- a/integration/analyzer_peliasQuery.js
+++ b/integration/analyzer_peliasQuery.js
@@ -2,7 +2,6 @@
 
 var tape = require('tape'),
     elastictest = require('elastictest'),
-    schema = require('../schema'),
     punctuation = require('../punctuation');
 
 module.exports.tests = {};
@@ -10,7 +9,7 @@ module.exports.tests = {};
 module.exports.tests.analyze = function(test, common){
   test( 'analyze', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasQuery' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -42,7 +41,7 @@ module.exports.tests.analyze = function(test, common){
 module.exports.tests.functional = function(test, common){
   test( 'functional', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasQuery' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -57,7 +56,7 @@ module.exports.tests.functional = function(test, common){
 module.exports.tests.address = function(test, common){
   test( 'address', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasQuery' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -81,7 +80,7 @@ module.exports.tests.address = function(test, common){
 module.exports.tests.unicode = function(test, common){
   test( 'normalization', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasQuery' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 

--- a/integration/analyzer_peliasStreet.js
+++ b/integration/analyzer_peliasStreet.js
@@ -10,7 +10,7 @@ module.exports.tests = {};
 module.exports.tests.analyze = function(test, common){
   test( 'analyze', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasStreet' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -33,7 +33,7 @@ module.exports.tests.analyze = function(test, common){
 module.exports.tests.functional = function(test, common){
   test( 'functional', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasStreet' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -50,7 +50,7 @@ module.exports.tests.functional = function(test, common){
 module.exports.tests.normalize_punctuation = function(test, common){
   test( 'normalize punctuation', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasStreet' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -68,7 +68,7 @@ module.exports.tests.normalize_punctuation = function(test, common){
 module.exports.tests.remove_ordinals = function(test, common){
   test( 'remove ordinals', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasStreet' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -142,7 +142,7 @@ module.exports.tests.remove_ordinals = function(test, common){
 module.exports.tests.tokenizer = function(test, common){
   test( 'tokenizer', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasStreet' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -167,7 +167,7 @@ module.exports.tests.tokenizer = function(test, common){
 module.exports.tests.unicode = function(test, common){
   test( 'normalization', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasStreet' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -198,7 +198,7 @@ module.exports.tests.unicode = function(test, common){
 module.exports.tests.germanic_street_suffixes = function (test, common) {
   test('germanic_street_suffixes', function (t) {
 
-    var suite = new elastictest.Suite(common.clientOpts, { schema: schema });
+    var suite = new elastictest.Suite(common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind(null, suite, t, 'peliasStreet');
     suite.action(function (done) { setTimeout(done, 500); }); // wait for es to bring some shards up
 

--- a/integration/analyzer_peliasZip.js
+++ b/integration/analyzer_peliasZip.js
@@ -2,7 +2,6 @@
 
 var tape = require('tape'),
     elastictest = require('elastictest'),
-    schema = require('../schema'),
     punctuation = require('../punctuation');
 
 module.exports.tests = {};
@@ -10,7 +9,7 @@ module.exports.tests = {};
 module.exports.tests.analyze = function(test, common){
   test( 'analyze', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasZip' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -25,7 +24,7 @@ module.exports.tests.analyze = function(test, common){
 module.exports.tests.functional = function(test, common){
   test( 'functional', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasZip' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 

--- a/integration/autocomplete_abbreviated_street_names.js
+++ b/integration/autocomplete_abbreviated_street_names.js
@@ -5,7 +5,6 @@
 // The cases tested here are described in: https://github.com/pelias/schema/issues/105
 
 const elastictest = require('elastictest');
-const schema = require('../schema');
 const config = require('pelias-config').generate();
 const getTotalHits = require('./_hits_total_helper');
 
@@ -15,7 +14,7 @@ module.exports.tests = {};
 module.exports.tests.index_expanded_form_search_contracted = function(test, common){
   test( 'index expanded and retrieve contracted form', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     // index a document with a name which contains a synonym (center)
@@ -56,7 +55,7 @@ module.exports.tests.index_expanded_form_search_contracted = function(test, comm
 // module.exports.tests.index_contracted_form_search_expanded = function(test, common){
 //   test( 'index contracted and search expanded', function(t){
 
-//     var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+//     var suite = new elastictest.Suite( common.clientOpts, common.create );
 //     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
 //     // index a document with a name which contains a synonym (center)

--- a/integration/autocomplete_directional_synonym_expansion.js
+++ b/integration/autocomplete_directional_synonym_expansion.js
@@ -5,7 +5,6 @@
 // The cases tested here are described in: https://github.com/pelias/schema/issues/105
 
 const elastictest = require('elastictest');
-const schema = require('../schema');
 const config = require('pelias-config').generate();
 const getTotalHits = require('./_hits_total_helper');
 
@@ -15,7 +14,7 @@ module.exports.tests = {};
 module.exports.tests.index_and_retrieve_expanded_form = function(test, common){
   test( 'index and retrieve expanded form', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     // index a document with a name which contains a synonym (center)
@@ -72,7 +71,7 @@ module.exports.tests.index_and_retrieve_expanded_form = function(test, common){
 module.exports.tests.index_and_retrieve_contracted_form = function(test, common){
   test( 'index and retrieve contracted form', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     // index a document with a name which contains a synonym (center)
@@ -111,7 +110,7 @@ module.exports.tests.index_and_retrieve_contracted_form = function(test, common)
 module.exports.tests.index_and_retrieve_mixed_form_1 = function(test, common){
   test( 'index and retrieve mixed form 1', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     // index a document with a name which contains a synonym (center)
@@ -168,7 +167,7 @@ module.exports.tests.index_and_retrieve_mixed_form_1 = function(test, common){
 module.exports.tests.index_and_retrieve_mixed_form_2 = function(test, common){
   test( 'index and retrieve mixed form 2', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     // index a document with a name which contains a synonym (center)

--- a/integration/autocomplete_street_synonym_expansion.js
+++ b/integration/autocomplete_street_synonym_expansion.js
@@ -5,8 +5,8 @@
 // The cases tested here are described in: https://github.com/pelias/schema/issues/105
 
 const elastictest = require('elastictest');
-const schema = require('../schema');
 const config = require('pelias-config').generate();
+
 const getTotalHits = require('./_hits_total_helper');
 
 module.exports.tests = {};
@@ -15,7 +15,7 @@ module.exports.tests = {};
 module.exports.tests.index_and_retrieve_expanded_form = function(test, common){
   test( 'index and retrieve expanded form', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     // index a document with a name which contains a synonym (center)
@@ -72,7 +72,7 @@ module.exports.tests.index_and_retrieve_expanded_form = function(test, common){
 module.exports.tests.index_and_retrieve_contracted_form = function(test, common){
   test( 'index and retrieve contracted form', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     // index a document with a name which contains a synonym (center)
@@ -111,7 +111,7 @@ module.exports.tests.index_and_retrieve_contracted_form = function(test, common)
 module.exports.tests.index_and_retrieve_mixed_form_1 = function(test, common){
   test( 'index and retrieve mixed form 1', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     // index a document with a name which contains a synonym (center)
@@ -168,7 +168,7 @@ module.exports.tests.index_and_retrieve_mixed_form_1 = function(test, common){
 module.exports.tests.index_and_retrieve_mixed_form_2 = function(test, common){
   test( 'index and retrieve mixed form 2', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     // index a document with a name which contains a synonym (center)

--- a/integration/bounding_box.js
+++ b/integration/bounding_box.js
@@ -1,7 +1,6 @@
 // validate bounding box behaves as expected
 
 const elastictest = require('elastictest');
-const schema = require('../schema');
 const config = require('pelias-config').generate();
 
 module.exports.tests = {};
@@ -9,7 +8,7 @@ module.exports.tests = {};
 module.exports.tests.index_and_retrieve = function(test, common){
   test( 'index and retrieve', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     // index a document with a bbox

--- a/integration/dynamic_templates.js
+++ b/integration/dynamic_templates.js
@@ -1,7 +1,6 @@
 // http://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-root-object-type.html#_dynamic_templates
 
 const elastictest = require('elastictest');
-const schema = require('../schema');
 const config = require('pelias-config').generate();
 
 module.exports.tests = {};
@@ -32,7 +31,7 @@ module.exports.all = function (tape, common) {
 function nameAssertion( analyzer, common ){
   return function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     const _type = config.schema.typeName;
 
     // index a document from a normal document layer
@@ -71,7 +70,7 @@ function nameAssertion( analyzer, common ){
 function phraseAssertion( analyzer, common ){
   return function(t){
 
-    const suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    const suite = new elastictest.Suite( common.clientOpts, common.create );
     const _type = config.schema.typeName;
 
     // index a document from a normal document layer
@@ -110,7 +109,7 @@ function phraseAssertion( analyzer, common ){
 function addendumAssertion( namespace, value, common ){
   return function(t){
 
-    const suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    const suite = new elastictest.Suite( common.clientOpts, common.create );
     const _type = config.schema.typeName;
 
     // index a document including the addendum

--- a/integration/multi_token_synonyms.js
+++ b/integration/multi_token_synonyms.js
@@ -1,7 +1,6 @@
 // validate analyzer is behaving as expected
 
 const elastictest = require('elastictest');
-const schema = require('../schema');
 const config = require('pelias-config').generate();
 
 module.exports.tests = {};
@@ -11,7 +10,7 @@ module.exports.tests = {};
 module.exports.tests.functional = function (test, common) {
   test('functional', function (t) {
 
-    var suite = new elastictest.Suite(common.clientOpts, { schema: schema });
+    var suite = new elastictest.Suite(common.clientOpts, common.create);
     suite.action(function (done) { setTimeout(done, 500); }); // wait for es to bring some shards up
 
     // index a document with all admin values

--- a/integration/run.js
+++ b/integration/run.js
@@ -2,11 +2,16 @@ const _ = require('lodash');
 const tape = require('tape');
 const config = require('pelias-config').generate();
 
+const schema = require('../schema');
+
 const common = {
   clientOpts: {
     host: 'localhost:9200',
     keepAlive: true,
     apiVersion: config.esclient.apiVersion
+  },
+  create: {
+    schema: schema,
   },
   summaryMap: (res) => {
     return res.hits.hits.map(h => {

--- a/integration/source_layer_sourceid_filtering.js
+++ b/integration/source_layer_sourceid_filtering.js
@@ -1,7 +1,6 @@
 // validate analyzer is behaving as expected
 
 const elastictest = require('elastictest');
-const schema = require('../schema');
 const config = require('pelias-config').generate();
 const getTotalHits = require('./_hits_total_helper');
 
@@ -10,7 +9,7 @@ module.exports.tests = {};
 module.exports.tests.source_filter = function(test, common){
   test( 'source filter', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     // index some docs

--- a/integration/validate.js
+++ b/integration/validate.js
@@ -2,14 +2,13 @@
 // your local elasticsearch server, useful to sanity check version upgrades.
 
 const elastictest = require('elastictest');
-const schema = require('../schema');
 
 module.exports.tests = {};
 
 module.exports.tests.validate = function(test, common){
   test( 'schema', t => {
 
-    var suite = new elastictest.Suite( common.clientOpts, { schema: schema } );
+    var suite = new elastictest.Suite( common.clientOpts, common.create );
 
     suite.assert( done => {
       suite.client.info({}, ( err, res, status ) => {


### PR DESCRIPTION
After looking at the changes in https://github.com/pelias/schema/pull/394, I noticed that all the parameters used to create test indices during the integration tests were identical.

Because we will want to make changes to those options as part of our move to support Elasticsearch 7, this PR is a pure refactoring that moves those options to the `common` object passed to each integration test.

This should allow us to make any future changes to index creation options in a single place.