### PR TITLE
CI: Remove Node.js 12 from build matrix

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x]
     steps:
     - uses: actions/checkout@v2
     - name: Install node.js ${{ matrix.node-version }}
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x]
         es-version: [7.6.1]
         jdk-version: [oraclejdk11]
     steps:


### PR DESCRIPTION
We normally try to keep all our CI configurations identical, but the schema repository is a bit of a special case since it has to do so many extra things around Elasticsearch.

Apparently, one of those extra things, `npm install -g npm`, now installs a new enough version of NPM that it doesn't work on Node.js 12.

We are removing Node.js 12 support globally soon anyway in https://github.com/pelias/pelias/issues/950,
so we might as well remove it here to make all the tests pass again.