### PR TITLE
feat(es7): remove _all mapping

### DIFF
--- a/mappings/document.js
+++ b/mappings/document.js
@@ -186,9 +186,6 @@ var schema = {
   _source: {
     excludes : ['shape','phrase']
   },
-  _all: {
-    enabled: false
-  },
   dynamic: 'strict'
 };
 

--- a/test/document.js
+++ b/test/document.js
@@ -185,7 +185,7 @@ module.exports.tests.dynamic_templates = function(test, common) {
 // _all should be disabled
 module.exports.tests.all_disabled = function(test, common) {
   test('_all disabled', function(t) {
-    t.equal(schema._all.enabled, false, '_all disabled');
+    t.false(schema._all, '_all undefined');
     t.end();
   });
 };

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -1149,9 +1149,6 @@
         "phrase"
       ]
     },
-    "_all": {
-      "enabled": false
-    },
     "dynamic": "strict"
   }
 }


### PR DESCRIPTION
The `_all` field was deprecated in Elasticsearch 6 and completely removed in [Elasticsearch 7](https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html#all-meta-field-removed).

Pelias has disabled this field for quite some time, however now that we have dropped support for ES5, we can remove this configuration option.

This happens to be the final change required to add support for ES7! :tada: 

Connects https://github.com/pelias/pelias/issues/831