### PR TITLE
chore(CI): Remove ES_TYPE var

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ matrix:
   fast_finish: true
 env:
   matrix:
-    - ES_VERSION=6.8.5 ES_TYPE=_doc JDK_VERSION=oraclejdk8
-    - ES_VERSION=6.8.5 ES_TYPE=_doc JDK_VERSION=oraclejdk11
-    - ES_VERSION=7.5.1 ES_TYPE=_doc JDK_VERSION=oraclejdk11
+    - ES_VERSION=6.8.5 JDK_VERSION=oraclejdk8
+    - ES_VERSION=6.8.5 JDK_VERSION=oraclejdk11
+    - ES_VERSION=7.5.1 JDK_VERSION=oraclejdk11
 jdk:
   - oraclejdk8
   - oraclejdk11

--- a/scripts/setup_ci.sh
+++ b/scripts/setup_ci.sh
@@ -59,13 +59,9 @@ v=( ${ES_VERSION//./ } ) # split version number on '.'
 PELIAS_CONFIG=$(
   jq -n \
     --arg apiVersion "${v[0]}.${v[1]}" \
-    --arg typeName "${ES_TYPE}" \
     '{
       esclient: {
         apiVersion: $apiVersion
-      },
-      schema: {
-        typeName: $typeName
       }
     } | del(.. | select(. == ""))'
 );


### PR DESCRIPTION
Now that we have dropped support for Elasticsearch 5 and the `doc` type, we can remove this CI configuration variable as well.