### PR TITLE
disable term frequencies for admin abbreviation fields

### DIFF
--- a/integration/admin_abbreviations.js
+++ b/integration/admin_abbreviations.js
@@ -1,0 +1,126 @@
+/**
+ * this test suite ensures that 'admin_abbreviation' fields
+ * are indexed in a way that indexing multiple tokens in the
+ * same field does not affect scoring even when the tokens
+ * are duplicates or prefixes of each other.
+*/
+
+const elastictest = require('elastictest');
+const config = require('pelias-config').generate();
+const getTotalHits = require('./_hits_total_helper');
+
+module.exports.tests = {};
+module.exports.tests.functional = function (test, common) {
+  test('functional', function (t) {
+
+    var suite = new elastictest.Suite(common.clientOpts, common.create);
+    suite.action(done => setTimeout(done, 500)); // wait for es to bring some shards up
+
+    // index document 1 with country_a='NZL'
+    suite.action(done => {
+      suite.client.index({
+        index: suite.props.index,
+        type: config.schema.typeName,
+        id: '1',
+        body: {
+          parent: {
+            country_a: ['NZL']
+          }
+        }
+      }, done);
+    });
+
+    // index document 2 with country_a='NZL' & 'NZ'
+    suite.action(done => {
+      suite.client.index({
+        index: suite.props.index,
+        type: config.schema.typeName,
+        id: '2',
+        body: {
+          parent: {
+            country_a: ['NZL', 'NZ']
+          }
+        }
+      }, done);
+    });
+
+    // search for 'NZL' on 'parent.country_a' and compare scores
+    suite.assert(done => {
+      suite.client.search({
+        index: suite.props.index,
+        type: config.schema.typeName,
+        body: {
+          query: {
+            match: {
+              'parent.country_a': {
+                'query': 'nzl'
+              }
+            }
+          }
+        }
+      }, (err, res) => {
+        t.equal(err, undefined);
+        t.equal(getTotalHits(res.hits), 2, 'matches both documents');
+        t.equal(res.hits.hits[0]._score, res.hits.hits[1]._score, 'scores match');
+        done();
+      });
+    });
+
+    // search for 'NZL' on 'parent.country_a.ngram' and compare scores
+    suite.assert(done => {
+      suite.client.search({
+        index: suite.props.index,
+        type: config.schema.typeName,
+        body: {
+          query: {
+            match: {
+              'parent.country_a.ngram': {
+                'query': 'nzl'
+              }
+            }
+          }
+        }
+      }, (err, res) => {
+        t.equal(err, undefined);
+        t.equal(getTotalHits(res.hits), 2, 'matches both documents');
+        t.equal(res.hits.hits[0]._score, res.hits.hits[1]._score, 'scores match');
+        done();
+      });
+    });
+
+    // search for 'NZ' on 'parent.country_a.ngram' and compare scores
+    suite.assert(done => {
+      suite.client.search({
+        index: suite.props.index,
+        type: config.schema.typeName,
+        body: {
+          query: {
+            match: {
+              'parent.country_a.ngram': {
+                'query': 'nz'
+              }
+            }
+          }
+        }
+      }, (err, res) => {
+        t.equal(err, undefined);
+        t.equal(getTotalHits(res.hits), 2, 'matches both documents');
+        t.equal(res.hits.hits[0]._score, res.hits.hits[1]._score, 'scores match');
+        done();
+      });
+    });
+
+    suite.run(t.end);
+  });
+};
+
+module.exports.all = (tape, common) => {
+
+  function test(name, testFunction) {
+    return tape('multi token synonyms: ' + name, testFunction);
+  }
+
+  for (var testCase in module.exports.tests) {
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/integration/run.js
+++ b/integration/run.js
@@ -110,7 +110,8 @@ var tests = [
   require('./autocomplete_street_synonym_expansion.js'),
   require('./autocomplete_directional_synonym_expansion.js'),
   require('./autocomplete_abbreviated_street_names.js'),
-  require('./multi_token_synonyms.js')
+  require('./multi_token_synonyms.js'),
+  require('./admin_abbreviations.js')
 ];
 
 tests.map(function(t) {

--- a/mappings/document.js
+++ b/mappings/document.js
@@ -1,4 +1,5 @@
 const admin = require('./partial/admin');
+const admin_abbreviation = require('./partial/admin_abbreviation');
 const postalcode = require('./partial/postalcode');
 const hash = require('./partial/hash');
 const multiplier = require('./partial/multiplier');
@@ -69,85 +70,85 @@ var schema = {
       properties: {
         // https://github.com/whosonfirst/whosonfirst-placetypes#continent
         continent: admin,
-        continent_a: admin,
+        continent_a: admin_abbreviation,
         continent_id: keyword,
         continent_source: keyword,
 
         // https://github.com/whosonfirst/whosonfirst-placetypes#ocean
         ocean: admin,
-        ocean_a: admin,
+        ocean_a: admin_abbreviation,
         ocean_id: keyword,
         ocean_source: keyword,
 
         // https://github.com/whosonfirst/whosonfirst-placetypes#empire
         empire: admin,
-        empire_a: admin,
+        empire_a: admin_abbreviation,
         empire_id: keyword,
         empire_source: keyword,
 
         // https://github.com/whosonfirst/whosonfirst-placetypes#country
         country: admin,
-        country_a: admin,
+        country_a: admin_abbreviation,
         country_id: keyword,
         country_source: keyword,
 
         // https://github.com/whosonfirst/whosonfirst-placetypes#dependency
         dependency: admin,
-        dependency_a: admin,
+        dependency_a: admin_abbreviation,
         dependency_id: keyword,
         dependency_source: keyword,
 
         // https://github.com/whosonfirst/whosonfirst-placetypes#marinearea
         marinearea: admin,
-        marinearea_a: admin,
+        marinearea_a: admin_abbreviation,
         marinearea_id: keyword,
         marinearea_source: keyword,
 
         // https://github.com/whosonfirst/whosonfirst-placetypes#macroregion
         macroregion: admin,
-        macroregion_a: admin,
+        macroregion_a: admin_abbreviation,
         macroregion_id: keyword,
         macroregion_source: keyword,
 
         // https://github.com/whosonfirst/whosonfirst-placetypes#region
         region: admin,
-        region_a: admin,
+        region_a: admin_abbreviation,
         region_id: keyword,
         region_source: keyword,
 
         // https://github.com/whosonfirst/whosonfirst-placetypes#macrocounty
         macrocounty: admin,
-        macrocounty_a: admin,
+        macrocounty_a: admin_abbreviation,
         macrocounty_id: keyword,
         macrocounty_source: keyword,
 
         // https://github.com/whosonfirst/whosonfirst-placetypes#county
         county: admin,
-        county_a: admin,
+        county_a: admin_abbreviation,
         county_id: keyword,
         county_source: keyword,
 
         // https://github.com/whosonfirst/whosonfirst-placetypes#locality
         locality: admin,
-        locality_a: admin,
+        locality_a: admin_abbreviation,
         locality_id: keyword,
         locality_source: keyword,
 
         // https://github.com/whosonfirst/whosonfirst-placetypes#borough
         borough: admin,
-        borough_a: admin,
+        borough_a: admin_abbreviation,
         borough_id: keyword,
         borough_source: keyword,
 
         // https://github.com/whosonfirst/whosonfirst-placetypes#localadmin
         localadmin: admin,
-        localadmin_a: admin,
+        localadmin_a: admin_abbreviation,
         localadmin_id: keyword,
         localadmin_source: keyword,
 
         // https://github.com/whosonfirst/whosonfirst-placetypes#neighbourhood
         neighbourhood: admin,
-        neighbourhood_a: admin,
+        neighbourhood_a: admin_abbreviation,
         neighbourhood_id: keyword,
         neighbourhood_source: keyword,
 

--- a/mappings/partial/admin_abbreviation.js
+++ b/mappings/partial/admin_abbreviation.js
@@ -1,0 +1,17 @@
+const _ = require('lodash');
+const admin = require('./admin.json');
+
+// this partial is the same as 'admin.json'
+// with the addition of the key 'index_options=docs'
+// note: this prevents document frequencies from being indexed, this has the effect of
+// preventing term frequencies from affecting scoring when multiple terms are indexed.
+// https://www.elastic.co/guide/en/elasticsearch/reference/current/index-options.html
+
+module.exports = _.merge(admin, {
+  "index_options": "docs",
+  "fields": {
+    "ngram": {
+      "index_options": "docs"
+    }
+  }
+});

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -2112,9 +2112,11 @@
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "index_options": "docs"
               }
-            }
+            },
+            "index_options": "docs"
           },
           "continent_a": {
             "type": "text",
@@ -2127,9 +2129,11 @@
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "index_options": "docs"
               }
-            }
+            },
+            "index_options": "docs"
           },
           "continent_id": {
             "type": "keyword",
@@ -2150,9 +2154,11 @@
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "index_options": "docs"
               }
