### PR TITLE
Remove JDK configuration from CI

### DIFF
--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -9,7 +9,6 @@ jobs:
           - ubuntu-22.04
         node-version: [18.x, 20.x, 22.x]
         es-version: [7.6.1]
-        jdk-version: [oraclejdk11]
         icuTokenizer: [true, false]
     steps:
     - uses: actions/checkout@v4
@@ -17,10 +16,9 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
-    - name: Start elasticsearch ${{ matrix.es-version }} (${{ matrix.jdk-version }})
+    - name: Start elasticsearch ${{ matrix.es-version }}
       env:
         ES_VERSION: ${{ matrix.es-version }}
-        JDK_VERSION: ${{ matrix.jdk-version }}
       run: ./scripts/setup_ci.sh
     - name: Run integration tests
       run: |

--- a/scripts/setup_ci.sh
+++ b/scripts/setup_ci.sh
@@ -4,9 +4,6 @@ set -e
 # create elasticsearch directory
 mkdir /tmp/elasticsearch
 
-# allow switching the JDK version
-curl -s https://raw.githubusercontent.com/michaelklishin/jdk_switcher/master/jdk_switcher.sh | bash -s use "${JDK_VERSION}"
-
 # download and install elasticsearch with ICU plugin
 FILENAME="elasticsearch-${ES_VERSION}-linux-x86_64.tar.gz"
 STRIP_COMPONENTS=1


### PR DESCRIPTION
For quite some time we have configured a specific version of the JDK in our CI.

As far as I understand it, modern versions of Elasticsearch use a bundled version of the JDK so this configuration may no longer be relevant.

On a practical/security note: it also looks like [the scripts](https://github.com/michaelklishin/jdk_switcher) used to switch JDK versions are over 4 years old, and just calling a bash script from a 3rd party repository is a bit scary.

I don't see any changes due to the removal of this option, is it possible we don't need it anymore? @missinglink what do you think?