### PR TITLE
add check_version.js script

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "elasticsearch": "^16.0.0",
     "lodash": "^4.17.15",
     "pelias-config": "^4.5.0",
-    "pelias-logger": "^1.3.0"
+    "pelias-logger": "^1.3.0",
+    "semver": "^7.1.1"
   },
   "devDependencies": {
     "difflet": "^1.0.1",

--- a/scripts/check_plugins.js
+++ b/scripts/check_plugins.js
@@ -5,14 +5,10 @@ const client = new es.Client(config.esclient);
 const cli = require('./cli');
 
 // mandatory plugins
-const plugins = [ 'analysis-icu' ];
+const required = ['analysis-icu'];
 
 // list of failures
 let failures = [];
-
-// helper strings for output
-const success = colors.green('✔');
-const failure = colors.red('✖');
 
 // returns the appropriate plugin name for the configured Elasticsearch version
 function elasticsearchPluginUtility() {
@@ -24,7 +20,7 @@ function elasticsearchPluginUtility() {
 }
 
 cli.header("checking elasticsearch plugins");
-client.nodes.info( null, function( err, res ){
+client.nodes.info(null, (err, res) => {
 
   if( err ){
     console.error(err);
@@ -52,16 +48,14 @@ client.nodes.info( null, function( err, res ){
     // per node failures
     let node_failures = [];
 
-    // iterate over all installed plugins on this node
-    plugins.forEach( function( plugin ){
+    // iterate over all required plugins
+    required.forEach(plugin => {
 
       // bool, is the plugin currently installed?
-      const isInstalled = !!node.plugins.filter( function( installedPlugin ){
-        return installedPlugin.name == plugin;
-      }).length;
+      const isInstalled = node.plugins.some(installed => installed.name === plugin);
 
       // output status to terminal
-      console.log( ` checking plugin '${plugin}': ${isInstalled ? success : failure}` );
+      console.log( ` checking plugin '${plugin}': ${isInstalled ? cli.status.success : cli.status.failure}` );
 
       // record this plugin as not installed yet
       if( !isInstalled ){
@@ -79,9 +73,9 @@ client.nodes.info( null, function( err, res ){
   if( failures.length ){
     console.error( colors.red(`${failures.length} required plugin(s) are not installed on the node(s) shown above.` ) );
     console.error( "you must install the plugins before continuing with the installation.");
-    failures.forEach( function( failure ){
+    failures.forEach(failure => {
       console.error( `\nyou can install the missing packages on '${failure.node.name}' [${failure.node.ip}] with the following command(s):\n` );
-      failure.plugins.forEach( function( plugin ){
+      failure.plugins.forEach(plugin => {
         console.error( colors.green( `sudo ${failure.node.settings.path.home}/bin/${elasticsearchPluginUtility()} install ${plugin}`) );
       });
     });

--- a/scripts/check_plugins.js
+++ b/scripts/check_plugins.js
@@ -3,7 +3,6 @@ const config = require('pelias-config').generate();
 const es = require('elasticsearch');
 const client = new es.Client(config.esclient);
 const cli = require('./cli');
-const schema = require('../schema');
 
 // mandatory plugins
 const plugins = [ 'analysis-icu' ];

--- a/scripts/check_version.js
+++ b/scripts/check_version.js
@@ -1,0 +1,38 @@
+const _ = require('lodash');
+const semver = require('semver');
+const es = require('elasticsearch');
+const colors = require('colors/safe');
+const config = require('pelias-config').generate();
+const client = new es.Client(config.esclient);
+const cli = require('./cli');
+
+// helper strings for output
+const success = colors.green('✔');
+const failure = colors.red('✖');
+
+// pass target elastic version semver as the first CLI arg
+const targetVersion = process.argv[2];
+if(!targetVersion){
+  console.error('you must pass a target elasticsearch version semver as the first argument');
+  process.exit(1);
+}
+
+cli.header(`checking elasticsearch server version matches "${targetVersion}"`);
+client.info(null, (err, res) => {
+
+  if (err) {
+    console.error(err);
+    process.exit(1);
+  }
+
+  let version = _.get(res, 'version.number', '0.0.0');
+
+  // pretty print error message
+  if (!semver.satisfies(version, targetVersion)) {
+    console.log(`${failure} ${version}\n`);
+    process.exit(1)
+  }
+
+  console.log(`${success} ${version}\n`);
+  console.log();
+});

--- a/scripts/check_version.js
+++ b/scripts/check_version.js
@@ -1,14 +1,9 @@
 const _ = require('lodash');
 const semver = require('semver');
 const es = require('elasticsearch');
-const colors = require('colors/safe');
 const config = require('pelias-config').generate();
 const client = new es.Client(config.esclient);
 const cli = require('./cli');
-
-// helper strings for output
-const success = colors.green('✔');
-const failure = colors.red('✖');
 
 // pass target elastic version semver as the first CLI arg
 const targetVersion = process.argv[2];
@@ -25,14 +20,14 @@ client.info(null, (err, res) => {
     process.exit(1);
   }
 
-  let version = _.get(res, 'version.number', '0.0.0');
+  const version = _.get(res, 'version.number', '0.0.0');
 
   // pretty print error message
   if (!semver.satisfies(version, targetVersion)) {
-    console.log(`${failure} ${version}\n`);
+    console.log(`${cli.status.failure} ${version}\n`);
     process.exit(1)
   }
 
-  console.log(`${success} ${version}\n`);
+  console.log(`${cli.status.success} ${version}\n`);
   console.log();
 });

--- a/scripts/cli.js
+++ b/scripts/cli.js
@@ -1,7 +1,13 @@
 
-var util = require('util');
+const util = require('util');
+const colors = require('colors/safe');
 
 module.exports.header = function( text ){
   var rule = new Array( text.length + 3 ).join("-");
   console.log( util.format("\n\033[0;33m%s\n %s \n%s\033[0m\n", rule, text, rule ) );
+}
+
+module.exports.status = {
+  success: colors.green('✔'),
+  failure: colors.red('✖')
 }

--- a/scripts/create_index.js
+++ b/scripts/create_index.js
@@ -1,11 +1,22 @@
 const child_process = require('child_process');
 const config = require('pelias-config').generate();
 const es = require('elasticsearch');
+const SUPPORTED_ES_VERSIONS = '>=6.8.5 || >=7.5.1';
 
 const cli = require('./cli');
 const schema = require('../schema');
 
+cli.header("create index");
+
 const client = new es.Client(config.esclient);
+
+// check minimum elasticsearch versions before continuing
+try {
+  child_process.execSync(`node ${__dirname}/check_version.js "${SUPPORTED_ES_VERSIONS}"`);
+} catch (e) {
+  console.error(`unsupported elasticsearch version. try: ${SUPPORTED_ES_VERSIONS}\n`);
+  process.exit(1);
+}
 
 // check mandatory plugins are installed before continuing
 try {
@@ -14,8 +25,6 @@ try {
   console.error("please install mandatory plugins before continuing.\n");
   process.exit(1);
 }
-
-cli.header("create index");
 
 const indexName = config.schema.indexName;
 const req = {

--- a/scripts/create_index.js
+++ b/scripts/create_index.js
@@ -1,7 +1,7 @@
 const child_process = require('child_process');
 const config = require('pelias-config').generate();
 const es = require('elasticsearch');
-const SUPPORTED_ES_VERSIONS = '>=6.8.5 || >=7.5.1';
+const SUPPORTED_ES_VERSIONS = '>=6.5.4 || >=7.4.2';
 
 const cli = require('./cli');
 const schema = require('../schema');


### PR DESCRIPTION
this PR adds a new script which checks the ES version of the server before attempting to create the schema.
it provides a more user-friendly error when encountering an unsupported version:

<img width="506" alt="Screenshot 2020-01-10 at 11 56 47" src="https://user-images.githubusercontent.com/738069/72148290-b1438e80-33a0-11ea-8afa-78e349f7f916.png">

inspired by https://github.com/pelias/schema/issues/428