### PR TITLE
feat(ES7): Remove type name from mapping configuration

### DIFF
--- a/integration/dynamic_templates.js
+++ b/integration/dynamic_templates.js
@@ -50,10 +50,10 @@ function nameAssertion( analyzer, common ){
 
       suite.client.indices.getMapping({
         index: suite.props.index,
-        type: _type
+        include_type_name: false
       }, (err, res) => {
 
-        const properties = res[suite.props.index].mappings[_type].properties;
+        const properties = res[suite.props.index].mappings.properties;
         t.equal( properties.name.dynamic, 'true' );
 
         const nameProperties = properties.name.properties;
@@ -89,10 +89,10 @@ function phraseAssertion( analyzer, common ){
 
       suite.client.indices.getMapping({
         index: suite.props.index,
-        type: _type
+        include_type_name: false
       }, ( err, res ) => {
 
-        const properties = res[suite.props.index].mappings[_type].properties;
+        const properties = res[suite.props.index].mappings.properties;
         t.equal( properties.phrase.dynamic, 'true' );
 
         const phraseProperties = properties.phrase.properties;
@@ -127,10 +127,10 @@ function addendumAssertion( namespace, value, common ){
     suite.assert( done => {
       suite.client.indices.getMapping({
         index: suite.props.index,
-        type: _type
+        include_type_name: false,
       }, ( err, res ) => {
 
-        const properties = res[suite.props.index].mappings[_type].properties;
+        const properties = res[suite.props.index].mappings.properties;
         t.equal( properties.addendum.dynamic, 'true' );
 
         const addendumProperties = properties.addendum.properties;

--- a/integration/run.js
+++ b/integration/run.js
@@ -12,6 +12,9 @@ const common = {
   },
   create: {
     schema: schema,
+    create: {
+      include_type_name: false
+    }
   },
   summaryMap: (res) => {
     return res.hits.hits.map(h => {

--- a/schema.js
+++ b/schema.js
@@ -1,10 +1,6 @@
-const config = require('pelias-config').generate();
-
 const schema = {
   settings: require('./settings')(),
-  mappings: {
-    [config.schema.typeName]: require('./mappings/document'),
-  }
+  mappings: require('./mappings/document'),
 };
 
 module.exports = schema;

--- a/scripts/create_index.js
+++ b/scripts/create_index.js
@@ -18,7 +18,11 @@ try {
 cli.header("create index");
 
 const indexName = config.schema.indexName;
-const req = { index: indexName, body: schema };
+const req = {
+  index: indexName,
+  body: schema,
+  include_type_name: false
+};
 
 client.indices.create(req, (err, res) => {
   if (err) {

--- a/test/compile.js
+++ b/test/compile.js
@@ -27,9 +27,8 @@ module.exports.tests.compile = function(test, common) {
 // the api codebase against an index without admin data
 module.exports.tests.indices = function(test, common) {
   test('explicitly specify some admin indices and their analyzer', function(t) {
-    const _type = config.schema.typeName;
-    t.equal(typeof schema.mappings[_type], 'object', 'mappings present');
-    t.equal(schema.mappings[_type].dynamic_templates[0].nameGram.mapping.analyzer, 'peliasIndexOneEdgeGram');
+    t.equal(typeof schema.mappings, 'object', 'mappings present');
+    t.equal(schema.mappings.dynamic_templates[0].nameGram.mapping.analyzer, 'peliasIndexOneEdgeGram');
     t.end();
   });
 };
@@ -37,9 +36,8 @@ module.exports.tests.indices = function(test, common) {
 // some 'admin' types allow single edgeNGrams and so have a different dynamic_template
 module.exports.tests.dynamic_templates = function(test, common) {
   test('dynamic_templates: nameGram', function(t) {
-    const _type = config.schema.typeName;
-    t.equal(typeof schema.mappings[_type].dynamic_templates[0].nameGram, 'object', 'nameGram template specified');
-    var template = schema.mappings[_type].dynamic_templates[0].nameGram;
+    t.equal(typeof schema.mappings.dynamic_templates[0].nameGram, 'object', 'nameGram template specified');
+    var template = schema.mappings.dynamic_templates[0].nameGram;
     t.equal(template.path_match, 'name.*');
     t.equal(template.match_mapping_type, 'string');
     t.deepEqual(template.mapping, {
@@ -50,9 +48,8 @@ module.exports.tests.dynamic_templates = function(test, common) {
     t.end();
   });
   test('dynamic_templates: phrase', function (t) {
-    const _type = config.schema.typeName;
-    t.equal(typeof schema.mappings[_type].dynamic_templates[1].phrase, 'object', 'phrase template specified');
-    var template = schema.mappings[_type].dynamic_templates[1].phrase;
+    t.equal(typeof schema.mappings.dynamic_templates[1].phrase, 'object', 'phrase template specified');
+    var template = schema.mappings.dynamic_templates[1].phrase;
     t.equal(template.path_match, 'phrase.*');
     t.equal(template.match_mapping_type, 'string');
     t.deepEqual(template.mapping, {
@@ -63,9 +60,8 @@ module.exports.tests.dynamic_templates = function(test, common) {
     t.end();
   });
   test('dynamic_templates: addendum', function (t) {
-    const _type = config.schema.typeName;
-    t.equal(typeof schema.mappings[_type].dynamic_templates[2].addendum, 'object', 'addendum template specified');
-    var template = schema.mappings[_type].dynamic_templates[2].addendum;
+    t.equal(typeof schema.mappings.dynamic_templates[2].addendum, 'object', 'addendum template specified');
+    var template = schema.mappings.dynamic_templates[2].addendum;
     t.equal(template.path_match, 'addendum.*');
     t.equal(template.match_mapping_type, 'string');
     t.deepEqual(template.mapping, {
@@ -106,16 +102,6 @@ module.exports.tests.current_schema = function(test, common) {
 
     // copy schema
     var schemaCopy = JSON.parse( JSON.stringify( schema ) );
-
-    // the fixture contains a _type named 'doc'.
-    // this code allows the generated schema to match the fixture if the
-    // type name is defined named differently in pelias.json, the rest of
-    // the settings still apply verbatim.
-    const _type = config.schema.typeName;
-    if(_type && _type !== 'doc'){
-      schemaCopy.mappings.doc = schemaCopy.mappings[_type];
-      delete schemaCopy.mappings[_type];
-    }
 
     // use the pelias config fixture instead of the local config
     process.env.PELIAS_CONFIG = path.resolve( __dirname + '/fixtures/config.json' );

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -572,588 +572,586 @@
     }
   },
   "mappings": {
-    "doc": {
-      "properties": {
-        "source": {
-          "type": "keyword"
-        },
-        "layer": {
-          "type": "keyword"
-        },
-        "name": {
-          "type": "object",
-          "dynamic": true
-        },
+    "properties": {
+      "source": {
+        "type": "keyword"
+      },
+      "layer": {
+        "type": "keyword"
+      },
+      "name": {
+        "type": "object",
+        "dynamic": true
+      },
+      "phrase": {
+        "type": "object",
+        "dynamic": true
+      },
+      "address_parts": {
+        "type": "object",
+        "dynamic": "strict",
+        "properties": {
+          "name": {
+            "type": "text",
+            "analyzer": "keyword",
+            "search_analyzer": "keyword"
+          },
+          "unit": {
+            "type": "text",
+            "analyzer": "peliasUnit",
+            "search_analyzer": "peliasUnit"
+          },
+          "number": {
+            "type": "text",
+            "analyzer": "peliasHousenumber",
+            "search_analyzer": "peliasHousenumber"
+          },
+          "street": {
+            "type": "text",
+            "analyzer": "peliasStreet",
+            "search_analyzer": "peliasStreet"
+          },
+          "cross_street": {
+            "type": "text",
+            "analyzer": "peliasStreet",
+            "search_analyzer": "peliasStreet"
+          },
+          "zip": {
+            "type": "text",
+            "analyzer": "peliasZip",
+            "search_analyzer": "peliasZip"
+          }
+        }
+      },
+      "parent": {
+        "type": "object",
+        "dynamic": "strict",
+        "properties": {
+          "continent": {
+            "type": "text",
+            "analyzer": "peliasAdmin",
+            "search_analyzer": "peliasAdmin",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "peliasIndexOneEdgeGram",
+                "search_analyzer": "peliasAdmin",
+                "doc_values": false
+              }
+            }
+          },
+          "continent_a": {
+            "type": "text",
+            "analyzer": "peliasAdmin",
+            "search_analyzer": "peliasAdmin",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "peliasIndexOneEdgeGram",
+                "search_analyzer": "peliasAdmin",
+                "doc_values": false
+              }
+            }
+          },
+          "continent_id": {
+            "type": "keyword",
+            "doc_values": false
+          },
+          "ocean": {
+            "type": "text",
+            "analyzer": "peliasAdmin",
+            "search_analyzer": "peliasAdmin",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "peliasIndexOneEdgeGram",
+                "search_analyzer": "peliasAdmin",
+                "doc_values": false
+              }
+            }
+          },
+          "ocean_a": {
+            "type": "text",
+            "analyzer": "peliasAdmin",
+            "search_analyzer": "peliasAdmin",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "peliasIndexOneEdgeGram",
+                "search_analyzer": "peliasAdmin",
+                "doc_values": false
+              }
+            }
+          },
+          "ocean_id": {
+            "type": "keyword",
+            "doc_values": false
+          },
+          "empire": {
+            "type": "text",
+            "analyzer": "peliasAdmin",
+            "search_analyzer": "peliasAdmin",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "peliasIndexOneEdgeGram",
+                "search_analyzer": "peliasAdmin",
+                "doc_values": false
+              }
+            }
+          },
+          "empire_a": {
+            "type": "text",
+            "analyzer": "peliasAdmin",
+            "search_analyzer": "peliasAdmin",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "peliasIndexOneEdgeGram",
+                "search_analyzer": "peliasAdmin",
+                "doc_values": false
+              }
+            }
+          },
+          "empire_id": {
+            "type": "keyword",
+            "doc_values": false
+          },
+          "country": {
+            "type": "text",
+            "analyzer": "peliasAdmin",
+            "search_analyzer": "peliasAdmin",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "peliasIndexOneEdgeGram",
+                "search_analyzer": "peliasAdmin",
+                "doc_values": false
+              }
+            }
+          },
+          "country_a": {
+            "type": "text",
+            "analyzer": "peliasAdmin",
+            "search_analyzer": "peliasAdmin",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "peliasIndexOneEdgeGram",
+                "search_analyzer": "peliasAdmin",
+                "doc_values": false
+              }
+            }
+          },
+          "country_id": {
+            "type": "keyword",
+            "doc_values": false
+          },
+          "dependency": {
+            "type": "text",
+            "analyzer": "peliasAdmin",
+            "search_analyzer": "peliasAdmin",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "peliasIndexOneEdgeGram",
+                "search_analyzer": "peliasAdmin",
+                "doc_values": false
+              }
+            }
+          },
+          "dependency_a": {
+            "type": "text",
+            "analyzer": "peliasAdmin",
+            "search_analyzer": "peliasAdmin",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "peliasIndexOneEdgeGram",
+                "search_analyzer": "peliasAdmin",
+                "doc_values": false
+              }
+            }
+          },
+          "dependency_id": {
+            "type": "keyword",
+            "doc_values": false
+          },
+          "marinearea": {
+            "type": "text",
+            "analyzer": "peliasAdmin",
+            "search_analyzer": "peliasAdmin",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "peliasIndexOneEdgeGram",
+                "search_analyzer": "peliasAdmin",
+                "doc_values": false
+              }
+            }
+          },
+          "marinearea_a": {
+            "type": "text",
+            "analyzer": "peliasAdmin",
+            "search_analyzer": "peliasAdmin",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "peliasIndexOneEdgeGram",
+                "search_analyzer": "peliasAdmin",
+                "doc_values": false
+              }
+            }
+          },
+          "marinearea_id": {
+            "type": "keyword",
+            "doc_values": false
+          },
+          "macroregion": {
+            "type": "text",
+            "analyzer": "peliasAdmin",
+            "search_analyzer": "peliasAdmin",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "peliasIndexOneEdgeGram",
+                "search_analyzer": "peliasAdmin",
+                "doc_values": false
+              }
+            }
+          },
+          "macroregion_a": {
+            "type": "text",
+            "analyzer": "peliasAdmin",
+            "search_analyzer": "peliasAdmin",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "peliasIndexOneEdgeGram",
+                "search_analyzer": "peliasAdmin",
+                "doc_values": false
+              }
+            }
+          },
+          "macroregion_id": {
+            "type": "keyword",
+            "doc_values": false
+          },
+          "region": {
+            "type": "text",
+            "analyzer": "peliasAdmin",
+            "search_analyzer": "peliasAdmin",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "peliasIndexOneEdgeGram",
+                "search_analyzer": "peliasAdmin",
+                "doc_values": false
+              }
+            }
+          },
+          "region_a": {
+            "type": "text",
+            "analyzer": "peliasAdmin",
+            "search_analyzer": "peliasAdmin",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "peliasIndexOneEdgeGram",
+                "search_analyzer": "peliasAdmin",
+                "doc_values": false
+              }
+            }
+          },
+          "region_id": {
+            "type": "keyword",
+            "doc_values": false
+          },
+          "macrocounty": {
+            "type": "text",
+            "analyzer": "peliasAdmin",
+            "search_analyzer": "peliasAdmin",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "peliasIndexOneEdgeGram",
+                "search_analyzer": "peliasAdmin",
+                "doc_values": false
+              }
+            }
+          },
+          "macrocounty_a": {
+            "type": "text",
+            "analyzer": "peliasAdmin",
+            "search_analyzer": "peliasAdmin",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "peliasIndexOneEdgeGram",
+                "search_analyzer": "peliasAdmin",
+                "doc_values": false
+              }
+            }
+          },
+          "macrocounty_id": {
+            "type": "keyword",
+            "doc_values": false
+          },
+          "county": {
+            "type": "text",
+            "analyzer": "peliasAdmin",
+            "search_analyzer": "peliasAdmin",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "peliasIndexOneEdgeGram",
+                "search_analyzer": "peliasAdmin",
+                "doc_values": false
+              }
+            }
+          },
+          "county_a": {
+            "type": "text",
+            "analyzer": "peliasAdmin",
+            "search_analyzer": "peliasAdmin",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "peliasIndexOneEdgeGram",
+                "search_analyzer": "peliasAdmin",
+                "doc_values": false
+              }
+            }
+          },
+          "county_id": {
+            "type": "keyword",
+            "doc_values": false
+          },
+          "locality": {
+            "type": "text",
+            "analyzer": "peliasAdmin",
+            "search_analyzer": "peliasAdmin",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "peliasIndexOneEdgeGram",
+                "search_analyzer": "peliasAdmin",
+                "doc_values": false
+              }
+            }
+          },
+          "locality_a": {
+            "type": "text",
+            "analyzer": "peliasAdmin",
+            "search_analyzer": "peliasAdmin",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "peliasIndexOneEdgeGram",
+                "search_analyzer": "peliasAdmin",
+                "doc_values": false
+              }
+            }
+          },
+          "locality_id": {
+            "type": "keyword",
+            "doc_values": false
+          },
+          "borough": {
+            "type": "text",
+            "analyzer": "peliasAdmin",
+            "search_analyzer": "peliasAdmin",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "peliasIndexOneEdgeGram",
+                "search_analyzer": "peliasAdmin",
+                "doc_values": false
+              }
+            }
+          },
+          "borough_a": {
+            "type": "text",
+            "analyzer": "peliasAdmin",
+            "search_analyzer": "peliasAdmin",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "peliasIndexOneEdgeGram",
+                "search_analyzer": "peliasAdmin",
+                "doc_values": false
+              }
+            }
+          },
+          "borough_id": {
+            "type": "keyword",
+            "doc_values": false
+          },
+          "localadmin": {
+            "type": "text",
+            "analyzer": "peliasAdmin",
+            "search_analyzer": "peliasAdmin",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "peliasIndexOneEdgeGram",
+                "search_analyzer": "peliasAdmin",
+                "doc_values": false
+              }
+            }
+          },
+          "localadmin_a": {
+            "type": "text",
+            "analyzer": "peliasAdmin",
+            "search_analyzer": "peliasAdmin",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "peliasIndexOneEdgeGram",
+                "search_analyzer": "peliasAdmin",
+                "doc_values": false
+              }
+            }
+          },
+          "localadmin_id": {
+            "type": "keyword",
+            "doc_values": false
+          },
+          "neighbourhood": {
+            "type": "text",
+            "analyzer": "peliasAdmin",
+            "search_analyzer": "peliasAdmin",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "peliasIndexOneEdgeGram",
+                "search_analyzer": "peliasAdmin",
+                "doc_values": false
+              }
+            }
+          },
+          "neighbourhood_a": {
+            "type": "text",
+            "analyzer": "peliasAdmin",
+            "search_analyzer": "peliasAdmin",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "peliasIndexOneEdgeGram",
+                "search_analyzer": "peliasAdmin",
+                "doc_values": false
+              }
+            }
+          },
+          "neighbourhood_id": {
+            "type": "keyword",
+            "doc_values": false
+          },
+          "postalcode": {
+            "type": "text",
+            "analyzer": "peliasZip",
+            "search_analyzer": "peliasZip",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "peliasIndexOneEdgeGram",
+                "search_analyzer": "peliasZip"
+              }
+            }
+          },
+          "postalcode_a": {
+            "type": "text",
+            "analyzer": "peliasZip",
+            "search_analyzer": "peliasZip",
+            "fields": {
+              "ngram": {
+                "type": "text",
+                "analyzer": "peliasIndexOneEdgeGram",
+                "search_analyzer": "peliasZip"
+              }
+            }
+          },
+          "postalcode_id": {
+            "type": "keyword",
+            "doc_values": false
+          }
+        }
+      },
+      "center_point": {
+        "type": "geo_point"
+      },
+      "shape": {
+        "type": "geo_shape"
+      },
+      "bounding_box": {
+        "type": "keyword",
+        "index": false
+      },
+      "source_id": {
+        "type": "keyword",
+        "doc_values": false
+      },
+      "category": {
+        "type": "keyword",
+        "doc_values": false
+      },
+      "population": {
+        "type": "long",
+        "null_value": 0
+      },
+      "popularity": {
+        "type": "long",
+        "null_value": 0
+      },
+      "addendum": {
+        "type": "object",
+        "dynamic": true
+      }
+    },
+    "dynamic_templates": [
+      {
+        "nameGram": {
+          "path_match": "name.*",
+          "match_mapping_type": "string",
+          "mapping": {
+            "type": "text",
+            "analyzer": "peliasIndexOneEdgeGram",
+            "search_analyzer": "peliasQuery"
+          }
+        }
+      },
+      {
         "phrase": {
-          "type": "object",
-          "dynamic": true
-        },
-        "address_parts": {
-          "type": "object",
-          "dynamic": "strict",
-          "properties": {
-            "name": {
-              "type": "text",
-              "analyzer": "keyword",
-              "search_analyzer": "keyword"
-            },
-            "unit": {
-              "type": "text",
-              "analyzer": "peliasUnit",
-              "search_analyzer": "peliasUnit"
-            },
-            "number": {
-              "type": "text",
-              "analyzer": "peliasHousenumber",
-              "search_analyzer": "peliasHousenumber"
-            },
-            "street": {
-              "type": "text",
-              "analyzer": "peliasStreet",
-              "search_analyzer": "peliasStreet"
-            },
-            "cross_street": {
-              "type": "text",
-              "analyzer": "peliasStreet",
-              "search_analyzer": "peliasStreet"
-            },
-            "zip": {
-              "type": "text",
-              "analyzer": "peliasZip",
-              "search_analyzer": "peliasZip"
-            }
+          "path_match": "phrase.*",
+          "match_mapping_type": "string",
+          "mapping": {
+            "type": "text",
+            "analyzer": "peliasPhrase",
+            "search_analyzer": "peliasQuery"
           }
-        },
-        "parent": {
-          "type": "object",
-          "dynamic": "strict",
-          "properties": {
-            "continent": {
-              "type": "text",
-              "analyzer": "peliasAdmin",
-              "search_analyzer": "peliasAdmin",
-              "fields": {
-                "ngram": {
-                  "type": "text",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "search_analyzer": "peliasAdmin",
-                  "doc_values": false
-                }
-              }
-            },
-            "continent_a": {
-              "type": "text",
-              "analyzer": "peliasAdmin",
-              "search_analyzer": "peliasAdmin",
-              "fields": {
-                "ngram": {
-                  "type": "text",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "search_analyzer": "peliasAdmin",
-                  "doc_values": false
-                }
-              }
-            },
-            "continent_id": {
-              "type": "keyword",
-              "doc_values": false
-            },
-            "ocean": {
-              "type": "text",
-              "analyzer": "peliasAdmin",
-              "search_analyzer": "peliasAdmin",
-              "fields": {
-                "ngram": {
-                  "type": "text",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "search_analyzer": "peliasAdmin",
-                  "doc_values": false
-                }
-              }
-            },
-            "ocean_a": {
-              "type": "text",
-              "analyzer": "peliasAdmin",
-              "search_analyzer": "peliasAdmin",
-              "fields": {
-                "ngram": {
-                  "type": "text",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "search_analyzer": "peliasAdmin",
-                  "doc_values": false
-                }
-              }
-            },
-            "ocean_id": {
-              "type": "keyword",
-              "doc_values": false
-            },
-            "empire": {
-              "type": "text",
-              "analyzer": "peliasAdmin",
-              "search_analyzer": "peliasAdmin",
-              "fields": {
-                "ngram": {
-                  "type": "text",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "search_analyzer": "peliasAdmin",
-                  "doc_values": false
-                }
-              }
-            },
-            "empire_a": {
-              "type": "text",
-              "analyzer": "peliasAdmin",
-              "search_analyzer": "peliasAdmin",
-              "fields": {
-                "ngram": {
-                  "type": "text",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "search_analyzer": "peliasAdmin",
-                  "doc_values": false
-                }
-              }
-            },
-            "empire_id": {
-              "type": "keyword",
-              "doc_values": false
-            },
-            "country": {
-              "type": "text",
-              "analyzer": "peliasAdmin",
-              "search_analyzer": "peliasAdmin",
-              "fields": {
-                "ngram": {
-                  "type": "text",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "search_analyzer": "peliasAdmin",
-                  "doc_values": false
-                }
-              }
-            },
-            "country_a": {
-              "type": "text",
-              "analyzer": "peliasAdmin",
-              "search_analyzer": "peliasAdmin",
-              "fields": {
-                "ngram": {
-                  "type": "text",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "search_analyzer": "peliasAdmin",
-                  "doc_values": false
-                }
-              }
-            },
-            "country_id": {
-              "type": "keyword",
-              "doc_values": false
-            },
-            "dependency": {
-              "type": "text",
-              "analyzer": "peliasAdmin",
-              "search_analyzer": "peliasAdmin",
-              "fields": {
-                "ngram": {
-                  "type": "text",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "search_analyzer": "peliasAdmin",
-                  "doc_values": false
-                }
-              }
-            },
-            "dependency_a": {
-              "type": "text",
-              "analyzer": "peliasAdmin",
-              "search_analyzer": "peliasAdmin",
-              "fields": {
-                "ngram": {
-                  "type": "text",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "search_analyzer": "peliasAdmin",
-                  "doc_values": false
-                }
-              }
-            },
-            "dependency_id": {
-              "type": "keyword",
-              "doc_values": false
-            },
-            "marinearea": {
-              "type": "text",
-              "analyzer": "peliasAdmin",
-              "search_analyzer": "peliasAdmin",
-              "fields": {
-                "ngram": {
-                  "type": "text",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "search_analyzer": "peliasAdmin",
-                  "doc_values": false
-                }
-              }
-            },
-            "marinearea_a": {
-              "type": "text",
-              "analyzer": "peliasAdmin",
-              "search_analyzer": "peliasAdmin",
-              "fields": {
-                "ngram": {
-                  "type": "text",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "search_analyzer": "peliasAdmin",
-                  "doc_values": false
-                }
-              }
-            },
-            "marinearea_id": {
-              "type": "keyword",
-              "doc_values": false
-            },
-            "macroregion": {
-              "type": "text",
-              "analyzer": "peliasAdmin",
-              "search_analyzer": "peliasAdmin",
-              "fields": {
-                "ngram": {
-                  "type": "text",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "search_analyzer": "peliasAdmin",
-                  "doc_values": false
-                }
-              }
-            },
-            "macroregion_a": {
-              "type": "text",
-              "analyzer": "peliasAdmin",
-              "search_analyzer": "peliasAdmin",
-              "fields": {
-                "ngram": {
-                  "type": "text",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "search_analyzer": "peliasAdmin",
-                  "doc_values": false
-                }
-              }
-            },
-            "macroregion_id": {
-              "type": "keyword",
-              "doc_values": false
-            },
-            "region": {
-              "type": "text",
-              "analyzer": "peliasAdmin",
-              "search_analyzer": "peliasAdmin",
-              "fields": {
-                "ngram": {
-                  "type": "text",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "search_analyzer": "peliasAdmin",
-                  "doc_values": false
-                }
-              }
-            },
-            "region_a": {
-              "type": "text",
-              "analyzer": "peliasAdmin",
-              "search_analyzer": "peliasAdmin",
-              "fields": {
-                "ngram": {
-                  "type": "text",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "search_analyzer": "peliasAdmin",
-                  "doc_values": false
-                }
-              }
-            },
-            "region_id": {
-              "type": "keyword",
-              "doc_values": false
-            },
-            "macrocounty": {
-              "type": "text",
-              "analyzer": "peliasAdmin",
-              "search_analyzer": "peliasAdmin",
-              "fields": {
-                "ngram": {
-                  "type": "text",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "search_analyzer": "peliasAdmin",
-                  "doc_values": false
-                }
-              }
-            },
-            "macrocounty_a": {
-              "type": "text",
-              "analyzer": "peliasAdmin",
-              "search_analyzer": "peliasAdmin",
-              "fields": {
-                "ngram": {
-                  "type": "text",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "search_analyzer": "peliasAdmin",
-                  "doc_values": false
-                }
-              }
-            },
-            "macrocounty_id": {
-              "type": "keyword",
-              "doc_values": false
-            },
-            "county": {
-              "type": "text",
-              "analyzer": "peliasAdmin",
-              "search_analyzer": "peliasAdmin",
-              "fields": {
-                "ngram": {
-                  "type": "text",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "search_analyzer": "peliasAdmin",
-                  "doc_values": false
-                }
-              }
-            },
-            "county_a": {
-              "type": "text",
-              "analyzer": "peliasAdmin",
-              "search_analyzer": "peliasAdmin",
-              "fields": {
-                "ngram": {
-                  "type": "text",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "search_analyzer": "peliasAdmin",
-                  "doc_values": false
-                }
-              }
-            },
-            "county_id": {
-              "type": "keyword",
-              "doc_values": false
-            },
-            "locality": {
-              "type": "text",
-              "analyzer": "peliasAdmin",
-              "search_analyzer": "peliasAdmin",
-              "fields": {
-                "ngram": {
-                  "type": "text",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "search_analyzer": "peliasAdmin",
-                  "doc_values": false
-                }
-              }
-            },
-            "locality_a": {
-              "type": "text",
-              "analyzer": "peliasAdmin",
-              "search_analyzer": "peliasAdmin",
-              "fields": {
-                "ngram": {
-                  "type": "text",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "search_analyzer": "peliasAdmin",
-                  "doc_values": false
-                }
-              }
-            },
-            "locality_id": {
-              "type": "keyword",
-              "doc_values": false
-            },
-            "borough": {
-              "type": "text",
-              "analyzer": "peliasAdmin",
-              "search_analyzer": "peliasAdmin",
-              "fields": {
-                "ngram": {
-                  "type": "text",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "search_analyzer": "peliasAdmin",
-                  "doc_values": false
-                }
-              }
-            },
-            "borough_a": {
-              "type": "text",
-              "analyzer": "peliasAdmin",
-              "search_analyzer": "peliasAdmin",
-              "fields": {
-                "ngram": {
-                  "type": "text",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "search_analyzer": "peliasAdmin",
-                  "doc_values": false
-                }
-              }
-            },
-            "borough_id": {
-              "type": "keyword",
-              "doc_values": false
-            },
-            "localadmin": {
-              "type": "text",
-              "analyzer": "peliasAdmin",
-              "search_analyzer": "peliasAdmin",
-              "fields": {
-                "ngram": {
-                  "type": "text",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "search_analyzer": "peliasAdmin",
-                  "doc_values": false
-                }
-              }
-            },
-            "localadmin_a": {
-              "type": "text",
-              "analyzer": "peliasAdmin",
-              "search_analyzer": "peliasAdmin",
-              "fields": {
-                "ngram": {
-                  "type": "text",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "search_analyzer": "peliasAdmin",
-                  "doc_values": false
-                }
-              }
-            },
-            "localadmin_id": {
-              "type": "keyword",
-              "doc_values": false
-            },
-            "neighbourhood": {
-              "type": "text",
-              "analyzer": "peliasAdmin",
-              "search_analyzer": "peliasAdmin",
-              "fields": {
-                "ngram": {
-                  "type": "text",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "search_analyzer": "peliasAdmin",
-                  "doc_values": false
-                }
-              }
-            },
-            "neighbourhood_a": {
-              "type": "text",
-              "analyzer": "peliasAdmin",
-              "search_analyzer": "peliasAdmin",
-              "fields": {
-                "ngram": {
-                  "type": "text",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "search_analyzer": "peliasAdmin",
-                  "doc_values": false
-                }
-              }
-            },
-            "neighbourhood_id": {
-              "type": "keyword",
-              "doc_values": false
-            },
-            "postalcode": {
-              "type": "text",
-              "analyzer": "peliasZip",
-              "search_analyzer": "peliasZip",
-              "fields": {
-                "ngram": {
-                  "type": "text",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "search_analyzer": "peliasZip"
-                }
-              }
-            },
-            "postalcode_a": {
-              "type": "text",
-              "analyzer": "peliasZip",
-              "search_analyzer": "peliasZip",
-              "fields": {
-                "ngram": {
-                  "type": "text",
-                  "analyzer": "peliasIndexOneEdgeGram",
-                  "search_analyzer": "peliasZip"
-                }
-              }
-            },
-            "postalcode_id": {
-              "type": "keyword",
-              "doc_values": false
-            }
-          }
-        },
-        "center_point": {
-          "type": "geo_point"
-        },
-        "shape": {
-          "type": "geo_shape"
-        },
-        "bounding_box": {
-          "type": "keyword",
-          "index": false
-        },
-        "source_id": {
-          "type": "keyword",
-          "doc_values": false
-        },
-        "category": {
-          "type": "keyword",
-          "doc_values": false
-        },
-        "population": {
-          "type": "long",
-          "null_value": 0
-        },
-        "popularity": {
-          "type": "long",
-          "null_value": 0
-        },
+        }
+      },
+      {
         "addendum": {
-          "type": "object",
-          "dynamic": true
-        }
-      },
-      "dynamic_templates": [
-        {
-          "nameGram": {
-            "path_match": "name.*",
-            "match_mapping_type": "string",
-            "mapping": {
-              "type": "text",
-              "analyzer": "peliasIndexOneEdgeGram",
-              "search_analyzer": "peliasQuery"
-            }
-          }
-        },
-        {
-          "phrase": {
-            "path_match": "phrase.*",
-            "match_mapping_type": "string",
-            "mapping": {
-              "type": "text",
-              "analyzer": "peliasPhrase",
-              "search_analyzer": "peliasQuery"
-            }
-          }
-        },
-        {
-          "addendum": {
-            "path_match": "addendum.*",
-            "match_mapping_type": "string",
-            "mapping": {
-              "type": "keyword",
-              "index": false,
-              "doc_values": false
-            }
+          "path_match": "addendum.*",
+          "match_mapping_type": "string",
+          "mapping": {
+            "type": "keyword",
+            "index": false,
+            "doc_values": false
           }
         }
-      ],
-      "_source": {
-        "excludes": [
-          "shape",
-          "phrase"
-        ]
-      },
-      "_all": {
-        "enabled": false
-      },
-      "dynamic": "strict"
-    }
+      }
+    ],
+    "_source": {
+      "excludes": [
+        "shape",
+        "phrase"
+      ]
+    },
+    "_all": {
+      "enabled": false
+    },
+    "dynamic": "strict"
   }
 }


### PR DESCRIPTION
In ES7, specifying a mapping type name when defining index will no longer be allowed by default. ES6 can emulate this behavior by setting the `include_type_name` parameter to `false` when creating and fetching mappings.

This PR sets that parameter so that our mapping format uses the ES7 preferred format, while still maintaining compatibility with ES6.

In the future, when we wish to drop support for ES6, we'll only have to stop using the `include_type_name` configuration option.

Connects https://github.com/pelias/pelias/issues/831