### PR TITLE
change query-time analyzer for street fields to peliasQuery

### DIFF
--- a/mappings/document.js
+++ b/mappings/document.js
@@ -44,13 +44,13 @@ var schema = {
         street: {
           type: 'text',
           analyzer: 'peliasStreet',
-          search_analyzer: 'peliasStreet',
+          search_analyzer: 'peliasQuery',
           similarity: 'peliasDefaultSimilarity'
         },
         cross_street: {
           type: 'text',
           analyzer: 'peliasStreet',
-          search_analyzer: 'peliasStreet',
+          search_analyzer: 'peliasQuery',
           similarity: 'peliasDefaultSimilarity'
         },
         zip: {

--- a/test/document.js
+++ b/test/document.js
@@ -70,10 +70,19 @@ module.exports.tests.address_analysis = function(test, common) {
   });
 
   // $street analysis is discussed in: https://github.com/pelias/schema/pull/77
+  // and https://github.com/pelias/api/pull/1444
   test('street', function(t) {
     t.equal(prop.street.type, 'text');
     t.equal(prop.street.analyzer, 'peliasStreet');
-    t.equal(prop.street.search_analyzer, 'peliasStreet');
+    t.equal(prop.street.search_analyzer, 'peliasQuery');
+    t.end();
+  });
+
+  // $cross_street analysis
+  test('cross_street', function (t) {
+    t.equal(prop.cross_street.type, 'text');
+    t.equal(prop.cross_street.analyzer, 'peliasStreet');
+    t.equal(prop.cross_street.search_analyzer, 'peliasQuery');
     t.end();
   });
 

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -615,13 +615,13 @@
           "street": {
             "type": "text",
             "analyzer": "peliasStreet",
-            "search_analyzer": "peliasStreet",
+            "search_analyzer": "peliasQuery",
             "similarity": "peliasDefaultSimilarity"
           },
           "cross_street": {
             "type": "text",
             "analyzer": "peliasStreet",
-            "search_analyzer": "peliasStreet",
+            "search_analyzer": "peliasQuery",
             "similarity": "peliasDefaultSimilarity"
           },
           "zip": {


### PR DESCRIPTION
change query-time analyzer for street fields to peliasQuery

as discussed in https://github.com/pelias/api/pull/1444
closes https://github.com/pelias/schema/issues/454