### PR TITLE
chore(CI): remove oraclejdk8 from test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,9 @@ node_js:
   - 12
 env:
   matrix:
-    - ES_VERSION=6.8.6 JDK_VERSION=oraclejdk8
     - ES_VERSION=6.8.6 JDK_VERSION=oraclejdk11
     - ES_VERSION=7.6.1 JDK_VERSION=oraclejdk11
 jdk:
-  - oraclejdk8
   - oraclejdk11
 install:
   - ./scripts/setup_ci.sh


### PR DESCRIPTION
_Extracted from https://github.com/pelias/schema/pull/394_

As Elasticsearch 7 will come with JDK 11 out of the box, we will eventually not care about JDK 8 support.

Once we are ready to drop that support, we can merge this PR.