### PR TITLE
ES8 support - remove deprecated include_type_name parameter

### DIFF
--- a/integration/dynamic_templates.js
+++ b/integration/dynamic_templates.js
@@ -49,8 +49,7 @@ function nameAssertion( analyzer, common ){
     suite.assert( done => {
 
       suite.client.indices.getMapping({
-        index: suite.props.index,
-        include_type_name: false
+        index: suite.props.index
       }, (err, res) => {
 
         const properties = res[suite.props.index].mappings.properties;
@@ -88,8 +87,7 @@ function phraseAssertion( analyzer, common ){
     suite.assert( done => {
 
       suite.client.indices.getMapping({
-        index: suite.props.index,
-        include_type_name: false
+        index: suite.props.index
       }, ( err, res ) => {
 
         const properties = res[suite.props.index].mappings.properties;
@@ -126,8 +124,7 @@ function addendumAssertion( namespace, value, common ){
     // inherited from the dynamic_template
     suite.assert( done => {
       suite.client.indices.getMapping({
-        index: suite.props.index,
-        include_type_name: false,
+        index: suite.props.index
       }, ( err, res ) => {
 
         const properties = res[suite.props.index].mappings.properties;

--- a/integration/run.js
+++ b/integration/run.js
@@ -13,7 +13,6 @@ const common = {
   create: {
     schema: schema,
     create: {
-      include_type_name: false
     }
   },
   summaryMap: (res) => {

--- a/scripts/create_index.js
+++ b/scripts/create_index.js
@@ -29,8 +29,7 @@ try {
 const indexName = config.schema.indexName;
 const req = {
   index: indexName,
-  body: schema,
-  include_type_name: false
+  body: schema
 };
 
 client.indices.create(req, (err, res) => {


### PR DESCRIPTION
In ES8 the include_type_name parameter is no longer supported and causes an error when creating an index.

https://www.elastic.co/guide/en/elasticsearch/reference/7.17/removal-of-types.html