### PR TITLE
chore(TravisCI): Remove deprecated `matrix` config section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ notifications:
 node_js:
   - 10
   - 12
-matrix:
-  fast_finish: true
 env:
   matrix:
     - ES_VERSION=6.8.6 JDK_VERSION=oraclejdk8


### PR DESCRIPTION
This config entry is deprecated, and has now started overwriting the `jobs` section, causing build issues.

Connects pelias/pelias#850