### PR TITLE
integration: merge elastictest into this module

### DIFF
--- a/integration/address_matching.js
+++ b/integration/address_matching.js
@@ -1,6 +1,6 @@
 // validate analyzer is behaving as expected
 
-const elastictest = require('elastictest');
+const Suite = require('../test/elastictest/Suite');
 const config = require('pelias-config').generate();
 const getTotalHits = require('./_hits_total_helper');
 
@@ -9,7 +9,7 @@ module.exports.tests = {};
 module.exports.tests.functional = function(test, common){
   test( 'functional', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     // index some docs
@@ -217,7 +217,7 @@ module.exports.tests.venue_vs_address = function(test, common){
     // Unfortunately there seems to be no easy way of fixing this, it's an artifact of us
     // storing the street names in the name.default field.
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     // index a venue

--- a/integration/admin_abbreviations.js
+++ b/integration/admin_abbreviations.js
@@ -1,4 +1,4 @@
-const elastictest = require('elastictest');
+const Suite = require('../test/elastictest/Suite');
 const config = require('pelias-config').generate();
 const getTotalHits = require('./_hits_total_helper');
 
@@ -12,7 +12,7 @@ module.exports.tests = {};
 module.exports.tests.synonyms = function (test, common) {
   test('synonyms - alpha3 does not share a prefix with alpha2', function (t) {
 
-    var suite = new elastictest.Suite(common.clientOpts, common.create);
+    var suite = new Suite(common.clientOpts, common.create);
     suite.action(done => setTimeout(done, 500)); // wait for es to bring some shards up
 
     // index document 1 with country_a='MEX'
@@ -140,7 +140,7 @@ module.exports.tests.synonyms = function (test, common) {
 
   test('synonyms - alpha3 shares a prefix with alpha2', function (t) {
 
-    var suite = new elastictest.Suite(common.clientOpts, common.create);
+    var suite = new Suite(common.clientOpts, common.create);
     suite.action(done => setTimeout(done, 500)); // wait for es to bring some shards up
 
     // index document 1 with country_a='NZL'
@@ -268,7 +268,7 @@ module.exports.tests.synonyms = function (test, common) {
 
   test('synonyms - additional synonyms do not increase field length', function (t) {
 
-    var suite = new elastictest.Suite(common.clientOpts, common.create);
+    var suite = new Suite(common.clientOpts, common.create);
     suite.action(done => setTimeout(done, 500)); // wait for es to bring some shards up
 
     // index document 1 with country_a='NZL'

--- a/integration/admin_matching.js
+++ b/integration/admin_matching.js
@@ -1,6 +1,6 @@
 // validate analyzer is behaving as expected
 
-const elastictest = require('elastictest');
+const Suite = require('../test/elastictest/Suite');
 const config = require('pelias-config').generate();
 const getTotalHits = require('./_hits_total_helper');
 
@@ -9,7 +9,7 @@ module.exports.tests = {};
 module.exports.tests.functional = function(test, common){
   test( 'functional', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     // index a document with all admin values

--- a/integration/analyzer_peliasAdmin.js
+++ b/integration/analyzer_peliasAdmin.js
@@ -1,7 +1,7 @@
 // validate analyzer is behaving as expected
 
 var tape = require('tape'),
-    elastictest = require('elastictest'),
+    Suite = require('../test/elastictest/Suite'),
     punctuation = require('../punctuation');
 
 module.exports.tests = {};
@@ -9,7 +9,7 @@ module.exports.tests = {};
 module.exports.tests.analyze = function(test, common){
   test( 'analyze', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasAdmin' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -33,7 +33,7 @@ module.exports.tests.analyze = function(test, common){
 module.exports.tests.functional = function(test, common){
   test( 'functional', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasAdmin' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -71,7 +71,7 @@ module.exports.tests.functional = function(test, common){
 module.exports.tests.synonyms = function(test, common){
   test( 'synonyms', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasAdmin' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -98,7 +98,7 @@ module.exports.tests.synonyms = function(test, common){
 module.exports.tests.tokenizer = function(test, common){
   test( 'tokenizer', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasAdmin' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -126,7 +126,7 @@ module.exports.tests.tokenizer = function(test, common){
 module.exports.tests.unicode = function(test, common){
   test( 'normalization', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasAdmin' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 

--- a/integration/analyzer_peliasHousenumber.js
+++ b/integration/analyzer_peliasHousenumber.js
@@ -1,7 +1,7 @@
 // validate analyzer is behaving as expected
 
 var tape = require('tape'),
-    elastictest = require('elastictest'),
+    Suite = require('../test/elastictest/Suite'),
     punctuation = require('../punctuation');
 
 module.exports.tests = {};
@@ -9,7 +9,7 @@ module.exports.tests = {};
 module.exports.tests.analyze = function(test, common){
   test( 'analyze', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasHousenumber' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -23,7 +23,7 @@ module.exports.tests.analyze = function(test, common){
 module.exports.tests.functional = function(test, common){
   test( 'functional', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasHousenumber' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 

--- a/integration/analyzer_peliasIndexOneEdgeGram.js
+++ b/integration/analyzer_peliasIndexOneEdgeGram.js
@@ -1,7 +1,7 @@
 // validate analyzer is behaving as expected
 
 var tape = require('tape'),
-    elastictest = require('elastictest'),
+    Suite = require('../test/elastictest/Suite'),
     punctuation = require('../punctuation');
 
 module.exports.tests = {};
@@ -9,7 +9,7 @@ module.exports.tests = {};
 module.exports.tests.analyze = function(test, common){
   test( 'analyze', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasIndexOneEdgeGram' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -95,7 +95,7 @@ module.exports.tests.analyze = function(test, common){
 module.exports.tests.address_suffix_expansions = function(test, common){
   test( 'address suffix expansions', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasIndexOneEdgeGram' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -125,7 +125,7 @@ module.exports.tests.address_suffix_expansions = function(test, common){
 module.exports.tests.stop_words = function(test, common){
   test( 'stop words', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasIndexOneEdgeGram' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -146,7 +146,7 @@ module.exports.tests.stop_words = function(test, common){
 module.exports.tests.functional = function(test, common){
   test( 'functional', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasIndexOneEdgeGram' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -172,7 +172,7 @@ module.exports.tests.functional = function(test, common){
 module.exports.tests.unique = function(test, common){
   test( 'unique', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasIndexOneEdgeGram' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -186,7 +186,7 @@ module.exports.tests.unique = function(test, common){
 module.exports.tests.address = function(test, common){
   test( 'address', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasIndexOneEdgeGram' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -218,7 +218,7 @@ module.exports.tests.address = function(test, common){
 module.exports.tests.unicode = function(test, common){
   test( 'normalization', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasIndexOneEdgeGram' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 

--- a/integration/analyzer_peliasPhrase.js
+++ b/integration/analyzer_peliasPhrase.js
@@ -1,6 +1,6 @@
 // validate analyzer is behaving as expected
 
-const elastictest = require('elastictest');
+const Suite = require('../test/elastictest/Suite');
 const punctuation = require('../punctuation');
 const config = require('pelias-config').generate();
 const getTotalHits = require('./_hits_total_helper');
@@ -10,7 +10,7 @@ module.exports.tests = {};
 module.exports.tests.analyze = function(test, common){
   test( 'analyze', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasPhrase' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -62,7 +62,7 @@ module.exports.tests.analyze = function(test, common){
 module.exports.tests.functional = function(test, common){
   test( 'functional', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasPhrase' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -109,7 +109,7 @@ module.exports.tests.functional = function(test, common){
 module.exports.tests.tokenizer = function(test, common){
   test( 'tokenizer', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasPhrase' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -135,7 +135,7 @@ module.exports.tests.tokenizer = function(test, common){
 module.exports.tests.slop = function(test, common){
   test( 'slop', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasPhrase' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -153,7 +153,7 @@ module.exports.tests.slop = function(test, common){
 module.exports.tests.slop_query = function(test, common){
   test( 'slop query', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasPhrase' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -249,7 +249,7 @@ module.exports.tests.slop_query = function(test, common){
 module.exports.tests.slop = function(test, common){
   test( 'slop', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     // index a document
@@ -293,7 +293,7 @@ module.exports.tests.slop = function(test, common){
 module.exports.tests.unicode = function(test, common){
   test( 'normalization', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasPhrase' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 

--- a/integration/analyzer_peliasQuery.js
+++ b/integration/analyzer_peliasQuery.js
@@ -1,7 +1,7 @@
 // validate analyzer is behaving as expected
 
 var tape = require('tape'),
-    elastictest = require('elastictest'),
+    Suite = require('../test/elastictest/Suite'),
     punctuation = require('../punctuation');
 
 module.exports.tests = {};
@@ -9,7 +9,7 @@ module.exports.tests = {};
 module.exports.tests.analyze = function(test, common){
   test( 'analyze', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasQuery' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -41,7 +41,7 @@ module.exports.tests.analyze = function(test, common){
 module.exports.tests.functional = function(test, common){
   test( 'functional', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasQuery' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -56,7 +56,7 @@ module.exports.tests.functional = function(test, common){
 module.exports.tests.address = function(test, common){
   test( 'address', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasQuery' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -80,7 +80,7 @@ module.exports.tests.address = function(test, common){
 module.exports.tests.unicode = function(test, common){
   test( 'normalization', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasQuery' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 

--- a/integration/analyzer_peliasStreet.js
+++ b/integration/analyzer_peliasStreet.js
@@ -1,12 +1,12 @@
 // validate analyzer is behaving as expected
-const elastictest = require('elastictest')
+const Suite = require('../test/elastictest/Suite')
 
 module.exports.tests = {};
 
 module.exports.tests.analyze = function(test, common){
   test( 'analyze', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasStreet' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -29,7 +29,7 @@ module.exports.tests.analyze = function(test, common){
 module.exports.tests.functional = function(test, common){
   test( 'functional', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasStreet' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -46,7 +46,7 @@ module.exports.tests.functional = function(test, common){
 module.exports.tests.normalize_punctuation = function(test, common){
   test( 'normalize punctuation', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasStreet' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -64,7 +64,7 @@ module.exports.tests.normalize_punctuation = function(test, common){
 module.exports.tests.remove_ordinals = function(test, common){
   test( 'remove ordinals', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasStreet' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -138,7 +138,7 @@ module.exports.tests.remove_ordinals = function(test, common){
 module.exports.tests.tokenizer = function(test, common){
   test( 'tokenizer', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasStreet' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -163,7 +163,7 @@ module.exports.tests.tokenizer = function(test, common){
 module.exports.tests.unicode = function(test, common){
   test( 'normalization', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasStreet' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -194,7 +194,7 @@ module.exports.tests.unicode = function(test, common){
 module.exports.tests.germanic_street_suffixes = function (test, common) {
   test('germanic_street_suffixes', function (t) {
 
-    var suite = new elastictest.Suite(common.clientOpts, common.create );
+    var suite = new Suite(common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind(null, suite, t, 'peliasStreet');
     suite.action(function (done) { setTimeout(done, 500); }); // wait for es to bring some shards up
 

--- a/integration/analyzer_peliasZip.js
+++ b/integration/analyzer_peliasZip.js
@@ -1,7 +1,7 @@
 // validate analyzer is behaving as expected
 
 var tape = require('tape'),
-    elastictest = require('elastictest'),
+    Suite = require('../test/elastictest/Suite'),
     punctuation = require('../punctuation');
 
 module.exports.tests = {};
@@ -9,7 +9,7 @@ module.exports.tests = {};
 module.exports.tests.analyze = function(test, common){
   test( 'analyze', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasZip' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
@@ -24,7 +24,7 @@ module.exports.tests.analyze = function(test, common){
 module.exports.tests.functional = function(test, common){
   test( 'functional', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     var assertAnalysis = common.analyze.bind( null, suite, t, 'peliasZip' );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 

--- a/integration/autocomplete_abbreviated_street_names.js
+++ b/integration/autocomplete_abbreviated_street_names.js
@@ -4,7 +4,7 @@
 // The greater issue is descriped in: https://github.com/pelias/pelias/issues/211
 // The cases tested here are described in: https://github.com/pelias/schema/issues/105
 
-const elastictest = require('elastictest');
+const Suite = require('../test/elastictest/Suite');
 const config = require('pelias-config').generate();
 const getTotalHits = require('./_hits_total_helper');
 
@@ -14,7 +14,7 @@ module.exports.tests = {};
 module.exports.tests.index_expanded_form_search_contracted = function(test, common){
   test( 'index expanded and retrieve contracted form', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     // index a document with a name which contains a synonym (center)
@@ -55,7 +55,7 @@ module.exports.tests.index_expanded_form_search_contracted = function(test, comm
 // module.exports.tests.index_contracted_form_search_expanded = function(test, common){
 //   test( 'index contracted and search expanded', function(t){
 
-//     var suite = new elastictest.Suite( common.clientOpts, common.create );
+//     var suite = new Suite( common.clientOpts, common.create );
 //     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
 //     // index a document with a name which contains a synonym (center)

--- a/integration/autocomplete_directional_synonym_expansion.js
+++ b/integration/autocomplete_directional_synonym_expansion.js
@@ -4,7 +4,7 @@
 // The greater issue is descriped in: https://github.com/pelias/pelias/issues/211
 // The cases tested here are described in: https://github.com/pelias/schema/issues/105
 
-const elastictest = require('elastictest');
+const Suite = require('../test/elastictest/Suite');
 const config = require('pelias-config').generate();
 const getTotalHits = require('./_hits_total_helper');
 
@@ -14,7 +14,7 @@ module.exports.tests = {};
 module.exports.tests.index_and_retrieve_expanded_form = function(test, common){
   test( 'index and retrieve expanded form', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     // index a document with a name which contains a synonym (center)
@@ -71,7 +71,7 @@ module.exports.tests.index_and_retrieve_expanded_form = function(test, common){
 module.exports.tests.index_and_retrieve_contracted_form = function(test, common){
   test( 'index and retrieve contracted form', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     // index a document with a name which contains a synonym (center)
@@ -110,7 +110,7 @@ module.exports.tests.index_and_retrieve_contracted_form = function(test, common)
 module.exports.tests.index_and_retrieve_mixed_form_1 = function(test, common){
   test( 'index and retrieve mixed form 1', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     // index a document with a name which contains a synonym (center)
@@ -167,7 +167,7 @@ module.exports.tests.index_and_retrieve_mixed_form_1 = function(test, common){
 module.exports.tests.index_and_retrieve_mixed_form_2 = function(test, common){
   test( 'index and retrieve mixed form 2', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     // index a document with a name which contains a synonym (center)

--- a/integration/autocomplete_street_synonym_expansion.js
+++ b/integration/autocomplete_street_synonym_expansion.js
@@ -4,7 +4,7 @@
 // The greater issue is descriped in: https://github.com/pelias/pelias/issues/211
 // The cases tested here are described in: https://github.com/pelias/schema/issues/105
 
-const elastictest = require('elastictest');
+const Suite = require('../test/elastictest/Suite');
 const config = require('pelias-config').generate();
 
 const getTotalHits = require('./_hits_total_helper');
@@ -15,7 +15,7 @@ module.exports.tests = {};
 module.exports.tests.index_and_retrieve_expanded_form = function(test, common){
   test( 'index and retrieve expanded form', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     // index a document with a name which contains a synonym (center)
@@ -72,7 +72,7 @@ module.exports.tests.index_and_retrieve_expanded_form = function(test, common){
 module.exports.tests.index_and_retrieve_contracted_form = function(test, common){
   test( 'index and retrieve contracted form', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     // index a document with a name which contains a synonym (center)
@@ -111,7 +111,7 @@ module.exports.tests.index_and_retrieve_contracted_form = function(test, common)
 module.exports.tests.index_and_retrieve_mixed_form_1 = function(test, common){
   test( 'index and retrieve mixed form 1', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     // index a document with a name which contains a synonym (center)
@@ -168,7 +168,7 @@ module.exports.tests.index_and_retrieve_mixed_form_1 = function(test, common){
 module.exports.tests.index_and_retrieve_mixed_form_2 = function(test, common){
   test( 'index and retrieve mixed form 2', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     // index a document with a name which contains a synonym (center)

--- a/integration/bounding_box.js
+++ b/integration/bounding_box.js
@@ -1,6 +1,6 @@
 // validate bounding box behaves as expected
 
-const elastictest = require('elastictest');
+const Suite = require('../test/elastictest/Suite');
 const config = require('pelias-config').generate();
 
 module.exports.tests = {};
@@ -8,7 +8,7 @@ module.exports.tests = {};
 module.exports.tests.index_and_retrieve = function(test, common){
   test( 'index and retrieve', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     // index a document with a bbox

--- a/integration/dynamic_templates.js
+++ b/integration/dynamic_templates.js
@@ -1,6 +1,6 @@
 // http://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-root-object-type.html#_dynamic_templates
 
-const elastictest = require('elastictest');
+const Suite = require('../test/elastictest/Suite');
 const config = require('pelias-config').generate();
 
 module.exports.tests = {};
@@ -31,7 +31,7 @@ module.exports.all = function (tape, common) {
 function nameAssertion( analyzer, common ){
   return function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     const _type = config.schema.typeName;
 
     // index a document from a normal document layer
@@ -70,7 +70,7 @@ function nameAssertion( analyzer, common ){
 function phraseAssertion( analyzer, common ){
   return function(t){
 
-    const suite = new elastictest.Suite( common.clientOpts, common.create );
+    const suite = new Suite( common.clientOpts, common.create );
     const _type = config.schema.typeName;
 
     // index a document from a normal document layer
@@ -109,7 +109,7 @@ function phraseAssertion( analyzer, common ){
 function addendumAssertion( namespace, value, common ){
   return function(t){
 
-    const suite = new elastictest.Suite( common.clientOpts, common.create );
+    const suite = new Suite( common.clientOpts, common.create );
     const _type = config.schema.typeName;
 
     // index a document including the addendum

--- a/integration/multi_token_synonyms.js
+++ b/integration/multi_token_synonyms.js
@@ -1,6 +1,6 @@
 // validate analyzer is behaving as expected
 
-const elastictest = require('elastictest');
+const Suite = require('../test/elastictest/Suite');
 const config = require('pelias-config').generate();
 
 module.exports.tests = {};
@@ -10,7 +10,7 @@ module.exports.tests = {};
 module.exports.tests.functional = function (test, common) {
   test('functional', function (t) {
 
-    var suite = new elastictest.Suite(common.clientOpts, common.create);
+    var suite = new Suite(common.clientOpts, common.create);
     suite.action(function (done) { setTimeout(done, 500); }); // wait for es to bring some shards up
 
     // index a document with all admin values

--- a/integration/source_layer_sourceid_filtering.js
+++ b/integration/source_layer_sourceid_filtering.js
@@ -1,6 +1,6 @@
 // validate analyzer is behaving as expected
 
-const elastictest = require('elastictest');
+const Suite = require('../test/elastictest/Suite');
 const config = require('pelias-config').generate();
 const getTotalHits = require('./_hits_total_helper');
 
@@ -9,7 +9,7 @@ module.exports.tests = {};
 module.exports.tests.source_filter = function(test, common){
   test( 'source filter', function(t){
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
     suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up
 
     // index some docs

--- a/integration/validate.js
+++ b/integration/validate.js
@@ -1,14 +1,14 @@
 // simply validate that the schema doesn't error when inserted in to
 // your local elasticsearch server, useful to sanity check version upgrades.
 
-const elastictest = require('elastictest');
+const Suite = require('../test/elastictest/Suite');
 
 module.exports.tests = {};
 
 module.exports.tests.validate = function(test, common){
   test( 'schema', t => {
 
-    var suite = new elastictest.Suite( common.clientOpts, common.create );
+    var suite = new Suite( common.clientOpts, common.create );
 
     suite.assert( done => {
       suite.client.info({}, ( err, res, status ) => {

--- a/package.json
+++ b/package.json
@@ -39,10 +39,11 @@
     "semver": "^7.1.1"
   },
   "devDependencies": {
+    "async": "^3.2.5",
     "difflet": "^1.0.1",
-    "elastictest": "^3.0.0",
     "iso3166-1": "^0.5.1",
     "proxyquire": "^2.0.0",
+    "randomstring": "^1.3.0",
     "tap-spec": "^5.0.0",
     "tape": "^5.0.0"
   },

--- a/test/elastictest/Suite.js
+++ b/test/elastictest/Suite.js
@@ -1,0 +1,103 @@
+const _ = require('lodash')
+const randomstring = require('randomstring')
+const elasticsearch = require('elasticsearch')
+const async = require('async')
+
+function Suite (clientOpts, props) {
+  this.actions = []
+  this.asserts = []
+  this.client = null
+  this.clientOpts = !!clientOpts && (clone(clientOpts) || {
+    host: 'localhost:9200',
+    keepAlive: true
+  })
+  this.props = props || {}
+  if (!_.has(this, 'props.index')) {
+    this.props.index = 'testindex-' + randomstring.generate(7).toLowerCase()
+  }
+}
+
+Suite.prototype.action = function (action) {
+  this.actions.push(action)
+}
+
+Suite.prototype.assert = function (assert) {
+  this.asserts.push(assert)
+}
+
+Suite.prototype.start = function (cb) {
+  this.client = new elasticsearch.Client(this.clientOpts)
+  cb()
+}
+
+Suite.prototype.create = function (cb) {
+  const cmd = _.merge(this.props.create, { index: this.props.index })
+  if (_.has(this, 'props.schema')) {
+    cmd.body = this.props.schema
+  }
+  this.client.indices.create(cmd, cb)
+}
+
+Suite.prototype.delete = function (cb) {
+  const cmd = _.merge(this.props.delete, { index: this.props.index })
+  this.client.indices.delete(cmd, cb)
+}
+
+Suite.prototype.refresh = function (cb) {
+  const cmd = _.merge(this.props.refresh, { index: this.props.index })
+  this.client.indices.refresh(cmd, cb)
+}
+
+// note: optimize was replaced in version ES@2.0, forcemerge used for later versions:
+// https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-forcemerge.html
+Suite.prototype.optimize = function (cb) {
+  try {
+    this.client.indices.forcemerge({ index: this.props.index }, cb)
+  } catch (e) {
+    const cmd = { index: this.props.index, waitForMerge: true, force: true }
+    this.client.indices.optimize(cmd, cb)
+  }
+}
+
+Suite.prototype.waitForStatus = function (status, cb) {
+  const cmd = { waitForStatus: status || 'yellow' }
+  this.client.cluster.health(cmd, cb)
+}
+
+Suite.prototype.run = function (cb) {
+  const self = this
+  self.start(err => {
+    if (err) { throw new Error(err) }
+    self.waitForStatus('yellow', err => {
+      if (err) { throw new Error(err) }
+      self.create(err => {
+        if (err) { throw new Error(err) }
+        async.series(self.actions, err => {
+          if (err) { throw new Error(err) }
+          self.refresh(err => {
+            if (err) { throw new Error(err) }
+            self.optimize(async.series(self.asserts, err => {
+              if (err) { throw new Error(err) }
+              self.delete(err => {
+                if (err) { throw new Error(err) }
+                self.client.close()
+                if (_.isFunction(cb)) {
+                  cb()
+                }
+              })
+            }))
+          })
+        })
+      })
+    })
+  })
+}
+
+// elasticsearch client requires that config objects not be reused.
+// Error: Do not reuse objects to configure the elasticsearch Client class:
+// https://github.com/elasticsearch/elasticsearch-js/issues/33
+function clone (obj) {
+  return JSON.parse(JSON.stringify(obj))
+}
+
+module.exports = Suite


### PR DESCRIPTION
I've archived https://github.com/missinglink/elastictest and pulled the `Suite.js` file into this repo.

It turned out no other repos used that npm module so including the src in this module directly makes maintenance and updates of that code easier since it's in the same place as the implementation.

cc/ @michaelkirk, I will pull your PR commits over here too.