### PR TITLE
chore(CI): Remove logic to handle Elasticsearch 2.4 downloads

### DIFF
--- a/scripts/setup_ci.sh
+++ b/scripts/setup_ci.sh
@@ -8,44 +8,29 @@ mkdir /tmp/elasticsearch
 curl -s https://raw.githubusercontent.com/michaelklishin/jdk_switcher/master/jdk_switcher.sh | bash -s use "${JDK_VERSION}"
 
 # download and install elasticsearch with ICU plugin
-# note: the download servers and plugin install binary changed between versions
+FILENAME="elasticsearch-${ES_VERSION}-linux-x86_64.tar.gz"
+STRIP_COMPONENTS=1
 
-if [[ "${ES_VERSION}" == "2.4"* ]]; then
-
-  # download from legacy host
-  wget -O - https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/${ES_VERSION}/elasticsearch-${ES_VERSION}.tar.gz \
-    | tar xz --directory=/tmp/elasticsearch --strip-components=1
-
-  # install ICU plugin
-  /tmp/elasticsearch/bin/plugin install analysis-icu
-
-  # start elasticsearch server
-  /tmp/elasticsearch/bin/elasticsearch --daemonize --path.data /tmp
-else
-  FILENAME="elasticsearch-${ES_VERSION}-linux-x86_64.tar.gz"
-  STRIP_COMPONENTS=1
-
-  # prior to ES7 the architecture was not included in the filename
-  if [[ "${ES_VERSION}" == "5"* || "${ES_VERSION}" == "6"* ]]; then
-    FILENAME="elasticsearch-${ES_VERSION}.tar.gz"
-  fi
-
-  # the 6.8.5 release is inconsisent with the others
-  # https://github.com/elastic/elasticsearch/issues/49599
-  if [[ "${ES_VERSION}" == "6.8.5" ]]; then
-    STRIP_COMPONENTS=2
-  fi
-
-  # download from new host
-  wget -O - "https://artifacts.elastic.co/downloads/elasticsearch/${FILENAME}" \
-    | tar xz --directory=/tmp/elasticsearch --strip-components="${STRIP_COMPONENTS}"
-
-  # install ICU plugin
-  /tmp/elasticsearch/bin/elasticsearch-plugin install analysis-icu
-
-  # start elasticsearch server
-  /tmp/elasticsearch/bin/elasticsearch --daemonize -Epath.data=/tmp/elasticsearch -Ediscovery.type=single-node
+# prior to ES7 the architecture was not included in the filename
+if [[ "${ES_VERSION}" == "5"* || "${ES_VERSION}" == "6"* ]]; then
+  FILENAME="elasticsearch-${ES_VERSION}.tar.gz"
 fi
+
+# the 6.8.5 release is inconsisent with the others
+# https://github.com/elastic/elasticsearch/issues/49599
+if [[ "${ES_VERSION}" == "6.8.5" ]]; then
+  STRIP_COMPONENTS=2
+fi
+
+# download from new host
+wget -O - "https://artifacts.elastic.co/downloads/elasticsearch/${FILENAME}" \
+  | tar xz --directory=/tmp/elasticsearch --strip-components="${STRIP_COMPONENTS}"
+
+# install ICU plugin
+/tmp/elasticsearch/bin/elasticsearch-plugin install analysis-icu
+
+# start elasticsearch server
+/tmp/elasticsearch/bin/elasticsearch --daemonize -Epath.data=/tmp/elasticsearch -Ediscovery.type=single-node
 
 # wait for server to boot up
 # logs show that on travis-ci it can take ~17s to boot an ES6 server


### PR DESCRIPTION
We definitely do not support such an old version any more, so this download code can go away.