### PR TITLE
enable docvalues for source_id field

### DIFF
--- a/mappings/document.js
+++ b/mappings/document.js
@@ -166,7 +166,7 @@ var schema = {
     bounding_box: require('./partial/boundingbox'),
 
     // meta info
-    source_id: keyword,
+    source_id: keyword_with_doc_values,
     category: keyword,
     population: multiplier,
     popularity: multiplier,

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -2986,8 +2986,7 @@
         "index": false
       },
       "source_id": {
-        "type": "keyword",
-        "doc_values": false
+        "type": "keyword"
       },
       "category": {
         "type": "keyword",


### PR DESCRIPTION
draft PR to test the effect of enabling `docvalues` for the `source_id` field.
this is motivated by the discussion in https://github.com/pelias/api/pull/1608

it is hoped that this field can be used as an additional sorting criteria in order to make the ordering of results with the same `_score` value more deterministic, and therefore make testing more stable and predictable.

my concerns with this change are:
- greatly increasing the index size (on disk)
- increasing the memory consumption (at runtime once `docvalues` are loaded)

the `source_id` values are almost entirely unique and non-sequential, so I'd expect to see poor compression.

although.. these concerns are hopefully unwarranted, we might want to check those before merging this.