### PR TITLE
Change to make compound ampersand words easier to match

### DIFF
--- a/integration/analyzer_peliasQuery.js
+++ b/integration/analyzer_peliasQuery.js
@@ -31,6 +31,10 @@ module.exports.tests.analyze = function(test, common){
     assertAnalysis('no kstem', 'McDonald\'s', ['mcdonalds']);
     assertAnalysis('no kstem', 'peoples', ['peoples']);
 
+    assertAnalysis('ampersand_splitter', 'AP Deli', ['ap', 'deli']);
+    assertAnalysis('ampersand_splitter', 'A&P Deli', ['a', '&', 'p', 'deli']);
+    assertAnalysis('ampersand_splitter', 'A & P Deli', ['a', '&', 'p', 'deli']);
+
     // remove punctuation (handled by the char_filter)
     assertAnalysis( 'punctuation', punctuation.all.join(''), ['&'] );
 
@@ -48,6 +52,9 @@ module.exports.tests.functional = function(test, common){
     assertAnalysis( 'country', 'Trinidad and Tobago', [ 'trinidad', 'and', 'tobago' ]);
     assertAnalysis( 'place', 'Toys "R" Us!', [ 'toys', 'r', 'us' ]);
     assertAnalysis( 'address', '101 mapzen place', [ '101', 'mapzen', 'place' ]);
+
+    assertAnalysis( 'place', 'A&P Deli', [ 'a', '&', 'p', 'deli' ]);
+    assertAnalysis( 'place', 'A & P Deli', [ 'a', '&', 'p', 'deli' ]);
 
     suite.run( t.end );
   });

