### PR TITLE
remove support for creating indices using Elasticsearch 6.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ node_js:
   - 12
 env:
   matrix:
-    - ES_VERSION=6.8.6 JDK_VERSION=oraclejdk11
     - ES_VERSION=7.6.1 JDK_VERSION=oraclejdk11
 jdk:
   - oraclejdk11

--- a/scripts/create_index.js
+++ b/scripts/create_index.js
@@ -1,7 +1,7 @@
 const child_process = require('child_process');
 const config = require('pelias-config').generate();
 const es = require('elasticsearch');
-const SUPPORTED_ES_VERSIONS = '>=6.5.4 || >=7.4.2';
+const SUPPORTED_ES_VERSIONS = '>=7.4.2';
 
 const cli = require('./cli');
 const schema = require('../schema');


### PR DESCRIPTION
BREAKING CHANGE: creating *new* Pelias indices using elasticsearch 6 is no longer supported

see https://github.com/pelias/pelias/issues/881

Attempting to run `create_index.js` against a `pelias/elasticsearch:6.8.5` server results in the following error:

```bash
 node scripts/create_index.js

--------------
 create index
--------------

unsupported elasticsearch version. try: >=7.4.2
```