### PR TITLE
Drop Nodejs 18, use Nodejs 20 docker baseimage

### DIFF
--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -7,7 +7,7 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [ 20.x, 22.x ]
         es-version: [7.6.1]
         icuTokenizer: [true, false]
     steps:

--- a/.github/workflows/_unit_tests.yml
+++ b/.github/workflows/_unit_tests.yml
@@ -7,7 +7,7 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [ 20.x, 22.x ]
         icuTokenizer: [true, false]
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This drops a now EOL Node.js version from our CI, and puts on a shiny new Docker baseimage.

Connects https://github.com/pelias/pelias/issues/985