### PR TITLE
trigger docker multiarch build

### DIFF
--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -7,7 +7,7 @@ jobs:
       matrix:
         os:
           - ${{ vars.UBUNTU_VERSION }}
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
         es-version: [7.6.1]
         jdk-version: [oraclejdk11]
     steps:
@@ -23,7 +23,6 @@ jobs:
       run: ./scripts/setup_ci.sh
     - name: Run integration tests
       run: |
-        npm install -g npm
         npm install
         curl http://127.0.0.1:9200/
         ./bin/create_index

--- a/.github/workflows/_unit_tests.yml
+++ b/.github/workflows/_unit_tests.yml
@@ -7,7 +7,7 @@ jobs:
       matrix:
         os:
           - ${{ vars.UBUNTU_VERSION }}
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
     steps:
     - uses: actions/checkout@v2
     - name: Install node.js ${{ matrix.node-version }}
@@ -16,6 +16,5 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - name: Run unit tests
       run: |
-        npm install -g npm
         npm install
         npm run test

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install Node.js
       uses: actions/setup-node@v2-beta
       with:
-        node-version: 16.x
+        node-version: 20.x
     - name: Run semantic-release
       env:
         GH_TOKEN: ${{ secrets.GH_SEMANTIC_RELEASE_TOKEN }}


### PR DESCRIPTION
I originally intended to trigger a multiarch build with an empty commit, however it was necessary to remove the `npm install -g npm` line due to `nodejs 16` only supporting `npm 9`.

I've also taken the opportunity to update some of the versions used for testing.