### PR TITLE
merge duplicate tokenizers

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -38,11 +38,7 @@ function generate(){
     },
     "analysis": {
       "tokenizer": {
-        "peliasNameTokenizer": {
-          "type": "pattern",
-          "pattern": "[\\s,/\\\\-]+"
-        },
-        "peliasStreetTokenizer": {
+        "peliasTokenizer": {
           "type": "pattern",
           "pattern": "[\\s,/\\\\-]+"
         }
@@ -50,7 +46,7 @@ function generate(){
       "analyzer": {
         "peliasAdmin": {
           "type": "custom",
-          "tokenizer": "peliasNameTokenizer",
+          "tokenizer": "peliasTokenizer",
           "char_filter" : ["punctuation", "nfkc_normalizer"],
           "filter": [
             "lowercase",
@@ -65,7 +61,7 @@ function generate(){
         },
         "peliasIndexOneEdgeGram" : {
           "type": "custom",
-          "tokenizer" : "peliasNameTokenizer",
+          "tokenizer" : "peliasTokenizer",
           "char_filter" : ["punctuation", "nfkc_normalizer"],
           "filter": [
             "lowercase",
@@ -85,7 +81,7 @@ function generate(){
         },
         "peliasQuery": {
           "type": "custom",
-          "tokenizer": "peliasNameTokenizer",
+          "tokenizer": "peliasTokenizer",
           "char_filter": ["punctuation", "nfkc_normalizer"],
           "filter": [
             "icu_folding",
@@ -99,7 +95,7 @@ function generate(){
         },
         "peliasPhrase": {
           "type": "custom",
-          "tokenizer":"peliasNameTokenizer",
+          "tokenizer":"peliasTokenizer",
           "char_filter" : ["punctuation", "nfkc_normalizer"],
           "filter": [
             "lowercase",
@@ -147,7 +143,7 @@ function generate(){
         },
         "peliasStreet": {
           "type": "custom",
-          "tokenizer":"peliasStreetTokenizer",
+          "tokenizer":"peliasTokenizer",
           "char_filter" : ["punctuation", "nfkc_normalizer"],
           "filter": [
             "lowercase",

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -14,11 +14,7 @@
     },
     "analysis": {
       "tokenizer": {
-        "peliasNameTokenizer": {
-          "type": "pattern",
-          "pattern": "[\\s,/\\\\-]+"
-        },
-        "peliasStreetTokenizer": {
+        "peliasTokenizer": {
           "type": "pattern",
           "pattern": "[\\s,/\\\\-]+"
         }
@@ -26,7 +22,7 @@
       "analyzer": {
         "peliasAdmin": {
           "type": "custom",
-          "tokenizer": "peliasNameTokenizer",
+          "tokenizer": "peliasTokenizer",
           "char_filter": [
             "punctuation",
             "nfkc_normalizer"
@@ -44,7 +40,7 @@
         },
         "peliasIndexOneEdgeGram": {
           "type": "custom",
-          "tokenizer": "peliasNameTokenizer",
+          "tokenizer": "peliasTokenizer",
           "char_filter": [
             "punctuation",
             "nfkc_normalizer"
@@ -67,7 +63,7 @@
         },
         "peliasQuery": {
           "type": "custom",
-          "tokenizer": "peliasNameTokenizer",
+          "tokenizer": "peliasTokenizer",
           "char_filter": [
             "punctuation",
             "nfkc_normalizer"
@@ -84,7 +80,7 @@
         },
         "peliasPhrase": {
           "type": "custom",
-          "tokenizer": "peliasNameTokenizer",
+          "tokenizer": "peliasTokenizer",
           "char_filter": [
             "punctuation",
             "nfkc_normalizer"
@@ -141,7 +137,7 @@
         },
         "peliasStreet": {
           "type": "custom",
-          "tokenizer": "peliasStreetTokenizer",
+          "tokenizer": "peliasTokenizer",
           "char_filter": [
             "punctuation",
             "nfkc_normalizer"


### PR DESCRIPTION
this is a purely cosmetic refactor that simplifies the schema a little.
at some point our two tokenizers `peliasNameTokenizer` and `peliasStreetTokenizer` became the same in all but name.
this PR merges them together into a single tokenizer named `peliasTokenizer`.