### PR TITLE
disable field norms across the board

### DIFF
--- a/integration/analyzer_peliasPhrase.js
+++ b/integration/analyzer_peliasPhrase.js
@@ -225,7 +225,7 @@ module.exports.tests.slop_query = function(test, common){
         t.equal( getTotalHits(res.hits), 3 );
         var hits = res.hits.hits;
 
-        t.equal( hits[0]._source.name.default, 'Lake Cayuga' );
+        t.equal( hits[0]._source.name.default, '7991 Lake Cayuga Dr' );
 
         // This behaviour changed between elasticsearch 2.4 & 5.6
         // In 2.4 the sloppy exact match ranked higher, after upgrading

--- a/mappings/document.js
+++ b/mappings/document.js
@@ -28,37 +28,43 @@ var schema = {
           type: 'text',
           analyzer: 'keyword',
           search_analyzer: 'keyword',
-          similarity: 'peliasDefaultSimilarity'
+          similarity: 'peliasDefaultSimilarity',
+          norms: false
         },
         unit: {
           type: 'text',
           analyzer: 'peliasUnit',
           search_analyzer: 'peliasUnit',
-          similarity: 'peliasDefaultSimilarity'
+          similarity: 'peliasDefaultSimilarity',
+          norms: false
         },
         number: {
           type: 'text',
           analyzer: 'peliasHousenumber',
           search_analyzer: 'peliasHousenumber',
-          similarity: 'peliasDefaultSimilarity'
+          similarity: 'peliasDefaultSimilarity',
+          norms: false
         },
         street: {
           type: 'text',
           analyzer: 'peliasStreet',
           search_analyzer: 'peliasQuery',
-          similarity: 'peliasDefaultSimilarity'
+          similarity: 'peliasDefaultSimilarity',
+          norms: false
         },
         cross_street: {
           type: 'text',
           analyzer: 'peliasStreet',
           search_analyzer: 'peliasQuery',
-          similarity: 'peliasDefaultSimilarity'
+          similarity: 'peliasDefaultSimilarity',
+          norms: false
         },
         zip: {
           type: 'text',
           analyzer: 'peliasZip',
           search_analyzer: 'peliasZip',
-          similarity: 'peliasDefaultSimilarity'
+          similarity: 'peliasDefaultSimilarity',
+          norms: false
         },
       }
     },
@@ -182,7 +188,8 @@ var schema = {
         type: 'text',
         analyzer: 'peliasIndexOneEdgeGram',
         search_analyzer: 'peliasQuery',
-        similarity: 'peliasDefaultSimilarity'
+        similarity: 'peliasDefaultSimilarity',
+        norms: false
       }
     },
   },{
@@ -193,7 +200,8 @@ var schema = {
         type: 'text',
         analyzer: 'peliasPhrase',
         search_analyzer: 'peliasQuery',
-        similarity: 'peliasDefaultSimilarity'
+        similarity: 'peliasDefaultSimilarity',
+        norms: false
       }
     }
   },{
@@ -203,7 +211,8 @@ var schema = {
       mapping: {
         type: 'keyword',
         index: false,
-        doc_values: false
+        doc_values: false,
+        norms: false
       }
     }
   }],

--- a/mappings/partial/admin.json
+++ b/mappings/partial/admin.json
@@ -3,13 +3,15 @@
   "analyzer": "peliasAdmin",
   "search_analyzer": "peliasAdmin",
   "similarity": "peliasDefaultSimilarity",
+  "norms": false,
   "fields": {
     "ngram": {
       "type": "text",
       "analyzer": "peliasIndexOneEdgeGram",
       "search_analyzer": "peliasAdmin",
       "similarity": "peliasDefaultSimilarity",
-      "doc_values": false
+      "doc_values": false,
+      "norms": false
     }
   }
 }

--- a/mappings/partial/countryAbbreviation.json
+++ b/mappings/partial/countryAbbreviation.json
@@ -3,13 +3,15 @@
   "analyzer": "peliasIndexCountryAbbreviation",
   "search_analyzer": "peliasQuery",
   "similarity": "peliasDefaultSimilarity",
+  "norms": false,
   "fields": {
     "ngram": {
       "type": "text",
       "analyzer": "peliasIndexCountryAbbreviationOneEdgeGram",
       "search_analyzer": "peliasQuery",
       "similarity": "peliasDefaultSimilarity",
-      "doc_values": false
+      "doc_values": false,
+      "norms": false
     }
   }
 }

--- a/mappings/partial/postalcode.json
+++ b/mappings/partial/postalcode.json
@@ -3,12 +3,14 @@
   "analyzer": "peliasZip",
   "search_analyzer": "peliasZip",
   "similarity": "peliasDefaultSimilarity",
