### PR TITLE
Add Saint/St to street_synonyms_en

### DIFF
--- a/synonyms/street_synonyms_en.txt
+++ b/synonyms/street_synonyms_en.txt
@@ -291,6 +291,7 @@ round, rnd
 route, rt, rte
 row, rw
 run, rn
+saint, st
 serviceway, swy, svwy, svcwy
 shoal, shl
 shoals, shls

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -685,6 +685,7 @@
             "route,rt,rte",
             "row,rw",
             "run,rn",
+            "saint,st",
             "serviceway,swy,svwy,svcwy",
             "shoal,shl",
             "shoals,shls",

--- a/test/settings.js
+++ b/test/settings.js
@@ -381,7 +381,7 @@ module.exports.tests.streetSynonymEnglishFilter = function(test, common) {
     var filter = s.analysis.filter.street_synonyms_en;
     t.equal(filter.type, 'synonym');
     t.true(Array.isArray(filter.synonyms));
-    t.equal(filter.synonyms.length, 373);
+    t.equal(filter.synonyms.length, 374);
     t.end();
   });
 };


### PR DESCRIPTION
This is a PR into #446. We can merge it in directly, test it separately, etc.

It adds a `saint/st` street synonym. Lack of this synonym on the street field has been a problem for a while, leading to issues such as https://github.com/pelias/pelias/issues/737