### PR TITLE
chore(CI): Remove old Elasticsearch type support (`doc`) from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ matrix:
   fast_finish: true
 env:
   matrix:
-    - ES_VERSION=6.8.5 ES_TYPE=doc JDK_VERSION=oraclejdk8
-    - ES_VERSION=6.8.5 ES_TYPE=doc JDK_VERSION=oraclejdk11
     - ES_VERSION=6.8.5 ES_TYPE=_doc JDK_VERSION=oraclejdk8
     - ES_VERSION=6.8.5 ES_TYPE=_doc JDK_VERSION=oraclejdk11
 jdk:


### PR DESCRIPTION
This drops support for testing the schema with the Elasticsearch type name set to `doc`. This was only needed to support Elasticsearch 5. In order to support Elasticsearch 7, we'll no longer be supporting ES5.

Connects https://github.com/pelias/pelias/issues/831