+  "norms": false,
   "fields": {
     "ngram": {
       "type": "text",
       "analyzer": "peliasIndexOneEdgeGram",
       "search_analyzer": "peliasZip",
-      "similarity": "peliasDefaultSimilarity"
+      "similarity": "peliasDefaultSimilarity",
+      "norms": false
     }
   }
 }

--- a/test/compile.js
+++ b/test/compile.js
@@ -44,7 +44,8 @@ module.exports.tests.dynamic_templates = function(test, common) {
       type: 'text',
       analyzer: 'peliasIndexOneEdgeGram',
       search_analyzer: 'peliasQuery',
-      similarity: 'peliasDefaultSimilarity'
+      similarity: 'peliasDefaultSimilarity',
+      norms: false
     });
     t.end();
   });
@@ -57,7 +58,8 @@ module.exports.tests.dynamic_templates = function(test, common) {
       type: 'text',
       analyzer: 'peliasPhrase',
       search_analyzer: 'peliasQuery',
-      similarity: 'peliasDefaultSimilarity'
+      similarity: 'peliasDefaultSimilarity',
+      norms: false
     });
     t.end();
   });
@@ -69,7 +71,8 @@ module.exports.tests.dynamic_templates = function(test, common) {
     t.deepEqual(template.mapping, {
       type: 'keyword',
       index: false,
-      doc_values: false
+      doc_values: false,
+      norms: false
     });
     t.end();
   });

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -2366,37 +2366,43 @@
             "type": "text",
             "analyzer": "keyword",
             "search_analyzer": "keyword",
-            "similarity": "peliasDefaultSimilarity"
+            "similarity": "peliasDefaultSimilarity",
+            "norms": false
           },
           "unit": {
             "type": "text",
             "analyzer": "peliasUnit",
             "search_analyzer": "peliasUnit",
-            "similarity": "peliasDefaultSimilarity"
+            "similarity": "peliasDefaultSimilarity",
+            "norms": false
           },
           "number": {
             "type": "text",
             "analyzer": "peliasHousenumber",
             "search_analyzer": "peliasHousenumber",
-            "similarity": "peliasDefaultSimilarity"
+            "similarity": "peliasDefaultSimilarity",
+            "norms": false
           },
           "street": {
             "type": "text",
             "analyzer": "peliasStreet",
             "search_analyzer": "peliasQuery",
-            "similarity": "peliasDefaultSimilarity"
+            "similarity": "peliasDefaultSimilarity",
+            "norms": false
           },
           "cross_street": {
             "type": "text",
             "analyzer": "peliasStreet",
             "search_analyzer": "peliasQuery",
-            "similarity": "peliasDefaultSimilarity"
+            "similarity": "peliasDefaultSimilarity",
+            "norms": false
           },
           "zip": {
             "type": "text",
             "analyzer": "peliasZip",
             "search_analyzer": "peliasZip",
-            "similarity": "peliasDefaultSimilarity"
+            "similarity": "peliasDefaultSimilarity",
+            "norms": false
           }
         }
       },
@@ -2409,13 +2415,15 @@
             "analyzer": "peliasAdmin",
             "search_analyzer": "peliasAdmin",
             "similarity": "peliasDefaultSimilarity",
+            "norms": false,
             "fields": {
               "ngram": {
                 "type": "text",
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "norms": false
               }
             }
           },
@@ -2424,13 +2432,15 @@
             "analyzer": "peliasAdmin",
             "search_analyzer": "peliasAdmin",
             "similarity": "peliasDefaultSimilarity",
+            "norms": false,
             "fields": {
               "ngram": {
                 "type": "text",
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "norms": false
               }
             }
           },
@@ -2447,13 +2457,15 @@
             "analyzer": "peliasAdmin",
             "search_analyzer": "peliasAdmin",
             "similarity": "peliasDefaultSimilarity",
+            "norms": false,
             "fields": {
               "ngram": {
                 "type": "text",
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "norms": false
               }
             }
           },
@@ -2462,13 +2474,15 @@
             "analyzer": "peliasAdmin",
             "search_analyzer": "peliasAdmin",
             "similarity": "peliasDefaultSimilarity",
+            "norms": false,
             "fields": {
               "ngram": {
                 "type": "text",
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "norms": false
               }
             }
           },
@@ -2485,13 +2499,15 @@
             "analyzer": "peliasAdmin",
             "search_analyzer": "peliasAdmin",
             "similarity": "peliasDefaultSimilarity",
+            "norms": false,
             "fields": {
               "ngram": {
                 "type": "text",
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "norms": false
               }
             }
           },
@@ -2500,13 +2516,15 @@
             "analyzer": "peliasAdmin",
             "search_analyzer": "peliasAdmin",
             "similarity": "peliasDefaultSimilarity",
+            "norms": false,
             "fields": {
               "ngram": {
                 "type": "text",
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "norms": false
               }
             }
           },
