### PR TITLE
Bump NodeJs version on CI, fix compatibility with Node >20 in tests

### DIFF
--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -7,13 +7,13 @@ jobs:
       matrix:
         os:
           - ${{ vars.UBUNTU_VERSION }}
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x, 22.x]
         es-version: [7.6.1]
         jdk-version: [oraclejdk11]
     steps:
     - uses: actions/checkout@v2
     - name: Install node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2-beta
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - name: Start elasticsearch ${{ matrix.es-version }} (${{ matrix.jdk-version }})

--- a/.github/workflows/_unit_tests.yml
+++ b/.github/workflows/_unit_tests.yml
@@ -7,11 +7,11 @@ jobs:
       matrix:
         os:
           - ${{ vars.UBUNTU_VERSION }}
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x, 22.x]
     steps:
     - uses: actions/checkout@v2
     - name: Install node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2-beta
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - name: Run unit tests

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install Node.js
-      uses: actions/setup-node@v2-beta
+      uses: actions/setup-node@v4
       with:
         node-version: 20.x
     - name: Run semantic-release

--- a/scripts/create_index.js
+++ b/scripts/create_index.js
@@ -38,5 +38,5 @@ client.indices.create(req, (err, res) => {
     process.exit(1);
   }
   console.log('[put mapping]', '\t', indexName, res, '\n');
-  process.exit(!!err);
+  process.exit(0);
 });


### PR DESCRIPTION
:wave:

I was working on something and realised that `create_index.js` doesn't work on modern Node versions... Also decided to update CI to run on Node 18/20/22 and removed Node 16 (let me know if you think it is still needed, but IMO it is too outdated )