### PR TITLE
chore(CI): Add Elasticsearch 7 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,14 @@ node_js:
   - 10
   - 12
 matrix:
+  allow_failures:
+    - env: ES_VERSION=7.5.1 ES_TYPE=_doc JDK_VERSION=oraclejdk11
   fast_finish: true
 env:
   matrix:
     - ES_VERSION=6.8.5 ES_TYPE=_doc JDK_VERSION=oraclejdk8
     - ES_VERSION=6.8.5 ES_TYPE=_doc JDK_VERSION=oraclejdk11
+    - ES_VERSION=7.5.1 ES_TYPE=_doc JDK_VERSION=oraclejdk11
 jdk:
   - oraclejdk8
   - oraclejdk11


### PR DESCRIPTION
This adds Elasticsearch 7.5.1 to the CI test matrix. Until we merge complete support for ES7, this CI run is allowed to fail without failing the entire build.

Connects https://github.com/pelias/pelias/issues/831