### PR TITLE
add dedicated concordance field

### DIFF
--- a/mappings/document.js
+++ b/mappings/document.js
@@ -171,6 +171,9 @@ var schema = {
     population: multiplier,
     popularity: multiplier,
 
+    // concordance (indexed foreign key references)
+    concordance: hash,
+
     // addendum (non-indexed supplimentary data)
     addendum: hash
   },
@@ -195,6 +198,12 @@ var schema = {
         search_analyzer: 'peliasQuery',
         similarity: 'peliasDefaultSimilarity'
       }
+    }
+  },{
+    concordance: {
+      path_match: 'concordance.*',
+      match_mapping_type: 'string',
+      mapping: keyword
     }
   },{
     addendum: {

--- a/test/compile.js
+++ b/test/compile.js
@@ -61,9 +61,20 @@ module.exports.tests.dynamic_templates = function(test, common) {
     });
     t.end();
   });
+  test('dynamic_templates: concordance', function (t) {
+    t.equal(typeof schema.mappings.dynamic_templates[2].concordance, 'object', 'concordance template specified');
+    var template = schema.mappings.dynamic_templates[2].concordance;
+    t.equal(template.path_match, 'concordance.*');
+    t.equal(template.match_mapping_type, 'string');
+    t.deepEqual(template.mapping, {
+      type: 'keyword',
+      doc_values: false
+    });
+    t.end();
+  });
   test('dynamic_templates: addendum', function (t) {
-    t.equal(typeof schema.mappings.dynamic_templates[2].addendum, 'object', 'addendum template specified');
-    var template = schema.mappings.dynamic_templates[2].addendum;
+    t.equal(typeof schema.mappings.dynamic_templates[3].addendum, 'object', 'addendum template specified');
+    var template = schema.mappings.dynamic_templates[3].addendum;
     t.equal(template.path_match, 'addendum.*');
     t.equal(template.match_mapping_type, 'string');
     t.deepEqual(template.mapping, {

--- a/test/document.js
+++ b/test/document.js
@@ -23,7 +23,7 @@ module.exports.tests.properties = function(test, common) {
 module.exports.tests.fields = function(test, common) {
   var fields = ['source', 'layer', 'name', 'phrase', 'address_parts',
     'parent', 'center_point', 'shape', 'bounding_box', 'source_id', 'category',
-    'population', 'popularity', 'addendum'];
+    'population', 'popularity', 'concordance', 'addendum'];
   test('fields specified', function(t) {
     t.deepEqual(Object.keys(schema.properties), fields);
     t.end();

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -2992,6 +2992,10 @@
         "type": "keyword",
         "doc_values": false
       },
+      "concordance": {
+        "type": "object",
+        "dynamic": true
+      },
       "population": {
         "type": "long",
         "null_value": 0
@@ -3027,6 +3031,16 @@
             "analyzer": "peliasPhrase",
             "search_analyzer": "peliasQuery",
             "similarity": "peliasDefaultSimilarity"
+          }
+        }
+      },
+      {
+        "concordance": {
+          "path_match": "concordance.*",
+          "match_mapping_type": "string",
+          "mapping": {
+            "type": "keyword",
+            "doc_values": false
           }
         }
       },


### PR DESCRIPTION
ping! @pelias/contributors this PR is a discussion with code attached 🚀 

this year has seen some work around recording and exposing 'concordances' (the WOF term for foreign key references).
these concordances are valuable to organisations who also use the foreign ID system and would like an easy way of joining Pelias GIDs with other datasets.

<img width="357" alt="Screenshot 2021-10-13 at 13 53 33" src="https://user-images.githubusercontent.com/738069/137127576-72a86640-bc7e-479c-ae60-e10d8ba7dcbd.png">

the existing implementation works great, looking at [Germany in WOF](https://pelias.github.io/compare/#/v1/place?ids=whosonfirst%3Acountry%3A85633111) you can see it returns a treasure trove of useful concordances in the `addendum`.

one problem we've identified with using the addendum is that it's (by definition) only semi-structured and comes without many guarantees of correctness or availability.

what would be better is if concordances were more structured and formalised within Pelias so that they could be considered a public API which integrators could rely upon for a 'crosswalk' between datasets.

this PR would potentially open the door for that, it could be combined with a PR to `pelias/model` to perform the validation.
the validation rules would need a little thought, but things like casing, delimiters, abbreviations, collisions, etc would need to be considered.

there is also a secondary concern (beyond simply displaying the information), which is that users may also wish to search on these values, this is certainly never going to be possible with the addendum.

introducing a new parameter would need a bit more discussion but what comes to mind is the `/v1/place` endpoint could support `concordance` lookup, either via the existing `?ids=` param or a new one.

thoughts?