-            }
+            },
+            "index_options": "docs"
           },
           "ocean_a": {
             "type": "text",
@@ -2165,9 +2171,11 @@
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "index_options": "docs"
               }
-            }
+            },
+            "index_options": "docs"
           },
           "ocean_id": {
             "type": "keyword",
@@ -2188,9 +2196,11 @@
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "index_options": "docs"
               }
-            }
+            },
+            "index_options": "docs"
           },
           "empire_a": {
             "type": "text",
@@ -2203,9 +2213,11 @@
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "index_options": "docs"
               }
-            }
+            },
+            "index_options": "docs"
           },
           "empire_id": {
             "type": "keyword",
@@ -2226,9 +2238,11 @@
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "index_options": "docs"
               }
-            }
+            },
+            "index_options": "docs"
           },
           "country_a": {
             "type": "text",
@@ -2241,9 +2255,11 @@
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "index_options": "docs"
               }
-            }
+            },
+            "index_options": "docs"
           },
           "country_id": {
             "type": "keyword",
@@ -2264,9 +2280,11 @@
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "index_options": "docs"
               }
-            }
+            },
+            "index_options": "docs"
           },
           "dependency_a": {
             "type": "text",
@@ -2279,9 +2297,11 @@
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "index_options": "docs"
               }
-            }
+            },
+            "index_options": "docs"
           },
           "dependency_id": {
             "type": "keyword",
@@ -2302,9 +2322,11 @@
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "index_options": "docs"
               }
