### PR TITLE
Update Ubuntu and other Github Action versions in CI

### DIFF
--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ${{ vars.UBUNTU_VERSION }}
+          - ubuntu-22.04
         node-version: [18.x, 20.x, 22.x]
         es-version: [7.6.1]
         jdk-version: [oraclejdk11]

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -11,7 +11,7 @@ jobs:
         es-version: [7.6.1]
         jdk-version: [oraclejdk11]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:

--- a/.github/workflows/_unit_tests.yml
+++ b/.github/workflows/_unit_tests.yml
@@ -9,7 +9,7 @@ jobs:
           - ${{ vars.UBUNTU_VERSION }}
         node-version: [18.x, 20.x, 22.x]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:

--- a/.github/workflows/_unit_tests.yml
+++ b/.github/workflows/_unit_tests.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ${{ vars.UBUNTU_VERSION }}
+          - ubuntu-22.04
         node-version: [18.x, 20.x, 22.x]
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,7 +11,7 @@ jobs:
   npm-publish:
     needs: [unit-tests, integration-tests]
     if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-    runs-on: ${{ vars.UBUNTU_VERSION }}
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - name: Install Node.js
@@ -29,7 +29,7 @@ jobs:
     # note: github actions won't run a job if you don't call one of the status check functions, so `always()` is called since it evalutes to `true`
     if: ${{ always() && needs.unit-tests.result == 'success' && (needs.npm-publish.result == 'success' || needs.npm-publish.result == 'skipped') }}
     needs: [unit-tests, integration-tests, npm-publish]
-    runs-on: ${{ vars.UBUNTU_VERSION }}
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Build Docker images

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.ref == 'refs/heads/master' && github.event_name == 'push'
     runs-on: ${{ vars.UBUNTU_VERSION }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install Node.js
       uses: actions/setup-node@v4
       with:
@@ -31,7 +31,7 @@ jobs:
     needs: [unit-tests, integration-tests, npm-publish]
     runs-on: ${{ vars.UBUNTU_VERSION }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Build Docker images
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
This PR includes a bunch of commits made by a script that standardizes as much as possible our CI config across all repositories.

Along the way it also ensures we test all Node.js versions that are an LTS release, not EOL, and currently work with this repository. Any Github Actions that were out of date or used old Node.js versions (checkout and setup-node @v2) are also updated.

For the schema repository,  20 and 22 support was added in #497, so fortunately we were already totally up to date with Node.js versions, so nothing had to be done.

Also, the CI OS version is now hardcoded to `ubuntu-22.04`. We fooled around with an organization wide CI variable to configure that, but it broke CI in forks and doesn't really help us much, so it's now undone.

The schema repository is a bit of a special snowflake due to Elasticsearch, so we don't exactly use a standard template here, but it's not that dissimilar.

Finally, because this repository has a Dockerfile and we just [updated the Docker baseimage to support Node.js 18](https://github.com/pelias/docker-baseimage/pull/29), there is an empty commit to trigger a new major version release.

Connects https://github.com/pelias/pelias/issues/950
Connects https://github.com/pelias/pelias/issues/951