### PR TITLE
chore(tests): Require ES7 tests to pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ node_js:
   - 10
   - 12
 matrix:
-  allow_failures:
-    - env: ES_VERSION=7.5.1 ES_TYPE=_doc JDK_VERSION=oraclejdk11
   fast_finish: true
 env:
   matrix:


### PR DESCRIPTION
Quickly following up from https://github.com/pelias/schema/pull/422, this requires the Elasticsearch 7 tests to pass, now that we have merged all changes required to add Elasticsearch 7 support.

Connects https://github.com/pelias/pelias/issues/831