### PR TITLE
feat: Allow variable index names for pelias docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,15 @@ Print a list of which plugins are installed and how to install any that are miss
 node scripts/check_plugins.js
 ```
 
+#### check indexed documents
+
+Display a summary of doc counts per source/layer. By default the stats for the importing index is used. Only use `--api` if your requesting index differs from your importing index
+
+```bash
+node scripts/check_stats.js
+node scripts/check_stats.js --api
+```
+
 ## Configuration
 
 ### Settings from `pelias.json`

--- a/scripts/check_stats.js
+++ b/scripts/check_stats.js
@@ -1,11 +1,13 @@
 const config = require('pelias-config').generate();
 const es = require('elasticsearch');
 const client = new es.Client(config.esclient);
+const targetIndex = getTargetIndex();
 
-async function stats() {
+
+async function stats(targetIndex) {
     try {
         const response = await client.search({
-            index: config.schema.indexName,
+            index: targetIndex,
             body: {
                 aggs: {
                     sources: {
@@ -29,7 +31,7 @@ async function stats() {
             request_cache: true,
             maxRetries: 1,
         });
-        console.log("Results for index \""+config.schema.indexName+"\":")
+        console.log("Results for index \"" + targetIndex + "\":")
         console.log(JSON.stringify(response, null, 2));
         process.exit(0);
     }
@@ -37,5 +39,12 @@ async function stats() {
         console.error(err);
         process.exit(!!err);
     }
+};
+
+function getTargetIndex() {
+    if (process.argv.length > 2 && ['--api', '-a'].indexOf(process.argv[2]) > -1) {
+        return config.api.indexName; //If none is set the value from pelias/config/config/defaults.json will be used ('pelias')
+    }
+    return config.schema.indexName;
 }
-stats();
+stats(targetIndex);

--- a/scripts/check_stats.js
+++ b/scripts/check_stats.js
@@ -1,0 +1,41 @@
+const config = require('pelias-config').generate();
+const es = require('elasticsearch');
+const client = new es.Client(config.esclient);
+
+async function stats() {
+    try {
+        const response = await client.search({
+            index: config.api.indexName,
+            body: {
+                aggs: {
+                    sources: {
+                        terms: {
+                            field: 'source',
+                            size: 100
+                        },
+                        aggs: {
+                            layers: {
+                                terms: {
+                                    field: "layer",
+                                    size: 100
+                                }
+                            }
+                        }
+                    }
+                },
+                size: 0,
+            },
+            timeout: '10s',
+            request_cache: true,
+            maxRetries: 1,
+        });
+        console.log("Results for index \""+config.api.indexName+"\":")
+        console.log(JSON.stringify(response, null, 2));
+        process.exit(0);
+    }
+    catch (err) {
+        console.error(err);
+        process.exit(!!err);
+    }
+}
+stats();

--- a/scripts/check_stats.js
+++ b/scripts/check_stats.js
@@ -5,7 +5,7 @@ const client = new es.Client(config.esclient);
 async function stats() {
     try {
         const response = await client.search({
-            index: config.api.indexName,
+            index: config.schema.indexName,
             body: {
                 aggs: {
                     sources: {
@@ -29,7 +29,7 @@ async function stats() {
             request_cache: true,
             maxRetries: 1,
         });
-        console.log("Results for index \""+config.api.indexName+"\":")
+        console.log("Results for index \""+config.schema.indexName+"\":")
         console.log(JSON.stringify(response, null, 2));
         process.exit(0);
     }


### PR DESCRIPTION
:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

---
#### Here's the reason for this change :rocket:
<!-- good place to use the magic github words that connect issues with PRs, like 
  - Fixes pelias/pelias#0000
  - Closes pelias/pelias#0000
  - Connected to pelias/pelias#0000
you can also just use good ol' words to explain what this does -->
Closes https://github.com/pelias/docker/issues/371 which allows the docker command  `pelias elastic stats` to use a different index name than the hardcoded ("pelias"). 

---
#### Here's what actually got changed :clap:
Moves the logic of the command `pelias elastic stats` from the docker repo to this repo to be able to use the command with other index names.

---
#### Here's how others can test the changes :eyes:
<!-- this could be queries or just mentioning that you've written unit/end-to-end tests as part of this awesome work... -->
<!-- did we mention, test are amazing! :rainbow: -->
1. Change `pelias.json` like
```json
"schema": {
    "indexName": "everything except pelias"
},
"api": {
    "indexName": "everything except pelias"
}
```
2. Import some data
3. Execute `node script/check_stats`
or
1. `docker build -t differentName/pelias-schema -f Dockerfile . `
2. Modify the docker-compose.yml to
```yaml
 schema:
    image: differentName/pelias-schema
```
3. Change `pelias.json` like
```json
"schema": {
    "indexName": "everything except pelias"
},
"api": {
    "indexName": "everything except pelias"
}
```
4. Import some data
5. Execute `pelias elastic stats`