--- a/settings.js
+++ b/settings.js
@@ -46,7 +46,7 @@ function generate(){
         "peliasIndexOneEdgeGram" : {
           "type": "custom",
           "tokenizer" : "peliasTokenizer",
-          "char_filter" : ["punctuation", "nfkc_normalizer"],
+          "char_filter" : ["punctuation", "nfkc_normalizer", "ampersand_splitter"],
           "filter": [
             "lowercase",
             "trim",
@@ -64,7 +64,7 @@ function generate(){
         "peliasQuery": {
           "type": "custom",
           "tokenizer": "peliasTokenizer",
-          "char_filter": ["punctuation", "nfkc_normalizer"],
+          "char_filter": ["punctuation", "nfkc_normalizer", "ampersand_splitter"],
           "filter": [
             "lowercase",
             "trim",
@@ -78,7 +78,7 @@ function generate(){
         "peliasPhrase": {
           "type": "custom",
           "tokenizer":"peliasTokenizer",
-          "char_filter" : ["punctuation", "nfkc_normalizer"],
+          "char_filter" : ["punctuation", "nfkc_normalizer", "ampersand_splitter"],
           "filter": [
             "lowercase",
             "trim",
@@ -124,7 +124,7 @@ function generate(){
         "peliasStreet": {
           "type": "custom",
           "tokenizer":"peliasTokenizer",
-          "char_filter" : ["punctuation", "nfkc_normalizer"],
+          "char_filter" : ["punctuation", "nfkc_normalizer", "ampersand_splitter"],
           "filter": [
             "lowercase",
             "trim",
@@ -223,6 +223,11 @@ function generate(){
           "type": "icu_normalizer",
           "name": "nfkc",
           "mode": "compose"
+        },
+        "ampersand_splitter": {
+          "type": "pattern_replace",
+          "pattern": "([^\s])&([^\s])",
+          "replacement": "$1 & $2"
         }
       }
     }

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -44,7 +44,8 @@
           "tokenizer": "peliasTokenizer",
           "char_filter": [
             "punctuation",
-            "nfkc_normalizer"
+            "nfkc_normalizer",
+            "ampersand_splitter"
           ],
           "filter": [
             "lowercase",
@@ -65,7 +66,8 @@
           "tokenizer": "peliasTokenizer",
           "char_filter": [
             "punctuation",
-            "nfkc_normalizer"
+            "nfkc_normalizer",
+            "ampersand_splitter"
           ],
           "filter": [
             "lowercase",
@@ -82,7 +84,8 @@
           "tokenizer": "peliasTokenizer",
           "char_filter": [
             "punctuation",
-            "nfkc_normalizer"
+            "nfkc_normalizer",
+            "ampersand_splitter"
           ],
           "filter": [
             "lowercase",
@@ -139,7 +142,8 @@
           "tokenizer": "peliasTokenizer",
           "char_filter": [
             "punctuation",
-            "nfkc_normalizer"
+            "nfkc_normalizer",
+            "ampersand_splitter"
           ],
           "filter": [
             "lowercase",
@@ -1761,6 +1765,11 @@
           "type": "icu_normalizer",
           "name": "nfkc",
           "mode": "compose"
+        },
+        "ampersand_splitter": {
+          "type": "pattern_replace",
+          "pattern": "[^s]&[^s]",
+          "replacement": " & "
         }
       }
     }

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -1768,8 +1768,8 @@
         },
         "ampersand_splitter": {
           "type": "pattern_replace",
-          "pattern": "[^s]&[^s]",
-          "replacement": " & "
+          "pattern": "([^s])&([^s])",
+          "replacement": "$1 & $2"
         }
       }
     }

--- a/test/settings.js
+++ b/test/settings.js
@@ -122,7 +122,7 @@ module.exports.tests.peliasIndexOneEdgeGramAnalyzer = function(test, common) {
     var analyzer = s.analysis.analyzer.peliasIndexOneEdgeGram;
     t.equal(analyzer.type, 'custom', 'custom analyzer');
     t.equal(typeof analyzer.tokenizer, 'string', 'tokenizer specified');
-    t.deepEqual(analyzer.char_filter, ["punctuation","nfkc_normalizer"], 'character filters specified');
+    t.deepEqual(analyzer.char_filter, ["punctuation","nfkc_normalizer","ampersand_splitter"], 'character filters specified');
     t.true(Array.isArray(analyzer.filter), 'filters specified');
     t.end();
   });
@@ -152,7 +152,7 @@ module.exports.tests.peliasQueryAnalyzer = function (test, common) {
     var analyzer = s.analysis.analyzer.peliasQuery;
     t.equal(analyzer.type, 'custom', 'custom analyzer');
     t.equal(typeof analyzer.tokenizer, 'string', 'tokenizer specified');
-    t.deepEqual(analyzer.char_filter, ['punctuation', 'nfkc_normalizer'], 'character filters specified');
+    t.deepEqual(analyzer.char_filter, ['punctuation', 'nfkc_normalizer', 'ampersand_splitter'], 'character filters specified');
     t.true(Array.isArray(analyzer.filter), 'filters specified');
     t.end();
   });
@@ -178,7 +178,7 @@ module.exports.tests.peliasPhraseAnalyzer = function(test, common) {
     var analyzer = s.analysis.analyzer.peliasPhrase;
     t.equal(analyzer.type, 'custom', 'custom analyzer');
     t.equal(typeof analyzer.tokenizer, 'string', 'tokenizer specified');
-    t.deepEqual(analyzer.char_filter, ["punctuation","nfkc_normalizer"], 'character filters specified');
+    t.deepEqual(analyzer.char_filter, ["punctuation","nfkc_normalizer","ampersand_splitter"], 'character filters specified');
     t.true(Array.isArray(analyzer.filter), 'filters specified');
     t.end();
   });
@@ -286,7 +286,7 @@ module.exports.tests.peliasStreetAnalyzer = function(test, common) {
     var analyzer = s.analysis.analyzer.peliasStreet;
     t.equal(analyzer.type, 'custom', 'custom analyzer');
     t.equal(typeof analyzer.tokenizer, 'string', 'tokenizer specified');
-    t.deepEqual(analyzer.char_filter, ['punctuation', 'nfkc_normalizer'], 'character filters specified');
+    t.deepEqual(analyzer.char_filter, ['punctuation', 'nfkc_normalizer', 'ampersand_splitter'], 'character filters specified');
     t.true(Array.isArray(analyzer.filter), 'filters specified');
     t.end();
   });


### PR DESCRIPTION
I *think* this is the correct change to make it so "A&P Deli" can be matched by any of these queries:
"A&P" "A & P" and "A and P"

I alias "and" to "und" because otherwise it seems like this change wouldn't work for german venues. 

But then again I am still not great at schema changes. Working on building an index with this locally now. Unittests & manual testing seem to tell me this change works.