@@ -2523,13 +2541,15 @@
             "analyzer": "peliasAdmin",
             "search_analyzer": "peliasAdmin",
             "similarity": "peliasDefaultSimilarity",
+            "norms": false,
             "fields": {
               "ngram": {
                 "type": "text",
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "norms": false
               }
             }
           },
@@ -2538,13 +2558,15 @@
             "analyzer": "peliasIndexCountryAbbreviation",
             "search_analyzer": "peliasQuery",
             "similarity": "peliasDefaultSimilarity",
+            "norms": false,
             "fields": {
               "ngram": {
                 "type": "text",
                 "analyzer": "peliasIndexCountryAbbreviationOneEdgeGram",
                 "search_analyzer": "peliasQuery",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "norms": false
               }
             }
           },
@@ -2561,13 +2583,15 @@
             "analyzer": "peliasAdmin",
             "search_analyzer": "peliasAdmin",
             "similarity": "peliasDefaultSimilarity",
+            "norms": false,
             "fields": {
               "ngram": {
                 "type": "text",
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "norms": false
               }
             }
           },
@@ -2576,13 +2600,15 @@
             "analyzer": "peliasAdmin",
             "search_analyzer": "peliasAdmin",
             "similarity": "peliasDefaultSimilarity",
+            "norms": false,
             "fields": {
               "ngram": {
                 "type": "text",
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "norms": false
               }
             }
           },
@@ -2599,13 +2625,15 @@
             "analyzer": "peliasAdmin",
             "search_analyzer": "peliasAdmin",
             "similarity": "peliasDefaultSimilarity",
+            "norms": false,
             "fields": {
               "ngram": {
                 "type": "text",
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "norms": false
               }
             }
           },
@@ -2614,13 +2642,15 @@
             "analyzer": "peliasAdmin",
             "search_analyzer": "peliasAdmin",
             "similarity": "peliasDefaultSimilarity",
+            "norms": false,
             "fields": {
               "ngram": {
                 "type": "text",
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "norms": false
               }
             }
           },
@@ -2637,13 +2667,15 @@
             "analyzer": "peliasAdmin",
             "search_analyzer": "peliasAdmin",
             "similarity": "peliasDefaultSimilarity",
+            "norms": false,
             "fields": {
               "ngram": {
                 "type": "text",
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "norms": false
               }
             }
           },
@@ -2652,13 +2684,15 @@
             "analyzer": "peliasAdmin",
             "search_analyzer": "peliasAdmin",
             "similarity": "peliasDefaultSimilarity",
+            "norms": false,
             "fields": {
               "ngram": {
                 "type": "text",
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "norms": false
               }
             }
           },
@@ -2675,13 +2709,15 @@
             "analyzer": "peliasAdmin",
             "search_analyzer": "peliasAdmin",
             "similarity": "peliasDefaultSimilarity",
+            "norms": false,
             "fields": {
               "ngram": {
                 "type": "text",
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "norms": false
               }
             }
           },
@@ -2690,13 +2726,15 @@
             "analyzer": "peliasAdmin",
             "search_analyzer": "peliasAdmin",
             "similarity": "peliasDefaultSimilarity",
+            "norms": false,
             "fields": {
               "ngram": {
                 "type": "text",
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "norms": false
               }
             }
           },
@@ -2713,13 +2751,15 @@
             "analyzer": "peliasAdmin",
             "search_analyzer": "peliasAdmin",
             "similarity": "peliasDefaultSimilarity",
+            "norms": false,
             "fields": {
               "ngram": {
                 "type": "text",
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "norms": false
               }
             }
           },
@@ -2728,13 +2768,15 @@
             "analyzer": "peliasAdmin",
             "search_analyzer": "peliasAdmin",
             "similarity": "peliasDefaultSimilarity",
+            "norms": false,
             "fields": {
               "ngram": {
                 "type": "text",
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "norms": false
               }
             }
           },
@@ -2751,13 +2793,15 @@
             "analyzer": "peliasAdmin",
             "search_analyzer": "peliasAdmin",
             "similarity": "peliasDefaultSimilarity",
+            "norms": false,
             "fields": {
               "ngram": {
                 "type": "text",
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "norms": false
               }
             }
           },
@@ -2766,13 +2810,15 @@
             "analyzer": "peliasAdmin",
             "search_analyzer": "peliasAdmin",
             "similarity": "peliasDefaultSimilarity",
+            "norms": false,
             "fields": {
               "ngram": {
                 "type": "text",
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "norms": false
               }
             }
           },
@@ -2789,13 +2835,15 @@
             "analyzer": "peliasAdmin",
             "search_analyzer": "peliasAdmin",
             "similarity": "peliasDefaultSimilarity",
+            "norms": false,
             "fields": {
               "ngram": {
                 "type": "text",
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "norms": false
               }
             }
           },
