### PR TITLE
fix(travis): loosen ES api version to only target major version number

### DIFF
--- a/scripts/setup_ci.sh
+++ b/scripts/setup_ci.sh
@@ -37,7 +37,7 @@ v=( ${ES_VERSION//./ } ) # split version number on '.'
 # generate a pelias.json config
 PELIAS_CONFIG=$(
   jq -n \
-    --arg apiVersion "${v[0]}.${v[1]}" \
+    --arg apiVersion "${v[0]}.x" \
     '{
       esclient: {
         apiVersion: $apiVersion


### PR DESCRIPTION
as per https://github.com/pelias/schema/issues/435, the elasticsearch library only allows targeting the latest version (such as `7.6`) or `7.x`.

this means that if we have an env var such as `ES_VERSION=7.5.1` in our Travis tests then the generated version `7.5` is invalid once a new version is available, this PR solves this.