-            }
+            },
+            "index_options": "docs"
           },
           "marinearea_a": {
             "type": "text",
@@ -2317,9 +2339,11 @@
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "index_options": "docs"
               }
-            }
+            },
+            "index_options": "docs"
           },
           "marinearea_id": {
             "type": "keyword",
@@ -2340,9 +2364,11 @@
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "index_options": "docs"
               }
-            }
+            },
+            "index_options": "docs"
           },
           "macroregion_a": {
             "type": "text",
@@ -2355,9 +2381,11 @@
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "index_options": "docs"
               }
-            }
+            },
+            "index_options": "docs"
           },
           "macroregion_id": {
             "type": "keyword",
@@ -2378,9 +2406,11 @@
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "index_options": "docs"
               }
-            }
+            },
+            "index_options": "docs"
           },
           "region_a": {
             "type": "text",
@@ -2393,9 +2423,11 @@
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "index_options": "docs"
               }
-            }
+            },
+            "index_options": "docs"
           },
           "region_id": {
             "type": "keyword",
@@ -2416,9 +2448,11 @@
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "index_options": "docs"
               }
-            }
+            },
+            "index_options": "docs"
           },
           "macrocounty_a": {
             "type": "text",
@@ -2431,9 +2465,11 @@
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "index_options": "docs"
               }
-            }
+            },
+            "index_options": "docs"
           },
           "macrocounty_id": {
             "type": "keyword",
@@ -2454,9 +2490,11 @@
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "index_options": "docs"
               }
-            }
+            },
+            "index_options": "docs"
           },
           "county_a": {
             "type": "text",
@@ -2469,9 +2507,11 @@
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "index_options": "docs"
               }
-            }
+            },
+            "index_options": "docs"
           },
           "county_id": {
             "type": "keyword",
@@ -2492,9 +2532,11 @@
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "index_options": "docs"
               }
-            }
+            },
+            "index_options": "docs"
           },
           "locality_a": {
             "type": "text",
@@ -2507,9 +2549,11 @@
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "index_options": "docs"
               }
-            }
+            },
+            "index_options": "docs"
           },
           "locality_id": {
             "type": "keyword",
@@ -2530,9 +2574,11 @@
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "index_options": "docs"
               }
-            }
+            },
+            "index_options": "docs"
           },
           "borough_a": {
             "type": "text",
@@ -2545,9 +2591,11 @@
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "index_options": "docs"
               }
-            }
+            },
+            "index_options": "docs"
           },
           "borough_id": {
             "type": "keyword",
@@ -2568,9 +2616,11 @@
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "index_options": "docs"
               }
-            }
+            },
+            "index_options": "docs"
           },
           "localadmin_a": {
             "type": "text",
@@ -2583,9 +2633,11 @@
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "index_options": "docs"
               }
-            }
+            },
+            "index_options": "docs"
           },
           "localadmin_id": {
             "type": "keyword",
@@ -2606,9 +2658,11 @@
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "index_options": "docs"
               }
-            }
+            },
+            "index_options": "docs"
           },
           "neighbourhood_a": {
             "type": "text",
@@ -2621,9 +2675,11 @@
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "index_options": "docs"
               }
-            }
+            },
+            "index_options": "docs"
           },
           "neighbourhood_id": {
             "type": "keyword",


### PR DESCRIPTION
This PR changes the way `parent.*_a` fields are indexed so that the term frequencies are not stored.
the effect of this change is that indexing multiple terms in the field (ie. what we call 'aliases') will have no adverse effect on scoring.

Merging this work will allow us to follow up with a alpha3<>alpha2 country code mapping (for `parent.country_a`) without worrying about the additional tokens adversely affecting scoring.

related:
- https://github.com/pelias/schema/pull/470
- https://github.com/pelias/schema/pull/469
- https://github.com/pelias/schema/issues/408