### PR TITLE
Upgrade CI to elasticsearch 6.8.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ matrix:
   fast_finish: true
 env:
   matrix:
-    - ES_VERSION=6.8.5 JDK_VERSION=oraclejdk8
-    - ES_VERSION=6.8.5 JDK_VERSION=oraclejdk11
+    - ES_VERSION=6.8.6 JDK_VERSION=oraclejdk8
+    - ES_VERSION=6.8.6 JDK_VERSION=oraclejdk11
     - ES_VERSION=7.5.1 JDK_VERSION=oraclejdk11
 jdk:
   - oraclejdk8

--- a/scripts/setup_ci.sh
+++ b/scripts/setup_ci.sh
@@ -16,12 +16,6 @@ if [[ "${ES_VERSION}" == "5"* || "${ES_VERSION}" == "6"* ]]; then
   FILENAME="elasticsearch-${ES_VERSION}.tar.gz"
 fi
 
-# the 6.8.5 release is inconsisent with the others
-# https://github.com/elastic/elasticsearch/issues/49599
-if [[ "${ES_VERSION}" == "6.8.5" ]]; then
-  STRIP_COMPONENTS=2
-fi
-
 # download from new host
 wget -O - "https://artifacts.elastic.co/downloads/elasticsearch/${FILENAME}" \
   | tar xz --directory=/tmp/elasticsearch --strip-components="${STRIP_COMPONENTS}"


### PR DESCRIPTION
Elasticsearch 6.8.6 has been released, so we can upgrade our CI to test against that version and remove some extremely frustrating code to work around a [release glitch in ES 6.8.5](https://github.com/elastic/elasticsearch/issues/49599).