@@ -2804,13 +2852,15 @@
             "analyzer": "peliasAdmin",
             "search_analyzer": "peliasAdmin",
             "similarity": "peliasDefaultSimilarity",
+            "norms": false,
             "fields": {
               "ngram": {
                 "type": "text",
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "norms": false
               }
             }
           },
@@ -2827,13 +2877,15 @@
             "analyzer": "peliasAdmin",
             "search_analyzer": "peliasAdmin",
             "similarity": "peliasDefaultSimilarity",
+            "norms": false,
             "fields": {
               "ngram": {
                 "type": "text",
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "norms": false
               }
             }
           },
@@ -2842,13 +2894,15 @@
             "analyzer": "peliasAdmin",
             "search_analyzer": "peliasAdmin",
             "similarity": "peliasDefaultSimilarity",
+            "norms": false,
             "fields": {
               "ngram": {
                 "type": "text",
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "norms": false
               }
             }
           },
@@ -2865,13 +2919,15 @@
             "analyzer": "peliasAdmin",
             "search_analyzer": "peliasAdmin",
             "similarity": "peliasDefaultSimilarity",
+            "norms": false,
             "fields": {
               "ngram": {
                 "type": "text",
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "norms": false
               }
             }
           },
@@ -2880,13 +2936,15 @@
             "analyzer": "peliasAdmin",
             "search_analyzer": "peliasAdmin",
             "similarity": "peliasDefaultSimilarity",
+            "norms": false,
             "fields": {
               "ngram": {
                 "type": "text",
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "norms": false
               }
             }
           },
@@ -2903,13 +2961,15 @@
             "analyzer": "peliasAdmin",
             "search_analyzer": "peliasAdmin",
             "similarity": "peliasDefaultSimilarity",
+            "norms": false,
             "fields": {
               "ngram": {
                 "type": "text",
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "norms": false
               }
             }
           },
@@ -2918,13 +2978,15 @@
             "analyzer": "peliasAdmin",
             "search_analyzer": "peliasAdmin",
             "similarity": "peliasDefaultSimilarity",
+            "norms": false,
             "fields": {
               "ngram": {
                 "type": "text",
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasAdmin",
                 "similarity": "peliasDefaultSimilarity",
-                "doc_values": false
+                "doc_values": false,
+                "norms": false
               }
             }
           },
@@ -2941,12 +3003,14 @@
             "analyzer": "peliasZip",
             "search_analyzer": "peliasZip",
             "similarity": "peliasDefaultSimilarity",
+            "norms": false,
             "fields": {
               "ngram": {
                 "type": "text",
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasZip",
-                "similarity": "peliasDefaultSimilarity"
+                "similarity": "peliasDefaultSimilarity",
+                "norms": false
               }
             }
           },
@@ -2955,12 +3019,14 @@
             "analyzer": "peliasZip",
             "search_analyzer": "peliasZip",
             "similarity": "peliasDefaultSimilarity",
+            "norms": false,
             "fields": {
               "ngram": {
                 "type": "text",
                 "analyzer": "peliasIndexOneEdgeGram",
                 "search_analyzer": "peliasZip",
-                "similarity": "peliasDefaultSimilarity"
+                "similarity": "peliasDefaultSimilarity",
+                "norms": false
               }
             }
           },
@@ -3014,7 +3080,8 @@
             "type": "text",
             "analyzer": "peliasIndexOneEdgeGram",
             "search_analyzer": "peliasQuery",
-            "similarity": "peliasDefaultSimilarity"
+            "similarity": "peliasDefaultSimilarity",
+            "norms": false
           }
         }
       },
@@ -3026,7 +3093,8 @@
             "type": "text",
             "analyzer": "peliasPhrase",
             "search_analyzer": "peliasQuery",
-            "similarity": "peliasDefaultSimilarity"
+            "similarity": "peliasDefaultSimilarity",
+            "norms": false
           }
         }
       },
@@ -3037,7 +3105,8 @@
           "mapping": {
             "type": "keyword",
             "index": false,
-            "doc_values": false
+            "doc_values": false,
+            "norms": false
           }
         }
       }


### PR DESCRIPTION
this DRAFT PR isn't meant to be merged, I'm just curious as to what a planet build would look like with `norms: false` on all the fields.

it's been a while since we last looked at this in https://github.com/pelias/schema/pull/323

I suspect that since setting `norms: false` will disable 'field length', it will:
- fix the issue we have with aliases counting towards the field length and therefore scoring lower when more aliases exist
- at the same time will have a negative impact on exact matching queries where the shorter field length allowed them to score higher

the thing I'm curious about is how much effect the second point has in practise, there is actually an integration test which regresses as part of this commit but I suspect that `population` / `popularity` scoring may, to some degree, resolve some of the exact matching issues.