### PR TITLE
Fix process exit code type error

### DIFF
--- a/scripts/drop_index.js
+++ b/scripts/drop_index.js
@@ -13,7 +13,7 @@ function drop() {
   const req = { index: config.schema.indexName };
   client.indices.delete(req, (err, res) => {
     console.log('\n[delete mapping]', '\t', config.schema.indexName, err || '\t', res);
-    process.exit(!!err);
+    process.exit(err ? 1 : 0);
   });
 }
 

--- a/scripts/update_settings.js
+++ b/scripts/update_settings.js
@@ -6,19 +6,19 @@ var schema = require('../schema');
 var _index = config.schema.indexName;
 
 // Error: ElasticsearchIllegalArgumentException[can't change the number of shards for an index
-if( schema.settings.hasOwnProperty('index') &&
-    schema.settings.index.hasOwnProperty('number_of_shards') ){
+if (schema.settings.hasOwnProperty('index') &&
+  schema.settings.index.hasOwnProperty('number_of_shards')) {
   delete schema.settings.index.number_of_shards;
   delete schema.settings.index.number_of_replicas;
 }
 
-client.indices.close( { index: _index }, function( err, res ){
-  console.log( '[close index]', '\t', _index, err || '\t', res );
-  client.indices.putSettings( { index: _index, body: schema.settings }, function( err, res ){
-    console.log( '[put settings]', '\t', _index, err || '\t', res );
-    client.indices.open( { index: _index }, function( err, res ){
-      console.log( '[open index]', '\t', _index, err || '\t', res );
-      process.exit( !!err );
+client.indices.close({ index: _index }, function (err, res) {
+  console.log('[close index]', '\t', _index, err || '\t', res);
+  client.indices.putSettings({ index: _index, body: schema.settings }, function (err, res) {
+    console.log('[put settings]', '\t', _index, err || '\t', res);
+    client.indices.open({ index: _index }, function (err, res) {
+      console.log('[open index]', '\t', _index, err || '\t', res);
+      process.exit(err ? 1 : 0);
     });
   });
 });


### PR DESCRIPTION
Since the node20 update process.exit(!!err) is not working anymore and
throwing `TypeError [ERR_INVALID_ARG_TYPE]: The "code" argument must be
of type number. Received type boolean (false)`, because the boolean is
not converted to a number anymore.
